### PR TITLE
Clean up Function/SEXP casts and related ops

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -70,7 +70,7 @@ REXPORT SEXP rir_markOptimize(SEXP what) {
         return R_NilValue;
     SEXP b = BODY(what);
     isValidFunctionSEXP(b);
-    Function* fun = (Function*)INTEGER(b);
+    Function* fun = sexp2function(b);
     fun->markOpt = true;
     return R_NilValue;
 }
@@ -81,14 +81,14 @@ REXPORT SEXP rir_eval(SEXP what, SEXP env) {
         f = isValidClosureSEXP(what);
     if (f == nullptr)
         Rf_error("Not rir compiled code");
-    return evalRirCode(functionCode(f), globalContext(), env, 0);
+    return evalRirCode(bodyCode(f), globalContext(), env, 0);
 }
 
 REXPORT SEXP rir_body(SEXP cls) {
     ::Function * f = isValidClosureSEXP(cls);
     if (f == nullptr)
         Rf_error("Not a valid rir compiled function");
-    return functionSEXP(f);
+    return function2store(f);
 }
 
 REXPORT SEXP rir_analysis_signature(SEXP what) {

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -5,9 +5,9 @@ SEXP envSymbol;
 SEXP callSymbol;
 SEXP execName;
 SEXP promExecName;
-Context * globalContext_;
+Context* globalContext_;
 
-Function * isValidFunctionSEXP(SEXP wrapper) {
+Function* isValidFunctionSEXP(SEXP wrapper) {
     return isValidFunctionObject(wrapper);
 }
 
@@ -15,13 +15,13 @@ Function * isValidFunctionSEXP(SEXP wrapper) {
 
   If the given closure is RIR function, returns its Function object, otherwise returns nullptr.
  */
-Function * isValidClosureSEXP(SEXP closure) {
+Function* isValidClosureSEXP(SEXP closure) {
     if (TYPEOF(closure) != CLOSXP)
         return nullptr;
-    return isValidFunctionSEXP(BODY(closure));
+    return isValidFunctionObject(BODY(closure));
 }
 
-Code * isValidPromiseSEXP(SEXP promise) {
+Code* isValidPromiseSEXP(SEXP promise) {
     return isValidCodeObject(PRCODE(promise));
 }
 

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -7,21 +7,14 @@
 
 // stuff from api the interpreter uses
 
-C_OR_CPP Code * isValidPromiseSEXP(SEXP promise);
-C_OR_CPP Function * isValidClosureSEXP(SEXP closure);
-C_OR_CPP Function * isValidFunctionSEXP(SEXP wrapper);
-
-// rir runtime functions -------------------------------------------------------
-
-C_OR_CPP Function * isValidClosureSEXP(SEXP wrapper);
+C_OR_CPP Code* isValidPromiseSEXP(SEXP promise);
+C_OR_CPP Function* isValidClosureSEXP(SEXP closure);
+C_OR_CPP Function* isValidFunctionSEXP(SEXP wrapper);
 
 /** Checks if given closure should be executed using RIR.
 
   If the given closure is RIR function, returns its Function object, otherwise returns nullptr.
  */
-C_OR_CPP Function * isValidClosureSEXP(SEXP closure);
-
-C_OR_CPP Code * isValidPromiseSEXP(SEXP promise);
 
 C_OR_CPP void printCode(Code* c);
 

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -126,8 +126,7 @@ void CodeVerifier::vefifyFunctionLayout(SEXP sexp, ::Context* ctx) {
     Function* f = fun.function;
     if (f->origin) {
         assert(TYPEOF(f->origin) == EXTERNALSXP and "Invalid origin type");
-        assert(static_cast<unsigned>(INTEGER(f->origin)[0]) ==
-                   FUNCTION_MAGIC and
+        assert(sexp2function(f->origin)->magic == FUNCTION_MAGIC and
                "Origin does not seem to be function bytecode");
     }
     assert(f->codeLength == objs.size() and "Invalid number of code objects");
@@ -138,7 +137,7 @@ void CodeVerifier::vefifyFunctionLayout(SEXP sexp, ::Context* ctx) {
     for (size_t i = 0, e = objs.size() - 1; i != e; ++i) {
         Code* c = objs[i];
         assert(c->magic == CODE_MAGIC and "Invalid code magic number");
-        assert(function(c) == f and "Invalid code offset");
+        assert(code2function(c) == f and "Invalid code offset");
         assert(c->src != 0 and "Code must have AST");
         unsigned oldo = c->stackLength;
         calculateAndVerifyStack(c);

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -35,7 +35,7 @@ bool Optimizer::inliner(CodeEditor& code, bool stable) {
 }
 
 SEXP Optimizer::reoptimizeFunction(SEXP s) {
-    Function* fun = (Function*)INTEGER(BODY(s));
+    Function* fun = sexp2function(BODY(s));
     bool safe = !fun->envLeaked && !fun->envChanged;
 
     CodeEditor code(s);

--- a/rir/src/optimization/stupid_inline.h
+++ b/rir/src/optimization/stupid_inline.h
@@ -113,8 +113,8 @@ class StupidInliner {
             if (!isValidFunctionSEXP(fun))
                 continue;
 
-            Function* f = (Function*)INTEGER(fun);
-            Code* c = functionCode(f);
+            Function* f = sexp2function(fun);
+            Code* c = bodyCode(f);
 
             // TODO: This is a bit of a hack to find out if the function
             // has just one code object.

--- a/rir/src/utils/CodeHandle.cpp
+++ b/rir/src/utils/CodeHandle.cpp
@@ -34,7 +34,7 @@ void CodeHandle::print() {
 }
 
 FunctionHandle CodeHandle::function() {
-    return (SEXP)((uintptr_t)::function(code) - FUNCTION_OFFSET);
+    return ::function2store(::code2function(code));
 }
 
 FunIdxT CodeHandle::idx() {

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -103,7 +103,7 @@ class FunctionHandle {
         CodeHandle code(ast, codeSize, sources.size(), callSiteLength, offset,
                         insert);
 
-        assert(::function(code.code) == function);
+        assert(::code2function(code.code) == function);
 
         memcpy(code.bc(), bc, codeSize);
 
@@ -172,7 +172,7 @@ class FunctionHandle {
 
     CodeHandle entryPoint() {
         assert(function->foffset);
-        return (Code*)((uintptr_t)function + function->foffset);
+        return bodyCode(function);
     }
 
     CodeHandleIterator begin() { return CodeHandleIterator(::begin(function)); }
@@ -188,7 +188,7 @@ class FunctionHandle {
     }
 
     inline Code* codeAtOffset(unsigned offset) {
-        return (Code*)((uintptr_t)function + offset);
+        return codeAt(function, offset);
     }
 
     SEXP ast() { return entryPoint().ast(); }


### PR DESCRIPTION
~~Maybe more commits to come.~~

This is a refactor to simplify/rename some of the conversion/cast code. I also searched for places that were doing things like `(Function*)INTEGER(s)` and replacing them with function calls, e.g. `sexp2function(s)`.

Assuming the tests pass, this is ready for review/merging. I'll open separate PRs (but reusing the same branch) for further work.