### PR TITLE
separate uniq instruction into setShared and uniq

### DIFF
--- a/rir/src/code/dataflow.h
+++ b/rir/src/code/dataflow.h
@@ -93,6 +93,19 @@ class FValue {
         return u.use != UseDef::unused();
     }
 
+    bool singleUse() const {
+        if (hasUseDef()) {
+            assert(u.use != UseDef::unused());
+            return u.use != UseDef::multiuse();
+        }
+        return false;
+    }
+
+    CodeEditor::Iterator use() {
+        assert(singleUse());
+        return u.use;
+    }
+
     struct UseDef {
         CodeEditor::Iterator def = unused();
         CodeEditor::Iterator use = unused();

--- a/rir/src/code/dataflow.h
+++ b/rir/src/code/dataflow.h
@@ -659,7 +659,9 @@ class DataflowAnalysis
             current().mergeAllEnv(FValue::Argument());
     }
 
-    void uniq_(CodeEditor::Iterator ins) override { current().top().used(ins); }
+    void make_unique_(CodeEditor::Iterator ins) override {
+        current().top().used(ins);
+    }
     void set_shared_(CodeEditor::Iterator ins) override {
         current().top().used(ins);
     }

--- a/rir/src/code/dataflow.h
+++ b/rir/src/code/dataflow.h
@@ -647,6 +647,9 @@ class DataflowAnalysis
     }
 
     void uniq_(CodeEditor::Iterator ins) override { current().top().used(ins); }
+    void set_shared_(CodeEditor::Iterator ins) override {
+        current().top().used(ins);
+    }
 
     void brobj_(CodeEditor::Iterator ins) override {
         current().top().used(ins);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -2117,7 +2117,7 @@ INSTRUCTION(set_shared_) {
     }
 }
 
-INSTRUCTION(uniq_) {
+INSTRUCTION(make_unique_) {
     SEXP v = ostack_top(ctx);
     if (NAMED(v) == 2) {
         v = shallow_duplicate(v);
@@ -2235,7 +2235,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             INS(extract2_);
             INS(subset2_);
             INS(dispatch_);
-            INS(uniq_);
+            INS(make_unique_);
             INS(set_shared_);
             INS(aslogical_);
             INS(lgl_and_);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -2110,11 +2110,16 @@ INSTRUCTION(invisible_) {
     R_Visible = 0;
 }
 
-INSTRUCTION(uniq_) {
+INSTRUCTION(set_shared_) {
     SEXP v = ostack_top(ctx);
     if (NAMED(v) < 2) {
         SET_NAMED(v, 2);
-    } else {
+    }
+}
+
+INSTRUCTION(uniq_) {
+    SEXP v = ostack_top(ctx);
+    if (NAMED(v) == 2) {
         v = shallow_duplicate(v);
         ostack_set(ctx, 0, v);
         SET_NAMED(v, 1);
@@ -2231,6 +2236,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             INS(subset2_);
             INS(dispatch_);
             INS(uniq_);
+            INS(set_shared_);
             INS(aslogical_);
             INS(lgl_and_);
             INS(lgl_or_);

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -82,7 +82,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::test_bounds_:
     case Opcode::swap_:
     case Opcode::int3_:
-    case Opcode::uniq_:
+    case Opcode::make_unique_:
     case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
@@ -185,7 +185,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::test_bounds_:
     case Opcode::swap_:
     case Opcode::int3_:
-    case Opcode::uniq_:
+    case Opcode::make_unique_:
     case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
@@ -372,7 +372,7 @@ void BC::print(CallSite cs) {
     case Opcode::ret_:
     case Opcode::swap_:
     case Opcode::int3_:
-    case Opcode::uniq_:
+    case Opcode::make_unique_:
     case Opcode::set_shared_:
     case Opcode::dup_:
     case Opcode::inc_:

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -83,6 +83,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::uniq_:
+    case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
     case Opcode::lgl_or_:
@@ -185,6 +186,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::uniq_:
+    case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
     case Opcode::lgl_or_:
@@ -371,6 +373,7 @@ void BC::print(CallSite cs) {
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::uniq_:
+    case Opcode::set_shared_:
     case Opcode::dup_:
     case Opcode::inc_:
     case Opcode::dup2_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -80,6 +80,7 @@ BC::ImmediateT decodeImmediate(Opcode bc, Opcode* pc) {
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::uniq_:
+    case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
     case Opcode::lgl_or_:
@@ -300,6 +301,7 @@ BC BC::subset2() { return BC(Opcode::subset2_); }
 BC BC::swap() { return BC(Opcode::swap_); }
 BC BC::int3() { return BC(Opcode::int3_); }
 BC BC::uniq() { return BC(Opcode::uniq_); }
+BC BC::setShared() { return BC(Opcode::set_shared_); }
 BC BC::asLogical() { return BC(Opcode::aslogical_); }
 BC BC::lglAnd() { return BC(Opcode::lgl_and_); }
 BC BC::lglOr() { return BC(Opcode::lgl_or_); }

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -79,7 +79,7 @@ BC::ImmediateT decodeImmediate(Opcode bc, Opcode* pc) {
     case Opcode::dup2_:
     case Opcode::swap_:
     case Opcode::int3_:
-    case Opcode::uniq_:
+    case Opcode::make_unique_:
     case Opcode::set_shared_:
     case Opcode::aslogical_:
     case Opcode::lgl_and_:
@@ -300,7 +300,7 @@ BC BC::extract2() { return BC(Opcode::extract2_); }
 BC BC::subset2() { return BC(Opcode::subset2_); }
 BC BC::swap() { return BC(Opcode::swap_); }
 BC BC::int3() { return BC(Opcode::int3_); }
-BC BC::uniq() { return BC(Opcode::uniq_); }
+BC BC::makeUnique() { return BC(Opcode::make_unique_); }
 BC BC::setShared() { return BC(Opcode::set_shared_); }
 BC BC::asLogical() { return BC(Opcode::aslogical_); }
 BC BC::lglAnd() { return BC(Opcode::lgl_and_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -233,7 +233,7 @@ class BC {
     inline static BC sub();
     inline static BC lt();
     inline static BC seq();
-    inline static BC uniq();
+    inline static BC makeUnique();
     inline static BC setShared();
     inline static BC asLogical();
     inline static BC lglOr();

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -234,6 +234,7 @@ class BC {
     inline static BC lt();
     inline static BC seq();
     inline static BC uniq();
+    inline static BC setShared();
     inline static BC asLogical();
     inline static BC lglOr();
     inline static BC lglAnd();

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -270,6 +270,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
             Case(SYMSXP) {
                 compileExpr(ctx, rhs);
                 cs << BC::dup()
+                   << BC::setShared()
                    << BC::stvar(lhs)
                    << BC::invisible();
                 return true;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -323,7 +323,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                         // Keep a copy of rhs since its the result of this
                         // expression
                         cs << BC::dup()
-                           << BC::uniq();
+                           << BC::setShared();
 
                         // Now load target and index
                         cs << BC::ldvar(target);
@@ -386,7 +386,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
         compileExpr(ctx, rhs);
         cs << BC::dup()
-           << BC::uniq();
+           << BC::setShared();
 
         // Evaluate the getter list and push it to the stack in reverse order
         for (unsigned i = lhsParts.size() - 1; i > 0; --i) {
@@ -456,12 +456,9 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
             ++arg;
             names.push_back(R_NilValue);
 
-            // Some setters do not check for the named flag!
-            if (fun != symbol::Bracket && fun != symbol::DoubleBracket) {
-                cs << BC::pick(1)
-                   << BC::uniq()
-                   << BC::put(1);
-            }
+            cs << BC::pick(1)
+               << BC::uniq()
+               << BC::put(1);
 
             // Load function and push it before the first arg and the value
             // from the last setter.
@@ -722,7 +719,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         ctx.pushLoop(loopBranch, breakBranch);
 
         compileExpr(ctx, seq);
-        cs << BC::uniq()
+        cs << BC::setShared()
            << BC::push((int)0);
 
         cs << BC::beginloop(breakBranch)

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -458,7 +458,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
             names.push_back(R_NilValue);
 
             cs << BC::pick(1)
-               << BC::uniq()
+               << BC::makeUnique()
                << BC::put(1);
 
             // Load function and push it before the first arg and the value
@@ -819,7 +819,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                    << BC::swap()
                    << BC::length()
                    << BC::dup()
-                   << BC::uniq()
+                   << BC::makeUnique()
                    << BC::inc()
                    << BC::swap()
                    // allocate the ans vector with same size and names

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -190,7 +190,7 @@ DEF_INSTR(set_shared_, 0, 1, 1, 1)
 /**
  * set_shared_:: marks tos to be shared (ie. named = 2)
  */
-DEF_INSTR(uniq_, 0, 1, 1, 1)
+DEF_INSTR(make_unique_, 0, 1, 1, 1)
 /**
  * uniq_:: duplicates tos if it is shared (ie. named > 1)
  */

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -186,6 +186,10 @@ DEF_INSTR(static_call_stack_, 2, -1, 1, 0)
 /**
  * static_call_stack_:: like call_stack, but call target is immediate
  */
+DEF_INSTR(set_shared_, 0, 1, 1, 1)
+/**
+ * set_shared_:: marks tos to be shared (ie. named = 2)
+ */
 DEF_INSTR(uniq_, 0, 1, 1, 1)
 /**
  * uniq_:: duplicates tos if it is shared (ie. named > 1)

--- a/rir/src/optimizer/cleanup.h
+++ b/rir/src/optimizer/cleanup.h
@@ -22,11 +22,32 @@ class BCCleanup : public InstructionDispatcher::Receiver {
         auto defI = v.u.def;
         BC def = *defI;
 
+        bool isDup = def.is(Opcode::dup_);
         // push - pop elimination
-        if (!v.used()) {
-            if (def.is(Opcode::push_) || def.is(Opcode::dup_)) {
+        if (def.is(Opcode::push_) || isDup) {
+            bool used = v.used();
+            if (used && v.singleUse()) {
+                CodeEditor::Iterator use = v.use();
+                if ((*use).is(Opcode::set_shared_) ||
+                    (*use).is(Opcode::uniq_)) {
+                    use.asCursor(code_).remove();
+                    used = false;
+                }
+            }
+
+            if (!used) {
                 defI.asCursor(code_).remove();
                 ins.asCursor(code_).remove();
+                /* if we remove a dup instruction then the potentially
+                 * following set_shared_ becomes obsolete as well */
+                if (isDup) {
+                    if ((ins + 1) != code_.end()) {
+                        auto next = ins + 1;
+                        if ((*next).is(Opcode::set_shared_)) {
+                            next.asCursor(code_).remove();
+                        }
+                    }
+                }
                 return;
             }
         }
@@ -136,17 +157,6 @@ class BCCleanup : public InstructionDispatcher::Receiver {
             if ((*(ins + 1)).is(Opcode::pop_) ||
                 (*(ins + 1)).is(Opcode::visible_) ||
                 (*(ins + 1)).is(Opcode::ldvar_)) {
-                ins.asCursor(code_).remove();
-            }
-        }
-    }
-
-    void uniq_(CodeEditor::Iterator ins) override {
-        if ((ins + 1) != code_.end()) {
-            if ((*(ins + 1)).is(Opcode::stvar_) ||
-                (*(ins + 1)).is(Opcode::pop_) ||
-                (*(ins + 1)).is(Opcode::subassign_) ||
-                (*(ins + 1)).is(Opcode::subassign2_)) {
                 ins.asCursor(code_).remove();
             }
         }

--- a/rir/src/optimizer/cleanup.h
+++ b/rir/src/optimizer/cleanup.h
@@ -29,7 +29,7 @@ class BCCleanup : public InstructionDispatcher::Receiver {
             if (used && v.singleUse()) {
                 CodeEditor::Iterator use = v.use();
                 if ((*use).is(Opcode::set_shared_) ||
-                    (*use).is(Opcode::uniq_)) {
+                    (*use).is(Opcode::make_unique_)) {
                     use.asCursor(code_).remove();
                     used = false;
                 }


### PR DESCRIPTION
our uniq instruction was a mixture of shallow copying the value and
bumping the named count. this worked well in some situations but in
general is not fine grained enough.

the new semantics is:
* uniq: if the tos value is shared then copy it (such that the tos is
        now an unique copy of the value)
* set_shared: bump the named count to 2 such that tos is marked as
              shared (ie. will be copied by a subsequent uniq).