### PR TITLE
Add vtables

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -47,14 +47,9 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env) {
         if (TYPEOF(body) == EXTERNALSXP)
             Rf_error("closure already compiled");
 
-        SEXP result = allocSExp(CLOSXP);
-        PROTECT(result);
-        auto res = Compiler::compileClosure(body, FORMALS(what), env);
-        SET_FORMALS(result, res.formals);
+        SEXP result = Compiler::compileClosure(body, FORMALS(what), env);
         SET_CLOENV(result, CLOENV(what));
-        SET_BODY(result, res.bc);
         Rf_copyMostAttrib(what, result);
-        UNPROTECT(1);
         return result;
     } else {
         if (TYPEOF(what) == BCODESXP) {
@@ -66,11 +61,16 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env) {
 }
 
 REXPORT SEXP rir_markOptimize(SEXP what) {
+    // TODO(mhyee): This is to mark a function for optimization.
+    // However, now that we have vtables, does this still make sense? Maybe it
+    // might be better to mark a specific version for optimization.
+    // For now, we just mark the first version in the vtable.
     if (TYPEOF(what) != CLOSXP)
         return R_NilValue;
     SEXP b = BODY(what);
-    isValidFunctionSEXP(b);
-    Function* fun = sexp2function(b);
+    assert(isValidDispatchTableSEXP(b) && "Expected a DispatchTable");
+    DispatchTable* dt = sexp2dispatchTable(b);
+    Function* fun = sexp2function(dt->entry[0]);
     fun->markOpt = true;
     return R_NilValue;
 }

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -18,8 +18,6 @@ SEXP rirExpr(SEXP f);
 
 SEXP rirEval_f(SEXP f, SEXP env);
 
-SEXP rirExpr(SEXP f);
-
 #ifdef __cplusplus
 }
 #endif

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -7,6 +7,10 @@ SEXP execName;
 SEXP promExecName;
 Context* globalContext_;
 
+DispatchTable* isValidDispatchTableSEXP(SEXP wrapper) {
+    return isValidDispatchTableObject(wrapper);
+}
+
 Function* isValidFunctionSEXP(SEXP wrapper) {
     return isValidFunctionObject(wrapper);
 }
@@ -18,7 +22,13 @@ Function* isValidFunctionSEXP(SEXP wrapper) {
 Function* isValidClosureSEXP(SEXP closure) {
     if (TYPEOF(closure) != CLOSXP)
         return nullptr;
-    return isValidFunctionObject(BODY(closure));
+    DispatchTable* t = isValidDispatchTableObject(BODY(closure));
+    if (t == nullptr)
+        return nullptr;
+    Function* f = sexp2function(t->entry[0]);
+    if (f->magic != FUNCTION_MAGIC)
+        return nullptr;
+    return f;
 }
 
 Code* isValidPromiseSEXP(SEXP promise) {

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -10,6 +10,7 @@
 C_OR_CPP Code* isValidPromiseSEXP(SEXP promise);
 C_OR_CPP Function* isValidClosureSEXP(SEXP closure);
 C_OR_CPP Function* isValidFunctionSEXP(SEXP wrapper);
+C_OR_CPP DispatchTable* isValidDispatchTableSEXP(SEXP wrapper);
 
 /** Checks if given closure should be executed using RIR.
 

--- a/rir/src/ir/CodeEditor.cpp
+++ b/rir/src/ir/CodeEditor.cpp
@@ -16,7 +16,8 @@ CodeEditor::CodeEditor(SEXP in) {
         ::Function* f = isValidClosureSEXP(in);
         assert(f != nullptr);
         formals_ = FORMALS(in);
-        bc = BODY(in);
+        DispatchTable* dispatchTable = sexp2dispatchTable(BODY(in));
+        bc = dispatchTable->entry[0];
     }
     FunctionHandle fh(bc);
     CodeHandle ch = fh.entryPoint();

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -110,7 +110,7 @@ void CodeVerifier::calculateAndVerifyStack(CodeHandle code) {
     code.code->stackLength = max.ostack;
 }
 
-void CodeVerifier::vefifyFunctionLayout(SEXP sexp, ::Context* ctx) {
+void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
     assert(TYPEOF(sexp) == EXTERNALSXP and "Invalid SEXPTYPE");
     FunctionHandle fun(sexp);
 

--- a/rir/src/ir/CodeVerifier.h
+++ b/rir/src/ir/CodeVerifier.h
@@ -17,7 +17,7 @@ class CodeVerifier {
 
     /** Verifies that the given function object is valid.
      */
-    static void vefifyFunctionLayout(SEXP sexp, ::Context* ctx);
+    static void verifyFunctionLayout(SEXP sexp, ::Context* ctx);
 };
 
 } // namespace rir

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -172,8 +172,8 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
     if (fun == symbol::Function && args.length() == 3) {
         auto cls = Compiler::compileClosure(args[1], args[0]);
-        cs << BC::push(cls.formals)
-           << BC::push(cls.bc)
+        cs << BC::push(FORMALS(cls))
+           << BC::push(BODY(cls))
            << BC::push(args[2])
            << BC::close();
         return true;
@@ -1219,7 +1219,7 @@ Compiler::CompilerRes Compiler::finalize() {
 
     FunctionHandle opt = code.finalize();
 #ifdef ENABLE_SLOWASSERT
-    CodeVerifier::vefifyFunctionLayout(opt.store, globalContext());
+    CodeVerifier::verifyFunctionLayout(opt.store, globalContext());
 #endif
 
     // Protect p;

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -35,7 +35,7 @@ bool Optimizer::inliner(CodeEditor& code, bool stable) {
 }
 
 SEXP Optimizer::reoptimizeFunction(SEXP s) {
-    Function* fun = sexp2function(BODY(s));
+    Function* fun = sexp2function(s);
     bool safe = !fun->envLeaked && !fun->envChanged;
 
     CodeEditor code(s);
@@ -48,9 +48,9 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
     }
 
     FunctionHandle opt = code.finalize();
-    opt.function->origin = BODY(s);
+    opt.function->origin = s;
 #ifdef ENABLE_SLOWASSERT
-    CodeVerifier::vefifyFunctionLayout(opt.store, globalContext());
+    CodeVerifier::verifyFunctionLayout(opt.store, globalContext());
 #endif
     SEXP res = opt.store;
     return res;

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -41,6 +41,8 @@ class FunctionHandle {
         function->size = sizeof(Function);
         function->origin = nullptr;
         function->next = nullptr;
+        function->closure = nullptr;
+        // TODO(mhyee): signature
         function->codeLength = 0;
         function->foffset = 0;
         function->invocationCount = 0;


### PR DESCRIPTION
Implements #49.

To support multiple (compiled) versions of a function, we introduce vtables. The body of a closure is a vtable (instead of a function):

    closure
       |---> formals
       |---> env
       |---> body (actually a vtable)
               | ----> compiled_bc1
               | ----> compiled_bc2
               | ...
               | ----> compiled_bcn

Currently, when a closure is called, the first function in the vtable is selected.

This is only the first step, but I'd like to get the code reviewed and merged. There will be some performance regression, as the call instruction cannot select an optimized function version to call.

There are a number of things we should discuss, probably in a meeting. For now, I left a bunch of TODOs.

I separated the work into multiple commits, to make it easier to review. I'll squash everything before merging.