### PR TITLE
Formals

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -16,10 +16,7 @@ rir.disassemble <- function(what) {
 
 # compiles given closure, or expression and returns the compiled version.
 rir.compile <- function(what) {
-    if (typeof(what) == "closure")
-        .Call("rir_compile", what)
-    else
-        .Call("rir_compile", what)
+    .Call("rir_compile", what)
 }
 
 # compiles code of the given file and returns the list of compiled version.

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -16,12 +16,10 @@ rir.disassemble <- function(what) {
 
 # compiles given closure, or expression and returns the compiled version.
 rir.compile <- function(what) {
-    # TODO: gnu-r compile function takes optional environment argument for expressions
-    # this just uses globalenv for now
     if (typeof(what) == "closure")
-        .Call("rir_compile", what, environment(what))
+        .Call("rir_compile", what)
     else
-        .Call("rir_compile", what, globalenv())
+        .Call("rir_compile", what)
 }
 
 # compiles code of the given file and returns the list of compiled version.

--- a/rir/src/R/Preserve.h
+++ b/rir/src/R/Preserve.h
@@ -10,7 +10,7 @@ class Preserve {
   public:
     Preserve(const Preserve& other) = delete;
 
-    Preserve(){};
+    Preserve() {}
 
     SEXP operator()(SEXP value) {
         R_PreserveObject(value);

--- a/rir/src/R/Protect.h
+++ b/rir/src/R/Protect.h
@@ -11,11 +11,11 @@ class Protect {
   public:
     Protect(const Protect& other) = delete;
 
-    Protect(){};
+    Protect() {}
     Protect(SEXP init) {
         Rf_protect(init);
         ++protectedValues_;
-    };
+    }
 
     SEXP operator()(SEXP value) {
         Rf_protect(value);

--- a/rir/src/R/RList.cpp
+++ b/rir/src/R/RList.cpp
@@ -4,7 +4,7 @@
 
 namespace rir {
 
-RList::RList(SEXP list) : list(list) {
+RList::RList(SEXP list) : list(list ? list : R_NilValue) {
     assert(TYPEOF(list) == LISTSXP || TYPEOF(list) == LANGSXP || TYPEOF(list) == NILSXP);
 }
 

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -34,7 +34,7 @@ REXPORT SEXP rir_disassemble(SEXP what) {
     return R_NilValue;
 }
 
-REXPORT SEXP rir_compile(SEXP what) {
+REXPORT SEXP rir_compile(SEXP what, SEXP env = NULL) {
 
     // TODO make this nicer
     if (TYPEOF(what) == CLOSXP) {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -55,8 +55,8 @@ REXPORT SEXP rir_compile(SEXP what) {
         if (TYPEOF(what) == BCODESXP) {
             what = VECTOR_ELT(CDR(what), 0);
         }
-        auto res = Compiler::compileExpression(what);
-        return res.bc;
+        SEXP result = Compiler::compileExpression(what);
+        return result;
     }
 }
 

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -34,7 +34,7 @@ REXPORT SEXP rir_disassemble(SEXP what) {
     return R_NilValue;
 }
 
-REXPORT SEXP rir_compile(SEXP what, SEXP env) {
+REXPORT SEXP rir_compile(SEXP what) {
 
     // TODO make this nicer
     if (TYPEOF(what) == CLOSXP) {
@@ -47,7 +47,7 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env) {
         if (TYPEOF(body) == EXTERNALSXP)
             Rf_error("closure already compiled");
 
-        SEXP result = Compiler::compileClosure(body, FORMALS(what), env);
+        SEXP result = Compiler::compileClosure(body, FORMALS(what));
         SET_CLOENV(result, CLOENV(what));
         Rf_copyMostAttrib(what, result);
         return result;
@@ -55,7 +55,7 @@ REXPORT SEXP rir_compile(SEXP what, SEXP env) {
         if (TYPEOF(what) == BCODESXP) {
             what = VECTOR_ELT(CDR(what), 0);
         }
-        auto res = Compiler::compileExpression(what, env);
+        auto res = Compiler::compileExpression(what);
         return res.bc;
     }
 }

--- a/rir/src/interpreter/deoptimizer.c
+++ b/rir/src/interpreter/deoptimizer.c
@@ -17,6 +17,8 @@ static DeoptInfo* DeoptInfo_alloc() {
         memcpy(newDeoptTable, deoptTable, deoptTableSize);
         memset((char*)newDeoptTable + deoptTableSize, 0,
                newDeoptTableSize - deoptTableSize);
+        if (deoptTableSize > 0)
+            free(deoptTable);
         deoptTable = newDeoptTable;
         deoptTableSize = newDeoptTableSize;
     }
@@ -39,8 +41,10 @@ uint32_t Deoptimizer_register(OpcodeT* oldPc) {
                sizeof(uint32_t) * deoptTableEntries);
         memset(newDeoptTableOffset + deoptTableEntries, 0,
                sizeof(uint32_t) * (newDeoptTableEntries - deoptTableEntries));
-        deoptTableEntries = newDeoptTableEntries;
+        if (deoptTableEntries > 0)
+            free(deoptTableOffset);
         deoptTableOffset = newDeoptTableOffset;
+        deoptTableEntries = newDeoptTableEntries;
     }
     uint32_t off = (char*)i - (char*)deoptTable;
     uint32_t idx = deoptTableEntriesUsed++;

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -157,8 +157,8 @@ SEXP createArgsListStack(Code* c, size_t nargs, CallSiteStruct* cs, SEXP env,
         SEXP arg = ostack_at(ctx, nargs - i - 1);
 
         if (!eager && (arg == R_MissingArg || arg == R_DotsSymbol)) {
-            // We have to wrap them in a promise, otherwise they are threated
-            // as extression to be evaluated, when in fact they are meant to be
+            // We have to wrap them in a promise, otherwise they are treated
+            // as expressions to be evaluated, when in fact they are meant to be
             // asts as values
             SEXP promise = mkPROMISE(arg, env);
             SET_PRVALUE(promise, arg);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -108,7 +108,6 @@ static void jit(SEXP cls, Context* ctx) {
         return;
     SEXP cmp = ctx->compiler(cls);
     SET_BODY(cls, BODY(cmp));
-    SET_FORMALS(cls, FORMALS(cmp));
     DispatchTable* dt = sexp2dispatchTable(BODY(cls));
     Function* fun = sexp2function(dt->entry[0]);
     fun->closure = cls;

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -270,8 +270,9 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
 
     f = FORMALS(op);
     a = actuals;
-    // get the first Code that is a compiled formal (or end())
-    Code* c = nextFormalPromise(begin(extractFunction(op)));
+    // get the first Code that is a compiled default value of a formal arg
+    // (or end() if no such exist)
+    Code* c = findDefaultArgument(begin(extractFunction(op)));
     while (f != R_NilValue) {
         if (CAR(f) != R_MissingArg) {
             if (CAR(a) == R_MissingArg) {
@@ -283,7 +284,7 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
             // Either just used the compiled formal or it was not needed.
             // Skip to next Code (at least the body Code is always there),
             // then find the following compiled formal
-            c = nextFormalPromise(next(c));
+            c = findDefaultArgument(next(c));
         }
         assert(CAR(f) != R_DotsSymbol || TYPEOF(CAR(a)) == DOTSXP);
         f = CDR(f);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -106,7 +106,7 @@ static void jit(SEXP cls, Context* ctx) {
     assert(TYPEOF(cls) == CLOSXP);
     if (TYPEOF(BODY(cls)) == EXTERNALSXP)
         return;
-    SEXP cmp = ctx->compiler(cls);
+    SEXP cmp = ctx->compiler(cls, NULL);
     SET_BODY(cls, BODY(cmp));
     DispatchTable* dt = sexp2dispatchTable(BODY(cls));
     Function* fun = sexp2function(dt->entry[0]);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -268,12 +268,18 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
        environment layout.  We can live with it for now since it only
        happens immediately after the environment creation.  LT */
 
+    Code* c = begin(extractFunction(op));
     f = FORMALS(op);
     a = actuals;
     while (f != R_NilValue) {
-        if (CAR(a) == R_MissingArg && CAR(f) != R_MissingArg) {
-            SETCAR(a, mkPROMISE(CAR(f), newrho));
-            SET_MISSING(a, 2);
+        if (CAR(f) != R_MissingArg) {
+            if (CAR(a) == R_MissingArg) {
+                while (!c->isFormalPromise)
+                    c = next(c);
+                SETCAR(a, createPromise(c, newrho));
+                SET_MISSING(a, 2);
+            }
+            c = next(c);
         }
         assert(CAR(f) != R_DotsSymbol || TYPEOF(CAR(a)) == DOTSXP);
         f = CDR(f);

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -347,6 +347,7 @@ static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
             Function* oldFun = fun;
             SEXP oldFunStore = funStore;
             cp_pool_add(ctx, oldFunStore);
+
             funStore = globalContext()->optimizer(funStore);
 
             oldFun->next = funStore;
@@ -535,7 +536,7 @@ SEXP doCall(Code* caller, SEXP callee, unsigned nargs, unsigned id, SEXP env,
             createArgsList(caller, call, nargs, cs, env, ctx, false);
         PROTECT(argslist);
 
-        // if body is INTSXP, it is rir serialized code, execute it directly
+        // if body is EXTERNALSXP, it is rir serialized code, execute it directly
         SEXP body = BODY(callee);
         if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidDispatchTableSEXP(body));

--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -106,7 +106,7 @@ static void jit(SEXP cls, Context* ctx) {
     assert(TYPEOF(cls) == CLOSXP);
     if (TYPEOF(BODY(cls)) == EXTERNALSXP)
         return;
-    SEXP cmp = ctx->compiler(cls, NULL);
+    SEXP cmp = ctx->compiler(cls);
     SET_BODY(cls, BODY(cmp));
     SET_FORMALS(cls, FORMALS(cmp));
     DispatchTable* dt = sexp2dispatchTable(BODY(cls));

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -14,7 +14,7 @@
 
   The idea is to call this if we want on demand compilation of closures.
  */
-typedef SEXP (*CompilerCallback)(SEXP, SEXP);
+typedef SEXP (*CompilerCallback)(SEXP);
 typedef SEXP (*OptimizerCallback)(SEXP);
 
 #ifdef __cplusplus

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -14,7 +14,7 @@
 
   The idea is to call this if we want on demand compilation of closures.
  */
-typedef SEXP (*CompilerCallback)(SEXP);
+typedef SEXP (*CompilerCallback)(SEXP, SEXP);
 typedef SEXP (*OptimizerCallback)(SEXP);
 
 #ifdef __cplusplus

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -131,9 +131,6 @@ typedef struct Code {
     unsigned magic; ///< Magic number that attempts to be PROMSXP already marked
     /// by the GC
 
-    unsigned _padding1;
-    SEXP attributes;  /// Attributes field
-
     unsigned header; /// offset to Function object
 
     // TODO comment these

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -148,6 +148,9 @@ typedef struct Code {
 
     unsigned perfCounter;
 
+    unsigned isFormalPromise : 1;  /// is this a default formal argument promise
+    unsigned free : 31;
+
     uint8_t data[]; /// the instructions
 
     /*

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -148,7 +148,8 @@ typedef struct Code {
 
     unsigned perfCounter;
 
-    unsigned isFormalPromise : 1;  /// is this a default formal argument promise
+    unsigned isDefaultArgument : 1;  /// is this a compiled default value
+                                     /// of a formal argument
     unsigned free : 31;
 
     uint8_t data[]; /// the instructions
@@ -495,9 +496,9 @@ INLINE Function* extractFunction(SEXP s) {
     return sexp2function(sexp2dispatchTable(BODY(s))->entry[0]);
 }
 
-INLINE Code* nextFormalPromise(Code* c) {
+INLINE Code* findDefaultArgument(Code* c) {
     Code* e = end(code2function(c));
-    while (c != e && !c->isFormalPromise)
+    while (c != e && !c->isDefaultArgument)
         c = next(c);
     return c;
 }

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -131,6 +131,9 @@ typedef struct Code {
     unsigned magic; ///< Magic number that attempts to be PROMSXP already marked
     /// by the GC
 
+    unsigned _padding1;
+    SEXP attributes;  /// Attributes field
+
     unsigned header; /// offset to Function object
 
     // TODO comment these

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -491,6 +491,10 @@ INLINE DispatchTable* isValidDispatchTableObject(SEXP s) {
     return t;
 }
 
+INLINE Function* extractFunction(SEXP s) {
+    return sexp2function(sexp2dispatchTable(BODY(s))->entry[0]);
+}
+
 const static uint32_t NO_DEOPT_INFO = (uint32_t)-1;
 
 #ifdef __cplusplus

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -495,6 +495,13 @@ INLINE Function* extractFunction(SEXP s) {
     return sexp2function(sexp2dispatchTable(BODY(s))->entry[0]);
 }
 
+INLINE Code* nextFormalPromise(Code* c) {
+    Code* e = end(code2function(c));
+    while (c != e && !c->isFormalPromise)
+        c = next(c);
+    return c;
+}
+
 const static uint32_t NO_DEOPT_INFO = (uint32_t)-1;
 
 #ifdef __cplusplus

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -45,6 +45,7 @@ void printCode(Code* c) {
     Rprintf("  Magic:     %x (hex)\n", c->magic);
     Rprintf("  Stack (o): %u\n", c->stackLength);
     Rprintf("  Code size: %u [b]\n", c->codeSize);
+    Rprintf("  Is formal: %s\n", c->isFormalPromise ? "true" : "false");
     if (c->magic != CODE_MAGIC)
         Rf_error("Wrong magic number -- corrupted IR bytecode");
 

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -41,11 +41,11 @@ extern void c_printCode(Code * c);
 
 void printCode(Code* c) {
     Rprintf("Code object (%p offset %x (hex))\n", c, c->header);
-    Rprintf("  Source:    %u (index to src pool)\n", c->src);
-    Rprintf("  Magic:     %x (hex)\n", c->magic);
-    Rprintf("  Stack (o): %u\n", c->stackLength);
-    Rprintf("  Code size: %u [b]\n", c->codeSize);
-    Rprintf("  Is formal: %s\n", c->isFormalPromise ? "true" : "false");
+    Rprintf("  Source:      %u (index to src pool)\n", c->src);
+    Rprintf("  Magic:       %x (hex)\n", c->magic);
+    Rprintf("  Stack (o):   %u\n", c->stackLength);
+    Rprintf("  Code size:   %u [B]\n", c->codeSize);
+    Rprintf("  Default arg? %s\n", c->isDefaultArgument ? "yes" : "no");
     if (c->magic != CODE_MAGIC)
         Rf_error("Wrong magic number -- corrupted IR bytecode");
 

--- a/rir/src/ir/CodeEditor.cpp
+++ b/rir/src/ir/CodeEditor.cpp
@@ -20,6 +20,8 @@ CodeEditor::CodeEditor(SEXP in) {
         formals_ = FORMALS(in);
         DispatchTable* dispatchTable = sexp2dispatchTable(BODY(in));
         bc = dispatchTable->entry[0];
+    } else {
+        assert(isValidFunctionObject(in));
     }
     FunctionHandle fh(bc);
     CodeHandle ch = fh.entryPoint();
@@ -242,8 +244,18 @@ void CodeEditor::print(bool verbose) {
         if (!p)
             continue;
 
+        bool isfp = false;
+        for (auto fp : formalsPromises)
+            if (i - 1 == fp) {
+                isfp = true;
+                break;
+            }
+
         Rprintf("------------------------\n");
-        Rprintf("@%d\n", (void*)(long)(i - 1));
+        if (isfp)
+            Rprintf("# formal promise\n");
+        else
+            Rprintf("@%d\n", (void*)(long)(i - 1));
         p->print();
     }
 }

--- a/rir/src/ir/CodeEditor.cpp
+++ b/rir/src/ir/CodeEditor.cpp
@@ -24,20 +24,20 @@ CodeEditor::CodeEditor(SEXP in) {
     FunctionHandle fh(bc);
     CodeHandle ch = fh.entryPoint();
     ast = ch.ast();
-    loadCode(fh, ch);
+    loadCode(fh, ch, true);
 }
 
 CodeEditor::CodeEditor(CodeHandle code, SEXP formals) {
     formals_ = formals;
     ast = code.ast();
-    loadCode(code.function(), code);
+    loadCode(code.function(), code, formals_ != nullptr);
 }
 
-void CodeEditor::loadCode(FunctionHandle function, CodeHandle code) {
+void CodeEditor::loadCode(FunctionHandle function, CodeHandle code, bool loadFormals) {
     std::unordered_map<Opcode*, LabelT> bcLabels;
 
     // Add promises that are default values of formal arguments
-    if (formals_) {
+    if (loadFormals) {
         for (auto c : function) {
             if (c->isFormalPromise) {
                 CodeHandle ch(c);
@@ -151,9 +151,8 @@ void CodeEditor::loadCode(FunctionHandle function, CodeHandle code) {
 }
 
 CodeEditor::~CodeEditor() {
-    for (auto p : promises) {
+    for (auto p : promises)
         delete p;
-    }
 
     BytecodeList* pos = front.next;
     while (pos != & last) {

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -425,7 +425,7 @@ class CodeEditor {
         }
     }
 
-    void loadCode(FunctionHandle function, CodeHandle code);
+    void loadCode(FunctionHandle function, CodeHandle code, bool loadFormals);
 
     ~CodeEditor();
 

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -355,7 +355,7 @@ class CodeEditor {
                             idx = duplicate.at(idx);
                         else
                             idx += proms;
-                        assert(editor.promises.size() >= idx &&
+                        assert(editor.promises.size() > idx &&
                                editor.promises[idx]);
                         CallSite_args(cs)[i] = idx;
                     }
@@ -366,7 +366,7 @@ class CodeEditor {
                         idx = duplicate.at(idx);
                     else
                         idx += proms;
-                    assert(editor.promises.size() >= idx &&
+                    assert(editor.promises.size() > idx &&
                            editor.promises[idx]);
                     insert->bc.immediate.fun = idx;
                 } else {

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -73,6 +73,7 @@ class CodeEditor {
     BytecodeList last;
 
     std::vector<CodeEditor*> promises;
+    std::vector<unsigned> formalsPromises;  // indices of formal argument promises
 
     SEXP ast;
 
@@ -428,7 +429,7 @@ class CodeEditor {
 
     ~CodeEditor();
 
-    unsigned write(FunctionHandle& function);
+    unsigned write(FunctionHandle& function, bool isFormal = false);
 
     FunctionHandle finalize();
 

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -408,7 +408,8 @@ class CodeEditor {
 
     Iterator end() const { return Iterator(&last); }
 
-    CodeEditor(SEXP closure);
+    explicit CodeEditor(SEXP closure);
+    explicit CodeEditor(CodeHandle code);
     CodeEditor(CodeHandle code, SEXP formals);
 
     std::map<SEXP, SEXP> arguments() const {

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -73,7 +73,8 @@ class CodeEditor {
     BytecodeList last;
 
     std::vector<CodeEditor*> promises;
-    std::vector<unsigned> formalsPromises;  // indices of formal argument promises
+    std::vector<unsigned> defaultArguments;  // indices of promises that are compiled
+                                             // default arguments
 
     SEXP ast;
 
@@ -426,11 +427,11 @@ class CodeEditor {
         }
     }
 
-    void loadCode(FunctionHandle function, CodeHandle code, bool loadFormals);
+    void loadCode(FunctionHandle function, CodeHandle code, bool loadCompiledDefaultArgs);
 
     ~CodeEditor();
 
-    unsigned write(FunctionHandle& function, bool isFormal = false);
+    unsigned write(FunctionHandle& function, bool isDefaultArgument = false);
 
     FunctionHandle finalize();
 

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -259,10 +259,10 @@ class CodeStream {
         sources.insert(sources.begin() + sourceIdx + 1, size - 1, 0);
     }
 
-    FunIdxT finalize(bool markFormal) {
+    FunIdxT finalize(bool markDefaultArg) {
         CodeHandle res =
             function.writeCode(ast, &(*code)[0], pos, callSites_.data(),
-                               callSites_.size(), sources, markFormal);
+                               callSites_.size(), sources, markDefaultArg);
 
         for (auto p : patchpoints) {
             unsigned pos = p.first;

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -259,10 +259,10 @@ class CodeStream {
         sources.insert(sources.begin() + sourceIdx + 1, size - 1, 0);
     }
 
-    FunIdxT finalize() {
+    FunIdxT finalize(bool markFormal) {
         CodeHandle res =
             function.writeCode(ast, &(*code)[0], pos, callSites_.data(),
-                               callSites_.size(), sources);
+                               callSites_.size(), sources, markFormal);
 
         for (auto p : patchpoints) {
             unsigned pos = p.first;

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -190,7 +190,7 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
                 unsigned deoptId = *reinterpret_cast<ArgT*>(cptr + 1);
                 Opcode* deoptPc = (Opcode*)Deoptimizer_pc(deoptId);
                 assert(f->origin);
-                FunctionHandle deoptFun = f->origin;
+                FunctionHandle deoptFun(f->origin);
                 CodeHandle deoptCode = deoptFun.entryPoint();
                 assert(deoptPc >= deoptCode.bc() &&
                        deoptPc < deoptCode.endBc());

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1164,7 +1164,7 @@ void compileExpr(Context& ctx, SEXP exp) {
             assert(false);
         }
         Case(EXTERNALSXP) {
-            assert(false);  // how to deal with this? (examples for base, through duplicate1 call
+            assert(false);
         }
         // TODO : some code (eg. serialize.c:2154) puts closures into asts...
         //        not sure how we want to handle it...
@@ -1201,7 +1201,7 @@ FunIdxT compilePromise(Context& ctx, SEXP exp, bool isFormal) {
 
 }  // anonymous namespace
 
-Compiler::CompilerRes Compiler::finalize() {
+SEXP Compiler::finalize() {
     // Rprintf("****************************************************\n");
     // Rprintf("Compiling function\n");
 
@@ -1211,7 +1211,6 @@ Compiler::CompilerRes Compiler::finalize() {
     auto formProm = compileFormals(ctx, formals);
 
     ctx.push(exp);
-
     compileExpr(ctx, exp);
     ctx.cs() << BC::ret();
     ctx.pop();

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1201,6 +1201,9 @@ FunIdxT compilePromise(Context& ctx, SEXP exp, bool isFormal) {
 Compiler::CompilerRes Compiler::finalize() {
     // Rprintf("****************************************************\n");
     // Rprintf("Compiling function\n");
+
+    Protect p;
+
     FunctionHandle function = FunctionHandle::create();
     Context ctx(function, preserve, env);
 
@@ -1221,11 +1224,11 @@ Compiler::CompilerRes Compiler::finalize() {
     Optimizer::optimize(code);
 
     FunctionHandle opt = code.finalize();
+    p(opt.store);
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(opt.store, globalContext());
 #endif
 
-    Protect p;
     SEXP formout = R_NilValue;
     SEXP f = formout;
     SEXP formin = formals;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -118,8 +118,8 @@ class Context {
 
     void pushPromiseContext(SEXP ast) { code.push(new PromiseContext(ast, fun, code.empty() ? nullptr : code.top())); }
 
-    FunIdxT pop(bool isFormal = false) {
-        auto idx = cs().finalize(isFormal);
+    FunIdxT pop(bool isDefaultArg = false) {
+        auto idx = cs().finalize(isDefaultArg);
         delete code.top();
         code.pop();
         return idx;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1163,6 +1163,9 @@ void compileExpr(Context& ctx, SEXP exp) {
         Case(BCODESXP) {
             assert(false);
         }
+        Case(EXTERNALSXP) {
+            assert(false);  // how to deal with this? (examples for base, through duplicate1 call
+        }
         // TODO : some code (eg. serialize.c:2154) puts closures into asts...
         //        not sure how we want to handle it...
         // Case(CLOSXP) {

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -82,7 +82,7 @@ class Context {
     FunctionHandle& fun;
     Preserve& preserve;
 
-    Context(FunctionHandle& fun, Preserve& preserve, SEXP env)
+    Context(FunctionHandle& fun, Preserve& preserve)
         : fun(fun), preserve(preserve) {}
 
     ~Context() { assert(code.empty()); }
@@ -1205,7 +1205,7 @@ Compiler::CompilerRes Compiler::finalize() {
     Protect p;
 
     FunctionHandle function = FunctionHandle::create();
-    Context ctx(function, preserve, env);
+    Context ctx(function, preserve);
 
     auto formProm = compileFormals(ctx, formals);
 

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1231,7 +1231,7 @@ Compiler::CompilerRes Compiler::finalize() {
     // have changed the lengths of some code objects
     Code* c = begin(opt.function);
     for (unsigned int i = 0; i < formProm.size(); ++i) {
-         if (formProm[i] == MISSING_ARG_IDX)
+        if (formProm[i] == MISSING_ARG_IDX)
             continue;
         while (!c->isFormalPromise)
             c = next(c);

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -77,6 +77,9 @@ class Compiler {
         Compiler c(ast, formals, env);
         auto res = c.finalize();
 
+        // Set formals (do it right away to prevent gc?)
+        SET_FORMALS(closure, res.formals);
+
         // Set the compiled function's closure pointer.
         Function* func = sexp2function(res.bc);
         func->closure = closure;
@@ -93,10 +96,9 @@ class Compiler {
         vtable->length = 1;
         vtable->entry[0] = res.bc;
 
-        // Set the closure fields.
+        // Set the closure body
         // NOTE: The closure environment is set by the caller.
         SET_BODY(closure, vtableStore);
-        SET_FORMALS(closure, formals);
 
         UNPROTECT(2);
         return closure;

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -21,7 +21,6 @@ namespace rir {
 class Compiler {
     SEXP exp;
     SEXP formals;
-    SEXP env;
     Preserve preserve;
 
   public:
@@ -30,22 +29,18 @@ class Compiler {
         SEXP formals;
     };
 
-    Compiler(SEXP exp, SEXP env) : exp(exp), formals(R_NilValue), env(env) {
+    Compiler(SEXP exp) : exp(exp), formals(R_NilValue) {
         preserve(exp);
-        if (env != R_NilValue)
-            preserve(env);
     }
 
-    Compiler(SEXP exp, SEXP formals, SEXP env) : exp(exp), formals(formals), env(env) {
+    Compiler(SEXP exp, SEXP formals) : exp(exp), formals(formals) {
         preserve(exp);
         preserve(formals);
-        if (env != R_NilValue)
-            preserve(env);
     }
 
     CompilerRes finalize();
 
-    static CompilerRes compileExpression(SEXP ast, SEXP env = R_NilValue) {
+    static CompilerRes compileExpression(SEXP ast) {
 #if 0
         size_t count = 1;
         static std::unordered_map<SEXP, size_t> counts;
@@ -67,16 +62,16 @@ class Compiler {
 #endif
 
         // Rf_PrintValue(ast);
-        Compiler c(ast, env);
+        Compiler c(ast);
         return c.finalize();
     }
 
-    static SEXP compileClosure(SEXP ast, SEXP formals, SEXP env = R_NilValue) {
+    static SEXP compileClosure(SEXP ast, SEXP formals) {
         Protect p;
         SEXP closure = allocSExp(CLOSXP);
         p(closure);
 
-        Compiler c(ast, formals, env);
+        Compiler c(ast, formals);
         auto res = c.finalize();
         p(res.bc);
         p(res.formals);

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -68,8 +68,7 @@ class Compiler {
 
     static SEXP compileClosure(SEXP ast, SEXP formals) {
         Protect p;
-        SEXP closure = allocSExp(CLOSXP);
-        p(closure);
+        SEXP closure = p(allocSExp(CLOSXP));
 
         Compiler c(ast, formals);
         auto res = c.finalize();
@@ -82,8 +81,7 @@ class Compiler {
 
         // Allocate a new vtable.
         size_t vtableSize = sizeof(DispatchTable) + sizeof(DispatchTableEntry);
-        SEXP vtableStore = Rf_allocVector(EXTERNALSXP, vtableSize);
-        p(vtableStore);
+        SEXP vtableStore = p(Rf_allocVector(EXTERNALSXP, vtableSize));
         DispatchTable* vtable = sexp2dispatchTable(vtableStore);
 
         // Initialize the vtable. Initially the table has one entry, which is

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -38,9 +38,7 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
     Function* fun = sexp2function(s);
     bool safe = !fun->envLeaked && !fun->envChanged;
 
-    FunctionHandle fh(s);
-    CodeHandle ch = fh.entryPoint();
-    CodeEditor code(ch, FORMALS(fun->closure));
+    CodeEditor code(s);
 
     for (int i = 0; i < 16; ++i) {
         bool changedInl = Optimizer::inliner(code, safe);
@@ -51,6 +49,7 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
 
     FunctionHandle opt = code.finalize();
     opt.function->origin = s;
+
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(opt.store, globalContext());
 #endif

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -38,7 +38,9 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
     Function* fun = sexp2function(s);
     bool safe = !fun->envLeaked && !fun->envChanged;
 
-    CodeEditor code(s);
+    FunctionHandle fh(s);
+    CodeHandle ch = fh.entryPoint();
+    CodeEditor code(ch, FORMALS(fun->closure));
 
     for (int i = 0; i < 16; ++i) {
         bool changedInl = Optimizer::inliner(code, safe);

--- a/rir/src/optimization/stupid_inline.h
+++ b/rir/src/optimization/stupid_inline.h
@@ -143,7 +143,7 @@ class StupidInliner {
                 if (idx < cs.nargs()) {
                     arg = code_.detachPromise(cs.args()[idx]);
                 } else {
-                    arg = new CodeEditor(Compiler::compileExpression(*f).bc);
+                    arg = new CodeEditor(Compiler::compileExpression(*f));
                 }
                 args[f.tag()] = arg;
                 ++idx;

--- a/rir/src/utils/CodeHandle.cpp
+++ b/rir/src/utils/CodeHandle.cpp
@@ -34,7 +34,7 @@ void CodeHandle::print() {
 }
 
 FunctionHandle CodeHandle::function() {
-    return ::function2store(::code2function(code));
+    return FunctionHandle(::function2store(::code2function(code)));
 }
 
 FunIdxT CodeHandle::idx() {

--- a/rir/src/utils/CodeHandle.h
+++ b/rir/src/utils/CodeHandle.h
@@ -21,6 +21,8 @@ class CodeHandle {
         code = new (insert) Code;
 
         code->magic = CODE_MAGIC;
+        code->_padding1 = 0xabababab;
+        code->attributes = R_NilValue;
         code->header = offset;
         code->src = src_pool_add(globalContext(), ast);
         code->codeSize = codeSize;

--- a/rir/src/utils/CodeHandle.h
+++ b/rir/src/utils/CodeHandle.h
@@ -17,7 +17,7 @@ class CodeHandle {
     Code* code;
 
     CodeHandle(SEXP ast, unsigned codeSize, unsigned sourceSize,
-               unsigned callSiteLength, unsigned offset, void* insert, bool isFormal) {
+               unsigned callSiteLength, unsigned offset, void* insert, bool isDefaultArg) {
         code = new (insert) Code;
 
         code->magic = CODE_MAGIC;
@@ -28,7 +28,7 @@ class CodeHandle {
         code->skiplistLength = skiplistLength(sourceSize);
         code->callSiteLength = callSiteLength;
         code->perfCounter = 0;
-        code->isFormalPromise = isFormal;
+        code->isDefaultArgument = isDefaultArg;
     }
 
     CodeHandle(Code* code) : code(code) { assert(code->magic == CODE_MAGIC); }

--- a/rir/src/utils/CodeHandle.h
+++ b/rir/src/utils/CodeHandle.h
@@ -17,7 +17,7 @@ class CodeHandle {
     Code* code;
 
     CodeHandle(SEXP ast, unsigned codeSize, unsigned sourceSize,
-               unsigned callSiteLength, unsigned offset, void* insert) {
+               unsigned callSiteLength, unsigned offset, void* insert, bool isFormal) {
         code = new (insert) Code;
 
         code->magic = CODE_MAGIC;
@@ -28,6 +28,7 @@ class CodeHandle {
         code->skiplistLength = skiplistLength(sourceSize);
         code->callSiteLength = callSiteLength;
         code->perfCounter = 0;
+        code->isFormalPromise = isFormal;
     }
 
     CodeHandle(Code* code) : code(code) { assert(code->magic == CODE_MAGIC); }

--- a/rir/src/utils/CodeHandle.h
+++ b/rir/src/utils/CodeHandle.h
@@ -21,8 +21,6 @@ class CodeHandle {
         code = new (insert) Code;
 
         code->magic = CODE_MAGIC;
-        code->_padding1 = 0xabababab;
-        code->attributes = R_NilValue;
         code->header = offset;
         code->src = src_pool_add(globalContext(), ast);
         code->codeSize = codeSize;

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -71,7 +71,7 @@ class FunctionHandle {
 
     CodeHandle writeCode(SEXP ast, void* bc, unsigned codeSize,
                          char* callSiteBuffer, unsigned callSiteLength,
-                         std::vector<unsigned>& sources, bool markFormal) {
+                         std::vector<unsigned>& sources, bool markDefaultArg) {
         assert(function->size <= capacity);
 
         unsigned totalSize =
@@ -110,7 +110,7 @@ class FunctionHandle {
         assert(function->size <= capacity);
 
         CodeHandle code(ast, codeSize, sources.size(), callSiteLength, offset,
-                        insert, markFormal);
+                        insert, markDefaultArg);
 
         assert(::code2function(code.code) == function);
 

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -64,7 +64,7 @@ class FunctionHandle {
 
     CodeHandle writeCode(SEXP ast, void* bc, unsigned codeSize,
                          char* callSiteBuffer, unsigned callSiteLength,
-                         std::vector<unsigned>& sources) {
+                         std::vector<unsigned>& sources, bool markFormal) {
         assert(function->size <= capacity);
 
         unsigned totalSize =
@@ -103,7 +103,7 @@ class FunctionHandle {
         assert(function->size <= capacity);
 
         CodeHandle code(ast, codeSize, sources.size(), callSiteLength, offset,
-                        insert);
+                        insert, markFormal);
 
         assert(::code2function(code.code) == function);
 


### PR DESCRIPTION
Default values for formal arguments are now also compiled.

They are written into the `Function` object as separate `Code` objects with a flag `isFormalPromise` set to true.

`CodeEditor` now takes care to keep these `Code`s in the function.

The interpreter uses these after it matches all actual arguments to a call and tries to see if any of the missing ones have a default value. If so, it wraps the `Code` to a promise and puts it into the arglist.

The compiler now does not change the formals of a closure, it only compiles them.