### PR TITLE
Removal of as-package code

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -52,7 +52,7 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env = NULL) {
         auto res = Compiler::compileClosure(body, FORMALS(what));
         SET_FORMALS(result, res.formals);
         SET_CLOENV(result, CLOENV(what));
-        SET_BODY(result, rir_createWrapperAst(res.bc));
+        SET_BODY(result, res.bc);
         Rf_copyMostAttrib(what, result);
         UNPROTECT(1);
         return result;
@@ -61,7 +61,7 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env = NULL) {
             what = VECTOR_ELT(CDR(what), 0);
         }
         auto res = Compiler::compileExpression(what);
-        return rir_createWrapperAst(res.bc);
+        return res.bc;
     }
 }
 

--- a/rir/src/config.h
+++ b/rir/src/config.h
@@ -4,17 +4,6 @@
 /** Everyone wants R */
 #include "R/r.h"
 
-
-/** If RIR_AS_PACKAGE is equal to 1, rir is built in mode that is compatible with vanilla GNU-R sources.
-
-  Disabling the option makes RIR link to a modified version of gnu-r where rir is able to see selected hidden functions from R runtime and bypass some of the wrappers.
- */
-
-#ifndef RIR_AS_PACKAGE
-#define RIR_AS_PACKAGE 0
-#endif
-
-
 /** C/C++ interoperability layer for declarations and common data types
  */
 #ifdef __cplusplus

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -529,7 +529,6 @@ INLINE SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
 
     return result;
 }
-#define USE_RIR_CONTEXT_SETUP true
 
 void warnSpecial(SEXP callee, SEXP call) {
     return;
@@ -631,7 +630,7 @@ SEXP doCall(Code* caller, SEXP callee, unsigned nargs, unsigned id, SEXP env,
         // if body is INTSXP, it is rir serialized code, execute it directly
         SEXP body = BODY(callee);
         assert(TYPEOF(body) == EXTERNALSXP || !COMPILE_ON_DEMAND);
-        if (USE_RIR_CONTEXT_SETUP && TYPEOF(body) == EXTERNALSXP) {
+        if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidFunctionSEXP(body));
             result =
                 rirCallClosure(call, env, callee, argslist, nargs, pc, ctx);
@@ -772,7 +771,7 @@ SEXP doCallStack(Code* caller, SEXP callee, size_t nargs, unsigned id, SEXP env,
         // if body is INTSXP, it is rir serialized code, execute it directly
         SEXP body = BODY(callee);
         assert(TYPEOF(body) == EXTERNALSXP || !COMPILE_ON_DEMAND);
-        if (USE_RIR_CONTEXT_SETUP && TYPEOF(body) == EXTERNALSXP) {
+        if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidFunctionSEXP(body));
             res = rirCallClosure(call, env, callee, argslist, nargs, pc, ctx);
             UNPROTECT(1);
@@ -891,7 +890,7 @@ SEXP doDispatchStack(Code* caller, size_t nargs, uint32_t id, SEXP env,
             // if body is INTSXP, it is rir serialized code, execute it directly
             SEXP body = BODY(callee);
             assert(TYPEOF(body) == EXTERNALSXP || !COMPILE_ON_DEMAND);
-            if (USE_RIR_CONTEXT_SETUP && TYPEOF(body) == EXTERNALSXP) {
+            if (TYPEOF(body) == EXTERNALSXP) {
                 assert(isValidFunctionSEXP(body));
                 res =
                     rirCallClosure(call, env, callee, actuals, nargs, pc, ctx);
@@ -1005,7 +1004,7 @@ SEXP doDispatch(Code* caller, uint32_t nargs, uint32_t id, SEXP env,
             // if body is INTSXP, it is rir serialized code, execute it directly
             SEXP body = BODY(callee);
             assert(TYPEOF(body) == EXTERNALSXP || !COMPILE_ON_DEMAND);
-            if (USE_RIR_CONTEXT_SETUP && TYPEOF(body) == EXTERNALSXP) {
+            if (TYPEOF(body) == EXTERNALSXP) {
                 assert(isValidFunctionSEXP(body));
                 res = rirCallClosure(call, env, callee, actuals, nargs, pc, ctx);
                 break;

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -7,122 +7,8 @@ SEXP execName;
 SEXP promExecName;
 Context * globalContext_;
 
-#if RIR_AS_PACKAGE == 1
-
-// envir.c: 1320
-// only needed by ddfindVar
-int ddVal(SEXP symbol) {
-    const char *buf;
-    char *endp;
-    int rval;
-
-    buf = CHAR(PRINTNAME(symbol));
-    if( !strncmp(buf,"..",2) && strlen(buf) > 2 ) {
-    buf += 2;
-    rval = (int) strtol(buf, &endp, 10);
-    if( *endp != '\0')
-        return 0;
-    else
-        return rval;
-    }
-    return 0;
-}
-
-// envir.c 1357, our version ignores i18n
-SEXP Rf_ddfindVar(SEXP symbol, SEXP rho) {
-    int i;
-    SEXP vl;
-
-    /* first look for ... symbol  */
-    vl = findVar(R_DotsSymbol, rho);
-    i = ddVal(symbol);
-    if (vl != R_UnboundValue) {
-        if (Rf_length(vl) >= i) {
-            vl = nthcdr(vl, i - 1);
-            return(CAR(vl));
-        } else {
-            error("the ... list does not contain %d elements", i);
-        }
-    } else {
-        error("..%d used in an incorrect context, no ... to look in", i);
-    }
-    return R_NilValue;
-}
-
-// memory.c 2333
-/** Creates a promise.
-
-  This is not the fastest way as we always PROTECT expr and rho, but GNU-R's GC does not seem to publish its free nodes API.
- */
-SEXP mkPROMISE(SEXP expr, SEXP rho) {
-    PROTECT(expr);
-    PROTECT(rho);
-    SEXP s = Rf_allocSExp(PROMSXP);
-    UNPROTECT(2);
-
-    /* precaution to ensure code does not get modified via
-       substitute() and the like */
-    if (NAMED(expr) < 2) SET_NAMED(expr, 2);
-
-    SET_PRCODE(s, expr);
-    SET_PRENV(s, rho);
-    SET_PRVALUE(s, R_UnboundValue);
-    SET_PRSEEN(s, 0);
-
-    return s;
-}
-
-SEXP forcePromise(SEXP promise) {
-    // eval.c 463 forcePromise
-    // The problem here is that the R_PendingPromises does not seem to be exported, so if we want to evaluate a promise, we must call the eval itself, fortunately this does evaluate the promise, but will likely not be superfast.
-    // TODO not using the Prstack will bite us - debugging info, etc?
-    // TODO there is some stuff from eval() missing, such as yielding and recursion check, but not a big deal here...
-    Code * c = isValidPromiseSEXP(promise);
-    if (c != NULL) {
-        if (PRSEEN(promise)) {
-            if (PRSEEN(promise) == 1)
-                error("promise already under evaluation: recursive default argument reference or earlier problems?");
-            else warning("restarting interrupted promise evaluation");
-        }
-        SET_PRSEEN(promise, 1);
-        SEXP val = evalRirCode(c, globalContext(), PRENV(promise), 0);
-        SET_PRSEEN(promise, 0);
-        SET_PRVALUE(promise, val);
-        SET_NAMED(val, 2);
-        SET_PRENV(promise, R_NilValue);
-        return val;
-    } else {
-        return Rf_eval(promise, PRENV(promise));
-    }
-}
-
-#endif
-
 Function * isValidFunctionSEXP(SEXP wrapper) {
-#if RIR_AS_PACKAGE == 1
-    if (TYPEOF(wrapper) != LANGSXP)
-        return nullptr;
-    // now we know it is uncompiled function, check that it contains what we expect
-    SEXP x = CAR(wrapper);
-    if (x != callSymbol)
-        return nullptr;
-    wrapper = CDR(wrapper);
-    if (wrapper == R_NilValue)
-        return nullptr;
-    x = CAR(wrapper);
-    if (x != execName)
-        return nullptr;
-    wrapper = CDR(wrapper);
-    if (wrapper == R_NilValue)
-        return nullptr;
-    x = CAR(wrapper);
-    if (TYPEOF(x) != EXTERNALSXP)
-        return nullptr;
-    // that's enough checking, return the function
-    return (Function*)INTEGER(x);
-#else
     return isValidFunctionObject(wrapper);
-#endif
 }
 
 /** Checks if given closure should be executed using RIR.
@@ -136,37 +22,7 @@ Function * isValidClosureSEXP(SEXP closure) {
 }
 
 Code * isValidPromiseSEXP(SEXP promise) {
-    SEXP body = PRCODE(promise);
-#if RIR_AS_PACKAGE == 1
-    if (TYPEOF(body) != LANGSXP)
-        return nullptr;
-    // now we know it is uncompiled function, check that it contains what we expect
-    SEXP x = CAR(body);
-    if (x != callSymbol)
-        return nullptr;
-    body = CDR(body);
-    if (body == R_NilValue)
-        return nullptr;
-    x = CAR(body);
-    if (x != promExecName)
-        return nullptr;
-    body = CDR(body);
-    if (body == R_NilValue)
-        return nullptr;
-    SEXP code  = CAR(body);
-    if (TYPEOF(code) != EXTERNALSXP)
-        return nullptr;
-    body = CDR(body);
-    if (body == R_NilValue)
-        return nullptr;
-    x = CAR(body);
-    if (TYPEOF(x) != EXTERNALSXP || Rf_length(x) != 1)
-        return nullptr;
-    unsigned offset = (unsigned)INTEGER(x)[0];
-    return codeAt((Function*)INTEGER(code), offset);
-#else
-    return isValidCodeObject(body);
-#endif
+    return isValidCodeObject(PRCODE(promise));
 }
 
 // for now, we will have to rewrite this when it goes to GNU-R proper
@@ -211,30 +67,11 @@ void printFunction(Function* f) {
 }
 
 SEXP rir_createWrapperAst(SEXP rirBytecode) {
-#if RIR_AS_PACKAGE == 1
-    SEXP envCall = Rf_lang1(envSymbol);
-    PROTECT(envCall);
-    SEXP result =  Rf_lang4(callSymbol, execName, rirBytecode, envCall);
-    UNPROTECT(1);
-    return result;
-#else
     return rirBytecode;
-#endif
 }
 
 SEXP rir_createWrapperPromise(Code * code) {
-#if RIR_AS_PACKAGE == 1
-    SEXP envCall = lang1(envSymbol);
-    PROTECT(envCall);
-    SEXP offset = Rf_allocVector(INTSXP, 1);
-    PROTECT(offset);
-    INTEGER(offset)[0] = code->header;
-    SEXP result =  Rf_lang5(callSymbol, promExecName, functionSEXP(function(code)), offset, envCall);
-    UNPROTECT(2);
-    return result;
-#else
     return (SEXP)code;
-#endif
 }
 
 // TODO change gnu-r to expect ptr and not bool aand we can get rid of the wrapper

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -66,22 +66,13 @@ void printFunction(Function* f) {
         printCode(c);
 }
 
-SEXP rir_createWrapperAst(SEXP rirBytecode) {
-    return rirBytecode;
-}
-
-SEXP rir_createWrapperPromise(Code * code) {
-    return (SEXP)code;
-}
-
-// TODO change gnu-r to expect ptr and not bool aand we can get rid of the wrapper
+// TODO change gnu-r to expect ptr and not bool and we can get rid of the wrapper
 int isValidFunctionObject_int_wrapper(SEXP closure) {
     return isValidFunctionObject(closure) != nullptr;
 }
 
 int isValidCodeObject_int_wrapper(SEXP code) {
     return isValidCodeObject(code) != nullptr;
-
 }
 
 void initializeRuntime(CompilerCallback compiler, OptimizerCallback optimizer) {

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -10,8 +10,6 @@
 C_OR_CPP Code * isValidPromiseSEXP(SEXP promise);
 C_OR_CPP Function * isValidClosureSEXP(SEXP closure);
 C_OR_CPP Function * isValidFunctionSEXP(SEXP wrapper);
-C_OR_CPP SEXP rir_createWrapperPromise(Code * code);
-
 
 // rir runtime functions -------------------------------------------------------
 
@@ -29,10 +27,6 @@ C_OR_CPP void printCode(Code* c);
 
 C_OR_CPP void printFunction(Function* f);
 C_OR_CPP void printFunctionFancy(SEXP f);
-
-C_OR_CPP SEXP rir_createWrapperAst(SEXP rirBytecode);
-
-C_OR_CPP SEXP rir_createWrapperPromise(Code * code);
 
 C_OR_CPP void initializeRuntime(CompilerCallback compiler,
                                 OptimizerCallback optimizer);


### PR DESCRIPTION
This is with relation to issue #13 and the comments there. 

It removes:
1. The `RIR_AS_PACKAGE` def and all the code that depended on it.
2. The `USE_RIR_CONTEXT_SETUP` def and its occurrences.
3. `createWrapperAst` and `createWrapperPromise` functions, which became identities after `RIR_AS_PACKAGE` was removed.