### PR TITLE
Fix cleanup for dup_

### DIFF
--- a/rir/src/optimization/cleanup.h
+++ b/rir/src/optimization/cleanup.h
@@ -47,8 +47,8 @@ class BCCleanup : public InstructionDispatcher::Receiver {
                 /* if we remove a dup instruction then the potentially
                  * following set_shared_ becomes obsolete as well */
                 if (isDup) {
-                    if ((ins + 1) != code_.end()) {
-                        auto next = ins + 1;
+                    if ((defI + 1) != code_.end()) {
+                        auto next = defI + 1;
                         if ((*next).is(Opcode::set_shared_)) {
                             next.asCursor(code_).remove();
                         }


### PR DESCRIPTION
The set_shared_ instruction potentially follows the dup_ (not the pop_).