### PR TITLE
let's clean up the horrible naming around `[` and `[[`

### DIFF
--- a/rir/src/analysis/dataflow.h
+++ b/rir/src/analysis/dataflow.h
@@ -685,10 +685,10 @@ class DataflowAnalysis
         case Opcode::inc_:
         case Opcode::is_:
         case Opcode::isfun_:
-        case Opcode::extract1_:
-        case Opcode::subset1_:
-        case Opcode::extract2_:
-        case Opcode::subset2_:
+        case Opcode::extract1_1_:
+        case Opcode::extract1_2_:
+        case Opcode::extract2_1_:
+        case Opcode::extract2_2_:
         case Opcode::close_:
         case Opcode::lgl_or_:
         case Opcode::lgl_and_:

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2192,7 +2192,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             NEXT();
         }
 
-        INSTRUCTION(subset1_) {
+        INSTRUCTION(extract1_1_) {
             SEXP idx = ostack_at(ctx, 0);
             SEXP val = ostack_at(ctx, 1);
 
@@ -2207,7 +2207,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             NEXT();
         }
 
-        INSTRUCTION(subset2_) {
+        INSTRUCTION(extract1_2_) {
             SEXP idx2 = ostack_at(ctx, 0);
             SEXP idx = ostack_at(ctx, 1);
             SEXP val = ostack_at(ctx, 2);
@@ -2337,7 +2337,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             NEXT();
         }
 
-        INSTRUCTION(extract1_) {
+        INSTRUCTION(extract2_1_) {
             SEXP idx = ostack_at(ctx, 0);
             SEXP val = ostack_at(ctx, 1);
             int i = -1;
@@ -2415,7 +2415,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         }
         }
 
-        INSTRUCTION(extract2_) {
+        INSTRUCTION(extract2_2_) {
             SEXP idx2 = ostack_at(ctx, 0);
             SEXP idx = ostack_at(ctx, 1);
             SEXP val = ostack_at(ctx, 2);

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -71,10 +71,10 @@ bool BC::operator==(const BC& other) const {
         return immediate.loc == other.immediate.loc;
 
     case Opcode::nop_:
-    case Opcode::subset2_:
-    case Opcode::extract2_:
-    case Opcode::subset1_:
-    case Opcode::extract1_:
+    case Opcode::extract1_1_:
+    case Opcode::extract1_2_:
+    case Opcode::extract2_1_:
+    case Opcode::extract2_2_:
     case Opcode::ret_:
     case Opcode::length_:
     case Opcode::names_:
@@ -191,10 +191,10 @@ void BC::write(CodeStream& cs) const {
         return;
 
     case Opcode::nop_:
-    case Opcode::subset2_:
-    case Opcode::extract2_:
-    case Opcode::subset1_:
-    case Opcode::extract1_:
+    case Opcode::extract1_1_:
+    case Opcode::extract1_2_:
+    case Opcode::extract2_1_:
+    case Opcode::extract2_2_:
     case Opcode::ret_:
     case Opcode::length_:
     case Opcode::names_:
@@ -440,10 +440,10 @@ void BC::print(CallSite* cs) {
     case Opcode::isfun_:
     case Opcode::invisible_:
     case Opcode::visible_:
-    case Opcode::subset2_:
-    case Opcode::extract2_:
-    case Opcode::subset1_:
-    case Opcode::extract1_:
+    case Opcode::extract1_1_:
+    case Opcode::extract1_2_:
+    case Opcode::extract2_1_:
+    case Opcode::extract2_2_:
     case Opcode::close_:
     case Opcode::length_:
     case Opcode::names_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -218,10 +218,10 @@ BC BC::eq() { return BC(Opcode::eq_); }
 BC BC::ne() { return BC(Opcode::ne_); }
 BC BC::invisible() { return BC(Opcode::invisible_); }
 BC BC::visible() { return BC(Opcode::visible_); }
-BC BC::extract1() { return BC(Opcode::extract1_); }
-BC BC::subset1() { return BC(Opcode::subset1_); }
-BC BC::extract2() { return BC(Opcode::extract2_); }
-BC BC::subset2() { return BC(Opcode::subset2_); }
+BC BC::extract1_1() { return BC(Opcode::extract1_1_); }
+BC BC::extract1_2() { return BC(Opcode::extract1_2_); }
+BC BC::extract2_1() { return BC(Opcode::extract2_1_); }
+BC BC::extract2_2() { return BC(Opcode::extract2_2_); }
 BC BC::swap() { return BC(Opcode::swap_); }
 BC BC::int3() { return BC(Opcode::int3_); }
 BC BC::makeUnique() { return BC(Opcode::make_unique_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -287,10 +287,10 @@ class BC {
     inline static BC isfun();
     inline static BC invisible();
     inline static BC visible();
-    inline static BC extract1();
-    inline static BC subset1();
-    inline static BC extract2();
-    inline static BC subset2();
+    inline static BC extract1_1();
+    inline static BC extract1_2();
+    inline static BC extract2_1();
+    inline static BC extract2_2();
     inline static BC swap();
     inline static BC put(uint32_t);
     inline static BC pick(uint32_t);
@@ -430,10 +430,10 @@ class BC {
             break;
         case Opcode::nop_:
         case Opcode::for_seq_size_:
-        case Opcode::extract1_:
-        case Opcode::subset1_:
-        case Opcode::extract2_:
-        case Opcode::subset2_:
+        case Opcode::extract1_1_:
+        case Opcode::extract2_1_:
+        case Opcode::extract1_2_:
+        case Opcode::extract2_2_:
         case Opcode::close_:
         case Opcode::ret_:
         case Opcode::pop_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -714,15 +714,15 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
             compileExpr(ctx, *idx);
             if (args.length() == 2) {
                 if (fun == symbol::DoubleBracket)
-                    cs << BC::extract1();
+                    cs << BC::extract2_1();
                 else
-                    cs << BC::subset1();
+                    cs << BC::extract1_1();
             } else {
                 compileExpr(ctx, *(idx + 1));
                 if (fun == symbol::DoubleBracket)
-                    cs << BC::extract2();
+                    cs << BC::extract2_2();
                 else
-                    cs << BC::subset2();
+                    cs << BC::extract1_2();
             }
 
             cs << BC::br(nextBranch);
@@ -850,7 +850,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         cs << BC::put(3);
 
         cs << BC::inc() << BC::dup2() << BC::lt() << BC::brtrue(endForBranch)
-           << BC::pull(2) << BC::pull(1) << BC::extract1();
+           << BC::pull(2) << BC::pull(1) << BC::extract2_1();
 
         // Put context back
         pcs.push_back(cs.currentPos());
@@ -1001,8 +1001,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                    << BC::pull(2)
                    << BC::brobj(objBranch);
 
-                cs << BC::extract1()
-                   << BC::br(contBranch);
+                cs << BC::extract2_1() << BC::br(contBranch);
 
                 static SEXP extractCall = nullptr;
                 if (!extractCall)

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -209,24 +209,24 @@ DEF_INSTR(isfun_, 0, 1, 1, 1)
 DEF_INSTR(is_, 1, 1, 1, 1)
 
 /**
- * extract1_:: do a[[b]], where a and b are on the stack and a is no obj
+ * extract2_1_:: do a[[b]], where a and b are on the stack and a is no obj
  */
-DEF_INSTR(extract1_, 0, 2, 1, 1)
+DEF_INSTR(extract2_1_, 0, 2, 1, 1)
 
 /**
- * subset1_:: do a[b], where a and b are on the stack and a is no obj
+ * extract1_1_:: do a[b], where a and b are on the stack and a is no obj
  */
-DEF_INSTR(subset1_, 0, 2, 1, 1)
+DEF_INSTR(extract1_1_, 0, 2, 1, 1)
 
 /**
- * extract2_:: do a[[b,c]], where a, b and c are on the stack and a is no obj
+ * extract2_2_:: do a[[b,c]], where a, b and c are on the stack and a is no obj
  */
-DEF_INSTR(extract2_, 0, 3, 1, 1)
+DEF_INSTR(extract2_2_, 0, 3, 1, 1)
 
 /**
- * subset2_:: do a[b,c], where a, b and c are on the stack and a is no obj
+ * extract1_2_:: do a[b,c], where a, b and c are on the stack and a is no obj
  */
-DEF_INSTR(subset2_, 0, 3, 1, 1)
+DEF_INSTR(extract1_2_, 0, 3, 1, 1)
 
 /**
  * brobj_:: branch if tos is object


### PR DESCRIPTION
internally we called `[[` extract and `[` subset, but then
`[[<-` and `[<-` both subassign. In the formar case we used
1,2 as a postfix to denote 1 vs. 2-dimensional indexing,
whereas in the later case we used it do distinguish between
`[` and `[[` :/

this commit cleans is up. Now both `[[` and `[` are called
extract. The former is extract2, the later is extract1.

Then we use a second index for the number of indices. So
`a[1,2]` is extract_1_2 `a[1]` is extract1_1 and `a[[1]]`
is extract2_1.