### PR TITLE
Increase benchmark running time

### DIFF
--- a/benchmarks/shootout/knucleotide/knucleotide.r
+++ b/benchmarks/shootout/knucleotide/knucleotide.r
@@ -82,7 +82,7 @@ paste. <- function (..., digits=16, sep=" ", collapse=NULL) {
     }
 }
 
-execute <- function(n = "shootout/fasta/fasta3000.txt") {
+execute <- function(n = "shootout/fasta/fasta10000.txt") {
     knucleotide(n)
 }
 

--- a/benchmarks/shootout/mandelbrot/mandelbrot-noout-naive.r
+++ b/benchmarks/shootout/mandelbrot/mandelbrot-noout-naive.r
@@ -30,6 +30,6 @@ mandelbrot_noout_naive <- function(args) {
     }
 }
 
-execute <- function(n = 400L) {
+execute <- function(n = 700L) {
     mandelbrot_noout_naive(n)
 }

--- a/benchmarks/shootout/reversecomplement/reversecomplement-2.r
+++ b/benchmarks/shootout/reversecomplement/reversecomplement-2.r
@@ -31,6 +31,6 @@ reversecomplement_2 <- function(args) {
 }
 
 
-execute <- function(n = "shootout/fasta/fasta300000.txt") {
+execute <- function(n = "shootout/fasta/fasta500000.txt") {
     reversecomplement_2(n)
 }

--- a/benchmarks/shootout/reversecomplement/reversecomplement.r
+++ b/benchmarks/shootout/reversecomplement/reversecomplement.r
@@ -30,7 +30,7 @@ reversecomplement <- function(args) {
 }
 
 
-execute <- function(n = "shootout/fasta/fasta300000.txt") {
+execute <- function(n = "shootout/fasta/fasta500000.txt") {
     reversecomplement(n)
 }
 

--- a/benchmarks/shootout/spectralnorm/spectralnorm-alt.r
+++ b/benchmarks/shootout/spectralnorm/spectralnorm-alt.r
@@ -27,7 +27,7 @@ spectralnorm_alt <- function(args) {
 }
 
 
-execute <- function(n = 250L) {
+execute <- function(n = 2000L) {
     spectralnorm_alt(n)
 }
 

--- a/benchmarks/shootout/spectralnorm/spectralnorm-alt2.r
+++ b/benchmarks/shootout/spectralnorm/spectralnorm-alt2.r
@@ -28,6 +28,6 @@ spectralnorm_alt2 <- function(args) {
     cat(sqrt(sum(u * v) / sum(v * v)), "\n")
 }
 
-execute <- function(n = 250L) {
+execute <- function(n = 1000L) {
     spectralnorm_alt2(n)
 }

--- a/benchmarks/shootout/spectralnorm/spectralnorm-math.r
+++ b/benchmarks/shootout/spectralnorm/spectralnorm-math.r
@@ -15,6 +15,6 @@ spectralnorm_math <- function(args) {
     cat(sqrt(max(eigen(t(m) %*% m)$val)), "\n")
 }
 
-execute <- function(n = 250L) {
+execute <- function(n = 1000L) {
     spectralnorm_math(n)
 }

--- a/benchmarks/shootout/spectralnorm/spectralnorm.r
+++ b/benchmarks/shootout/spectralnorm/spectralnorm.r
@@ -48,6 +48,6 @@ spectralnorm <- function(args) {
     u
 }
 
-    execute <- function(n = 250L) {
+    execute <- function(n = 1000L) {
         spectralnorm(n)
     }


### PR DESCRIPTION
Some benchmarks were running almost instantenously. This changes their defaults.

Measured on ginger, aim was to get all to take at least a second
