### PR TITLE
Expose SEXPs in RIR objects to R's GC.

### DIFF
--- a/rir/src/interpreter/interp.c
+++ b/rir/src/interpreter/interp.c
@@ -361,58 +361,76 @@ static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
             SEXP oldFunStore = funStore;
             cp_pool_add(ctx, oldFunStore);
 
-            PROTECT(funStore = globalContext()->optimizer(funStore));
+            funStore = globalContext()->optimizer(funStore);
 
-            oldFun->next = funStore;
-            fun = sexp2function(funStore);
-            fun->origin = oldFunStore;
+            // only if the optimizer actually changed something
+            if (funStore != oldFunStore) {
+                PROTECT(funStore);
 
-            // Add the new function to the vtable.
-            if (vtable->info.gc_area_length < vtable->capacity) {
-                vtable->entry[vtable->info.gc_area_length++] = funStore;
-            } else {
-                // Allocate a new, larger vtable.
-                DispatchTable* oldVtable = vtable;
+                oldFun->next = funStore;
+                fun = sexp2function(funStore);
 
-                size_t capacity = oldVtable->capacity * 2;
-                size_t size = sizeof(DispatchTable) +
-                              (capacity * sizeof(DispatchTableEntry));
-                vtableStore = PROTECT(Rf_allocVector(EXTERNALSXP, size));
-                vtable = sexp2dispatchTable(vtableStore);
+                // Update the vtable.
+                EXTERNALSXP_SET_ENTRY(vtableStore, 0, funStore);
 
-                // Initialize the new vtable, copying old entries over.
-                vtable->info.gc_area_start = sizeof(DispatchTable);  // at the end
-                vtable->info.gc_area_length = oldVtable->info.gc_area_length + 1;
-                vtable->magic = DISPATCH_TABLE_MAGIC;
-                vtable->capacity = capacity;
+#if 0
+// for now, the optimizer just produces a new version with the same signature
+// so there is no need to reallocate the vtable
+// TODO: take care of correctly updating the vtable and the closure
+                // Add the new function to the vtable.
+                if (vtable->info.gc_area_length < vtable->capacity) {
+                    vtable->entry[vtable->info.gc_area_length++] = funStore;
+                } else {
+                    // Allocate a new, larger vtable.
+                    DispatchTable* oldVtable = vtable;
 
-                for (size_t i = 0; i < oldVtable->info.gc_area_length; i++) {
-                    vtable->entry[i] = oldVtable->entry[i];
+                    size_t capacity = oldVtable->capacity * 2;
+                    size_t size = sizeof(DispatchTable) +
+                                  (capacity * sizeof(DispatchTableEntry));
+                    vtableStore = PROTECT(Rf_allocVector(EXTERNALSXP, size));
+                    vtable = sexp2dispatchTable(vtableStore);
+
+                    // Initialize the new vtable, copying old entries over.
+                    vtable->info.gc_area_start = sizeof(DispatchTable);  // at the end
+                    vtable->info.gc_area_length = oldVtable->info.gc_area_length + 1;
+                    vtable->magic = DISPATCH_TABLE_MAGIC;
+                    vtable->capacity = capacity;
+
+                    for (size_t i = 0; i < oldVtable->info.gc_area_length; i++) {
+                        vtable->entry[i] = oldVtable->entry[i];
+                        // oldVtable->entry[i] = NULL;
+                        // TODO: is this only referenced from this closure body? if not
+                        // we cannot null it out,
+                        // also, maybe just leave it be (we mark what we want to keep)
+                    }
+
+                    // Insert the new function version.
+                    vtable->entry[oldVtable->info.gc_area_length] = funStore;
+
+                    // NULL out the remaining entries.
+                    for (size_t i = vtable->info.gc_area_length; i < capacity; i++) {
+                        vtable->entry[i] = NULL;
+                    }
+
+                    // Update the closure with the new vtable.
+                    SET_BODY(callee, vtableStore);
+
+                    UNPROTECT(1);  // vtableStore
                 }
+#endif
 
-                // Insert the new function version.
-                vtable->entry[oldVtable->info.gc_area_length] = funStore;
+                fun->invocationCount = oldFun->invocationCount;
+                fun->envLeaked = oldFun->envLeaked;
+                fun->envChanged = oldFun->envChanged;
+                fun->closure = callee;
 
-                // NULL out the remaining entries.
-                for (size_t i = vtable->info.gc_area_length; i < capacity; i++) {
-                    vtable->entry[i] = NULL;
-                }
-
-                // Update the closure with the new vtable.
-                SET_BODY(callee, vtableStore);
-
-                UNPROTECT(1);
+                UNPROTECT(1);  // funStore
             }
 
-            fun->invocationCount = oldFun->invocationCount + 1;
-            fun->envLeaked = oldFun->envLeaked;
-            fun->envChanged = oldFun->envChanged;
-            fun->closure = callee;
-
-            UNPROTECT(1);
 
             optimizing = false;
-        } else if (fun->invocationCount < UINT_MAX)
+        }
+        if (fun->invocationCount < UINT_MAX)
             fun->invocationCount++;
     }
 
@@ -556,9 +574,10 @@ SEXP doCall(Code* caller, SEXP callee, unsigned nargs, unsigned id, SEXP env,
         SEXP body = BODY(callee);
         if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidDispatchTableSEXP(body));
+            assert(isValidFunctionSEXP(sexp2dispatchTable(body)->entry[0]));
             result =
                 rirCallClosure(call, env, callee, argslist, nargs, ctx);
-            UNPROTECT(1);
+            UNPROTECT(1); // argslist
             break;
         }
 
@@ -692,7 +711,7 @@ SEXP doCallStack(Code* caller, SEXP callee, size_t nargs, unsigned id, SEXP env,
         PROTECT(argslist);
         ostack_popn(ctx, nargs);
 
-        // if body is INTSXP, it is rir serialized code, execute it directly
+        // if body is EXTERNALSXP, it is rir serialized code, execute it directly
         SEXP body = BODY(callee);
         if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidDispatchTableSEXP(body));
@@ -810,7 +829,7 @@ SEXP doDispatchStack(Code* caller, size_t nargs, uint32_t id, SEXP env,
             break;
         }
         case CLOSXP: {
-            // if body is INTSXP, it is rir serialized code, execute it directly
+            // if body is EXTERNALSXP, it is rir serialized code, execute it directly
             SEXP body = BODY(callee);
             if (TYPEOF(body) == EXTERNALSXP) {
                 assert(isValidDispatchTableSEXP(body));
@@ -923,7 +942,7 @@ SEXP doDispatch(Code* caller, uint32_t nargs, uint32_t id, SEXP env,
             break;
         }
         case CLOSXP: {
-            // if body is INTSXP, it is rir serialized code, execute it directly
+            // if body is EXTERNALSXP, it is rir serialized code, execute it directly
             SEXP body = BODY(callee);
             if (TYPEOF(body) == EXTERNALSXP) {
                 assert(isValidDispatchTableSEXP(body));

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -89,7 +89,6 @@ typedef enum {
  */
 typedef SEXP FunctionSEXP;
 typedef SEXP SignatureSEXP;
-typedef SEXP ClosureSEXP;
 typedef SEXP PromiseSEXP;
 typedef SEXP DispatchTableEntry;
 
@@ -397,20 +396,24 @@ INLINE Code* next(Code* c) {
  *  A Function has a number of Code objects, codeLen, stored
  *  inline in data.
  */
+
+// TODO: some better mechanism... for now, keep these synced with the order
+// of the SEXPs in Function
+#define FUNCTION_SIGNATURE_OFFSET 0
+#define FUNCTION_ORIGIN_OFFSET 1
+#define FUNCTION_NEXT_OFFSET 2
+
 #pragma pack(push)
 #pragma pack(1)
 typedef struct Function {
     rir_header info;  /// for exposing SEXPs to GC
 
+    SignatureSEXP signature; /// pointer to this version's signature
+
     FunctionSEXP origin; /// Same Function with fewer optimizations,
                          //   NULL if original
 
     FunctionSEXP next;
-
-    ClosureSEXP closure; /// pointer to Closure
-                         //    which has a pointer to DispatchTable
-
-    SignatureSEXP signature;  /// pointer to this version's signature
 
     unsigned magic; /// used to detect Functions 0xCAFEBABE
 

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -64,7 +64,6 @@ void printFunction(Function* f) {
     Rprintf("Function object (%p):\n", f);
     Rprintf("  Magic:           %x (hex)\n", f->magic);
     Rprintf("  Size:            %u\n", f->size);
-    Rprintf("  Closure:         %p\n", f->closure);
     Rprintf("  Origin:          %p %s\n", f->origin, f->origin ? "" : "(unoptimized)");
     Rprintf("  Next:            %p\n", f->next);
     Rprintf("  Signature:       %p\n", f->signature);

--- a/rir/src/interpreter/runtime.c
+++ b/rir/src/interpreter/runtime.c
@@ -61,10 +61,13 @@ void printCode(Code* c) {
 }
 
 void printFunction(Function* f) {
-    Rprintf("Function object:\n");
+    Rprintf("Function object (%p):\n", f);
     Rprintf("  Magic:           %x (hex)\n", f->magic);
     Rprintf("  Size:            %u\n", f->size);
-    Rprintf("  Origin:          %s\n", f->origin ? "optimized" : "unoptimized");
+    Rprintf("  Closure:         %p\n", f->closure);
+    Rprintf("  Origin:          %p %s\n", f->origin, f->origin ? "" : "(unoptimized)");
+    Rprintf("  Next:            %p\n", f->next);
+    Rprintf("  Signature:       %p\n", f->signature);
     Rprintf("  Code objects:    %u\n", f->codeLength);
     Rprintf("  Fun code offset: %x (hex)\n", f->foffset);
     Rprintf("  Invoked:         %u\n", f->invocationCount);
@@ -75,6 +78,8 @@ void printFunction(Function* f) {
     // print respective code objects
     for (Code *c = begin(f), *e = end(f); c != e; c = next(c))
         printCode(c);
+
+    Rprintf("\n");
 }
 
 // TODO change gnu-r to expect ptr and not bool and we can get rid of the wrapper

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -69,13 +69,9 @@ class Compiler {
         Compiler c(ast, formals);
         SEXP res = p(c.finalize());
 
-        // Set the compiled function's closure pointer.
-        Function* func = sexp2function(res);
-        func->closure = closure;
-
         // Allocate a new vtable.
         size_t vtableSize = sizeof(DispatchTable) + sizeof(DispatchTableEntry);
-        SEXP vtableStore = Rf_allocVector(EXTERNALSXP, vtableSize);
+        SEXP vtableStore = p(Rf_allocVector(EXTERNALSXP, vtableSize));
         DispatchTable* vtable = sexp2dispatchTable(vtableStore);
 
         // Initialize the vtable. Initially the table has one entry, which is
@@ -84,7 +80,7 @@ class Compiler {
         vtable->info.gc_area_length = 1;
         vtable->magic = DISPATCH_TABLE_MAGIC;
         vtable->capacity = 1;
-        vtable->entry[0] = res;
+        EXTERNALSXP_SET_ENTRY(vtableStore, 0, res);
 
         // Set the closure fields.
         // NOTE: The closure environment is set by the caller.

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -75,7 +75,7 @@ class Compiler {
 
         // Allocate a new vtable.
         size_t vtableSize = sizeof(DispatchTable) + sizeof(DispatchTableEntry);
-        SEXP vtableStore = p(Rf_allocVector(EXTERNALSXP, vtableSize));
+        SEXP vtableStore = Rf_allocVector(EXTERNALSXP, vtableSize);
         DispatchTable* vtable = sexp2dispatchTable(vtableStore);
 
         // Initialize the vtable. Initially the table has one entry, which is

--- a/rir/src/ir/Compiler.h
+++ b/rir/src/ir/Compiler.h
@@ -80,9 +80,10 @@ class Compiler {
 
         // Initialize the vtable. Initially the table has one entry, which is
         // the compiled function.
-        SET_TRUELENGTH(vtableStore, 1);
+        vtable->info.gc_area_start = sizeof(DispatchTable);  // at the end
+        vtable->info.gc_area_length = 1;
         vtable->magic = DISPATCH_TABLE_MAGIC;
-        vtable->length = 1;
+        vtable->capacity = 1;
         vtable->entry[0] = res;
 
         // Set the closure fields.

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -42,9 +42,13 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
 
     for (int i = 0; i < 16; ++i) {
         bool changedInl = Optimizer::inliner(code, safe);
-        bool changedOpt = Optimizer::optimize(code, 2);
-        if (!changedInl && !changedOpt)
-            break;
+        bool changedOpt = Optimizer::optimize(code, 8);
+        if (!changedInl && !changedOpt) {
+            if (i == 0)
+                return s;
+            else
+                break;
+        }
     }
 
     FunctionHandle opt = code.finalize();
@@ -53,7 +57,6 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(opt.store, globalContext());
 #endif
-    SEXP res = opt.store;
-    return res;
+    return opt.store;
 }
 }

--- a/rir/src/ir/Optimizer.cpp
+++ b/rir/src/ir/Optimizer.cpp
@@ -35,7 +35,8 @@ bool Optimizer::inliner(CodeEditor& code, bool stable) {
 }
 
 SEXP Optimizer::reoptimizeFunction(SEXP s) {
-    Function* fun = sexp2function(s);
+    Function* fun = isValidFunctionObject(s);
+    assert(fun);
     bool safe = !fun->envLeaked && !fun->envChanged;
 
     CodeEditor code(s);
@@ -52,7 +53,7 @@ SEXP Optimizer::reoptimizeFunction(SEXP s) {
     }
 
     FunctionHandle opt = code.finalize();
-    opt.function->origin = s;
+    EXTERNALSXP_SET_ENTRY(opt.store, FUNCTION_ORIGIN_OFFSET, s);
 
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(opt.store, globalContext());

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -75,6 +75,7 @@ class FunctionHandle {
                          char* callSiteBuffer, unsigned callSiteLength,
                          std::vector<unsigned>& sources, bool markDefaultArg) {
         assert(function->size <= capacity);
+        assert(storeOwner_);
 
         unsigned totalSize =
             CodeHandle::totalSize(codeSize, sources.size(), callSiteLength);
@@ -95,14 +96,8 @@ class FunctionHandle {
 
             assert(function == payload);
 
-            // clear the fields that GC traces and release the old store
-            function->origin = nullptr;
-            function->next = nullptr;
-            function->closure = nullptr;
-            function->signature = nullptr;
-            R_ReleaseObject(store);
-
             R_PreserveObject(newStore);
+            R_ReleaseObject(store);
 
             store = newStore;
             payload = newPayload;

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -36,11 +36,10 @@ class FunctionHandle {
         assert(function == payload);
 
         function->info.gc_area_start = sizeof(rir_header);  // just after the header
-        function->info.gc_area_length = 4;  // origin, next, closure, signature
+        function->info.gc_area_length = 3; // signature, origin, next
+        function->signature = nullptr;
         function->origin = nullptr;
         function->next = nullptr;
-        function->closure = nullptr;
-        function->signature = nullptr;
         function->magic = FUNCTION_MAGIC;
         function->envLeaked = false;
         function->envChanged = false;
@@ -93,6 +92,15 @@ class FunctionHandle {
             void* newPayload = INTEGER(newStore);
 
             memcpy(newPayload, payload, capacity);
+            EXTERNALSXP_SET_ENTRY(
+                newStore, FUNCTION_SIGNATURE_OFFSET,
+                EXTERNALSXP_ENTRY(store, FUNCTION_SIGNATURE_OFFSET));
+            EXTERNALSXP_SET_ENTRY(
+                newStore, FUNCTION_ORIGIN_OFFSET,
+                EXTERNALSXP_ENTRY(store, FUNCTION_ORIGIN_OFFSET));
+            EXTERNALSXP_SET_ENTRY(
+                newStore, FUNCTION_NEXT_OFFSET,
+                EXTERNALSXP_ENTRY(store, FUNCTION_NEXT_OFFSET));
 
             assert(function == payload);
 

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -89,14 +89,19 @@ class FunctionHandle {
             SEXP newStore = Rf_allocVector(EXTERNALSXP, newCapacity);
             void* newPayload = INTEGER(newStore);
 
-            TYPEOF(newStore) = EXTERNALSXP;
-
             memcpy(newPayload, payload, capacity);
 
-            R_PreserveObject(newStore);
+            assert(function == payload);
+
+            // clear the fields that GC traces and release the old store
+            function->origin = nullptr;
+            function->next = nullptr;
+            function->closure = nullptr;
+            function->signature = nullptr;
             R_ReleaseObject(store);
 
-            assert(function == payload);
+            R_PreserveObject(newStore);
+
             store = newStore;
             payload = newPayload;
             function = (Function*)payload;

--- a/rir/src/utils/FunctionHandle.h
+++ b/rir/src/utils/FunctionHandle.h
@@ -32,7 +32,9 @@ class FunctionHandle {
         SEXP store = Rf_allocVector(EXTERNALSXP, initialSize);
         void* payload = INTEGER(store);
 
-        Function* function = (Function*)payload;
+        Function* function = new (payload) Function;
+        assert(function == payload);
+
         function->info.gc_area_start = sizeof(rir_header);  // just after the header
         function->info.gc_area_length = 4;  // origin, next, closure, signature
         function->origin = nullptr;


### PR DESCRIPTION
This patch adds a header to all RIR objects that contains information for the GC about pointers that we want to trace.

Every RIR object (with the exception of Code, since it is not a valid SEXP), now has to have rir_header as its first field and fill it with
1) offset in bytes to the first SEXP to trace
2) number of SEXPs to trace

Then it should make sure that all traced SEXPs are in one continuous block of memory.

For now, this applies to DispatchTable and Function, and to function Signature as soon as we have it.

Also, gnur needs to be patched as well, but I forgot how that was done. For now, I have 
[the patch](https://github.com/reactorlabs/rir/files/1427417/gnur.zip)... the build will fail until we update
