### PR TITLE
slightly change how we compile for loops

### DIFF
--- a/rir/src/analysis/dataflow.h
+++ b/rir/src/analysis/dataflow.h
@@ -692,7 +692,7 @@ class DataflowAnalysis
         case Opcode::close_:
         case Opcode::lgl_or_:
         case Opcode::lgl_and_:
-        case Opcode::test_bounds_:
+        case Opcode::for_seq_size_:
         case Opcode::seq_:
         case Opcode::names_:
         case Opcode::length_:

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -82,7 +82,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::asbool_:
     case Opcode::dup_:
     case Opcode::dup2_:
-    case Opcode::test_bounds_:
+    case Opcode::for_seq_size_:
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::make_unique_:
@@ -197,7 +197,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::asbool_:
     case Opcode::dup_:
     case Opcode::dup2_:
-    case Opcode::test_bounds_:
+    case Opcode::for_seq_size_:
     case Opcode::swap_:
     case Opcode::int3_:
     case Opcode::make_unique_:
@@ -403,7 +403,7 @@ void BC::print(CallSite* cs) {
     case Opcode::dup_:
     case Opcode::inc_:
     case Opcode::dup2_:
-    case Opcode::test_bounds_:
+    case Opcode::for_seq_size_:
     case Opcode::asast_:
     case Opcode::asbool_:
     case Opcode::add_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -189,7 +189,7 @@ BC BC::dup() { return BC(Opcode::dup_); }
 BC BC::inc() { return BC(Opcode::inc_); }
 BC BC::close() { return BC(Opcode::close_); }
 BC BC::dup2() { return BC(Opcode::dup2_); }
-BC BC::testBounds() { return BC(Opcode::test_bounds_); }
+BC BC::forSeqSize() { return BC(Opcode::for_seq_size_); }
 BC BC::add() { return BC(Opcode::add_); }
 BC BC::mul() { return BC(Opcode::mul_); }
 BC BC::div() { return BC(Opcode::div_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -253,7 +253,7 @@ class BC {
     inline static BC label(JmpT);
     inline static BC dup();
     inline static BC dup2();
-    inline static BC testBounds();
+    inline static BC forSeqSize();
     inline static BC inc();
     inline static BC close();
     inline static BC add();
@@ -423,7 +423,7 @@ class BC {
             immediate.i = *(uint32_t*)pc;
             break;
         case Opcode::nop_:
-        case Opcode::test_bounds_:
+        case Opcode::for_seq_size_:
         case Opcode::extract1_:
         case Opcode::subset1_:
         case Opcode::extract2_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -837,8 +837,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         ctx.pushLoop(loopBranch, breakBranch);
 
         compileExpr(ctx, seq);
-        cs << BC::setShared()
-           << BC::push((int)0);
+        cs << BC::setShared() << BC::forSeqSize() << BC::push((int)0);
 
         std::vector<unsigned> pcs;
 
@@ -848,17 +847,14 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
         // Move context out of the way
         pcs.push_back(cs.currentPos());
-        cs << BC::put(2);
+        cs << BC::put(3);
 
-        cs << BC::inc()
-           << BC::testBounds()
-           << BC::brfalse(endForBranch)
-           << BC::dup2()
-           << BC::extract1();
+        cs << BC::inc() << BC::dup2() << BC::lt() << BC::brtrue(endForBranch)
+           << BC::pull(2) << BC::pull(1) << BC::extract1();
 
         // Put context back
         pcs.push_back(cs.currentPos());
-        cs << BC::pick(3);
+        cs << BC::pick(4);
         pcs.push_back(cs.currentPos());
         cs << BC::swap();
 
@@ -872,7 +868,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         cs << endForBranch;
         // Put context back
         pcs.push_back(cs.currentPos());
-        cs << BC::pick(2);
+        cs << BC::pick(3);
 
         cs << breakBranch;
 
@@ -883,9 +879,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                 cs.remove(pc);
         }
 
-        cs << BC::pop()
-           << BC::pop()
-           << BC::push(R_NilValue)
+        cs << BC::pop() << BC::pop() << BC::pop() << BC::push(R_NilValue)
            << BC::invisible();
 
         ctx.popLoop();

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -303,9 +303,9 @@ DEF_INSTR(endcontext_, 0, 1, 0, 0)
 DEF_INSTR(inc_, 0, 1, 1, 1)
 
 /**
- * test_bounds_ :: check stack[0] is a valid inded into vector at stack[1]
+ * for_seq_size_ :: get size of the for loop sequence
  */
-DEF_INSTR(test_bounds_, 0, 2, 3, 1)
+DEF_INSTR(for_seq_size_, 0, 0, 1, 0)
 
 /**
  * return_ :: return instruction. Non-local return instruction as opposed to ret_.


### PR DESCRIPTION
we used to compile forloops by checking if the index is within the
looped-over array. that is slightly annoying to analyze. So lets
instead get the size of the looped-over array and compare if the
index variable is smaller or equal to the size.