### PR TITLE
Fix typo in rir.eval

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -19,7 +19,7 @@ rir.compile <- function(what) {
     .Call("rir_compile", what)
 }
 
-rir.eval <- function(what, env = globalEnv()) {
+rir.eval <- function(what, env = globalenv()) {
     .Call("rir_eval", what, env);
 }
 


### PR DESCRIPTION
The default argument for env should be globalenv() (all lowercase).