### PR TITLE
assert that variable lookup does not return a promise

### DIFF
--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -98,7 +98,9 @@ INLINE SEXP promiseValue(SEXP promise, Context * ctx) {
         SET_NAMED(promise, 2);
         return promise;
     } else {
-        return forcePromise(promise);
+        SEXP res = forcePromise(promise);
+        assert(TYPEOF(res) != PROMSXP && "promise returned promise");
+        return res;
     }
 }
 


### PR DESCRIPTION
I just want to make sure that what we get back from a variable lookup
can not be just another promise.