### PR TITLE
Speed up loops

### DIFF
--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -830,29 +830,27 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
         cs << BC::guardNamePrimitive(fun);
 
-        LabelT loopBranch = cs.mkLabel();
-        LabelT breakBranch = cs.mkLabel();
-        LabelT endForBranch = cs.mkLabel();
+        LabelT condBranch = cs.mkLabel();
+        LabelT bodyBranch = cs.mkLabel();
+        LabelT afterBranch = cs.mkLabel();
 
-        ctx.pushLoop(loopBranch, breakBranch);
+        ctx.pushLoop(condBranch, afterBranch);
 
         compileExpr(ctx, seq);
         cs << BC::setShared()
            << BC::push((int)0);
 
         std::vector<unsigned> pcs;
-
         pcs.push_back(cs.currentPos());
-        cs << BC::beginloop(breakBranch)
-           << loopBranch;
 
-        // Move context out of the way
-        pcs.push_back(cs.currentPos());
-        cs << BC::put(2);
+        cs << BC::beginloop(afterBranch);
 
-        cs << BC::inc()
-           << BC::testBounds()
-           << BC::brfalse(endForBranch)
+        // Stack is now [..., seq, idx, cntxt]
+        // Jump to step and condition
+        cs << BC::br(condBranch);
+
+        // After bounds check stack is [..., cntxt, seq, idx]
+        cs << bodyBranch
            << BC::dup2()
            << BC::extract1();
 
@@ -862,19 +860,28 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         pcs.push_back(cs.currentPos());
         cs << BC::swap();
 
+        // Stack is now [..., seq, idx, cntxt, seq[idx]]
         // Set the loop variable
         cs << BC::stvar(sym);
 
         compileExpr(ctx, body);
-        cs << BC::pop()
-           << BC::br(loopBranch);
+        cs << BC::pop();
 
-        cs << endForBranch;
+        cs << condBranch;
+
+        // Move context out of the way
+        pcs.push_back(cs.currentPos());
+        cs << BC::put(2);
+
+        cs << BC::inc()
+           << BC::testBounds()
+           << BC::brtrue(bodyBranch);
+
         // Put context back
         pcs.push_back(cs.currentPos());
         cs << BC::pick(2);
 
-        cs << breakBranch;
+        cs << afterBranch;
 
         if (ctx.loopNeedsContext()) {
             cs << BC::endcontext();

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -789,20 +789,20 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
         cs << BC::guardNamePrimitive(fun);
 
-        LabelT loopBranch = cs.mkLabel();
-        LabelT nextBranch = cs.mkLabel();
+        LabelT bodyBranch = cs.mkLabel();
+        LabelT afterBranch = cs.mkLabel();
 
-        ctx.pushLoop(loopBranch, nextBranch);
+        ctx.pushLoop(bodyBranch, afterBranch);
 
         unsigned beginLoopPos = cs.currentPos();
 
-        cs << BC::beginloop(nextBranch)
-           << loopBranch;
+        cs << BC::beginloop(afterBranch)
+           << bodyBranch;
 
         compileExpr(ctx, body);
         cs << BC::pop()
-           << BC::br(loopBranch)
-           << nextBranch;
+           << BC::br(bodyBranch)
+           << afterBranch;
 
         if (ctx.loopNeedsContext()) {
             cs << BC::endcontext();


### PR DESCRIPTION
Shuffled loop code around so that some jumps are avoided (one for every iteration but the first):

Instead of 
```
COND:
    <cond>
    brfalse_ END
    <body>
    br_ COND
END:
```

We now have
```
    br_ COND
BODY:
    <body>
COND:
    <cond>
    brtrue_ BODY
END:
```

`for` loop is similar, but a bit messier. `repeat` is not affected.