### PR TITLE
Optimizer invocation tweak

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -123,6 +123,50 @@ static void jit(SEXP cls, Context* ctx) {
     SET_BODY(cls, BODY(cmp));
 }
 
+void tryOptimizeClosure(DispatchTable* table, size_t offset, Context* ctx) {
+
+    // This function will optimize the function and update the linked list
+    // of functions, so that subsequent closure calls pick the most optimized
+    // version.
+
+    static bool optimizing = false;
+
+    Function* fun = table->at(offset);
+
+    if (!optimizing && !fun->next() && !fun->origin()) {
+         /* currently there is a bug if we reoptimize a function twice:
+          *  Deopt ids from the first optimization and second optimizations
+          *  will be mixed and the deoptimizer always only goes back one
+          *  optimization level!
+          *  To avoid this bug we currently only optimize once
+          */
+        Code* code = fun->body();
+        if (fun->markOpt ||
+                (fun->invocationCount == 1 && code->perfCounter > 100) ||
+                (fun->invocationCount == 10 && code->perfCounter > 20) ||
+                 fun->invocationCount == 100) {
+            optimizing = true;
+
+            Function* oldFun = fun;
+            cp_pool_add(ctx, oldFun->container());
+
+            SEXP opt = globalContext()->optimizer(fun->container());
+
+            if (opt != nullptr) {
+                fun = Function::unpack(opt);
+
+                fun->invocationCount = oldFun->invocationCount;
+                fun->envLeaked = oldFun->envLeaked;
+                fun->envChanged = oldFun->envChanged;
+
+                // Update the dispatch table
+                table->put(offset, fun);
+            }
+            optimizing = false;
+        }
+    }
+}
+
 void closureDebug(SEXP call, SEXP op, SEXP rho, SEXP newrho, RCNTXT* cntxt) {
     // TODO!!!
 }
@@ -336,61 +380,16 @@ static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
     DispatchTable* vtable = DispatchTable::unpack(BODY(callee));
     Function* fun = vtable->first();
 
-    static bool optimizing = false;
-
     // NOTE(mhyee): The introduction of a dispatch table for different function
     // versions changes many things. This function handles a closure call, and
     // will optimize the closure function and update the linked list of
     // functions, so that subsequent closure calls pick the most optimized
     // version.
-    // This is no longer true with the dispatch table, where the first function
-    // is always selected, unless specified by the call instruction.
-    // For now, to keep the changes simpler, we'll just optimize the function
-    // once and add it to the dispatch table. But the call will still select
-    // the original, unoptimized version.
+    // This does not introduce a new item into the dispatch table!
 
-    if (!optimizing &&
-        !fun->next() &&
-         /* currently there is a bug if we reoptimize a function twice:
-          *  Deopt ids from the first optimization and second optimizations
-          *  will be mixed and the deoptimizer always only goes back one
-          *  optimization level!
-          *  To avoid this bug we currently only optimize once
-          */
-        !fun->origin()) {
-        Code* code = fun->body();
-        if (fun->markOpt ||
-            (fun->invocationCount == 1 && code->perfCounter > 100) ||
-            (fun->invocationCount == 10 && code->perfCounter > 20) ||
-            fun->invocationCount == 100) {
-            optimizing = true;
+    tryOptimizeClosure(vtable, 0, ctx);
 
-            Function* oldFun = fun;
-            cp_pool_add(ctx, oldFun->container());
-
-            SEXP opt = globalContext()->optimizer(fun->container());
-
-            if (opt != nullptr) {
-                fun = Function::unpack(opt);
-
-                PROTECT(fun->container());
-
-                // Update the vtable.
-                vtable->put(0, fun);
-
-                fun->invocationCount = oldFun->invocationCount;
-                fun->envLeaked = oldFun->envLeaked;
-                fun->envChanged = oldFun->envChanged;
-
-                UNPROTECT(1);  // funStore
-            }
-
-            optimizing = false;
-        }
-    }
-
-    if (fun->invocationCount < UINT_MAX)
-        fun->invocationCount++;
+    fun->registerInvocation();
 
     // match formal arguments and create the env of this new activation record
     SEXP newEnv =
@@ -2706,20 +2705,30 @@ SEXP rirExpr(SEXP f) {
     return f;
 }
 
-SEXP rirEval_f(SEXP f, SEXP env) {
-    assert(TYPEOF(f) == EXTERNALSXP);
-    Function* ff;
+SEXP rirEval_f(SEXP what, SEXP env) {
+    assert(TYPEOF(what) == EXTERNALSXP);
+    Code* c;
+    Function* f;
     DispatchTable* t;
     // TODO we do not really need the arg counts now
-    if (isValidCodeObject(f)) {
-        Code* c = (Code*)f;
-        return evalRirCode(c, globalContext(), env, 0);
-    } else if ((ff = Function::check(f))) {
-        return evalRirCode(ff->body(), globalContext(), env, 0);
-    } else if ((t = DispatchTable::check(f))) {
-        // Default target is the first version in the dispatch table
-        return evalRirCode(t->first()->body(), globalContext(), env, 0);
+    if ((c = isValidCodeObject(what))) {
+        // nothing
+    } else if ((f = Function::check(what))) {
+        // note: could try to optimize, but no way to update the
+        // containing dispatch table
+        // also this branch is probably not taken at all,
+        // since this function is an API used only by gnur
+        // eval, which should always pass in a CLOSXP
+        f->registerInvocation();
+        c = f->body();
+    } else if ((t = DispatchTable::check(what))) {
+        size_t offset = 0; // Default target is the first version
+        f = t->at(offset);
+        tryOptimizeClosure(t, offset, globalContext());
+        f->registerInvocation();
+        c = f->body();
     } else {
         assert(false && "Expected a code object, function, or dispatch table");
     }
+    return evalRirCode(c, globalContext(), env, 0);
 }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2706,27 +2706,18 @@ SEXP rirExpr(SEXP f) {
 SEXP rirEval_f(SEXP what, SEXP env) {
     assert(TYPEOF(what) == EXTERNALSXP);
     Code* c;
-    Function* f;
     DispatchTable* t;
     // TODO we do not really need the arg counts now
-    if ((c = isValidCodeObject(what))) {
-        // nothing
-    } else if ((f = Function::check(what))) {
-        // note: could try to optimize, but no way to update the
-        // containing dispatch table
-        // also this branch is probably not taken at all,
-        // since this function is an API used only by gnur
-        // eval, which should always pass in a CLOSXP
-        f->registerInvocation();
-        c = f->body();
+    if (isValidCodeObject(what)) {
+        c = (Code*)what;
     } else if ((t = DispatchTable::check(what))) {
         size_t offset = 0; // Default target is the first version
-        f = t->at(offset);
         tryOptimizeClosure(t, offset, globalContext());
+        Function* f = t->at(offset);
         f->registerInvocation();
         c = f->body();
     } else {
-        assert(false && "Expected a code object, function, or dispatch table");
+        assert(false && "Expected a code object or a dispatch table");
     }
     return evalRirCode(c, globalContext(), env, 0);
 }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -387,9 +387,10 @@ static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
 
             optimizing = false;
         }
-        if (fun->invocationCount < UINT_MAX)
-            fun->invocationCount++;
     }
+
+    if (fun->invocationCount < UINT_MAX)
+        fun->invocationCount++;
 
     // match formal arguments and create the env of this new activation record
     SEXP newEnv =

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -140,6 +140,11 @@ public:
 
     unsigned invocationCount;
 
+    void registerInvocation() {
+        if (invocationCount < UINT_MAX)
+            invocationCount++;
+    }
+
     unsigned envLeaked : 1;
     unsigned envChanged : 1;
     unsigned deopt : 1;


### PR DESCRIPTION
Before, when a RIR closure was called from the GNU R eval, e.g. directly from REPL, we did not track the number of invocations nor did we try to optimize such closures..
