### PR TITLE
refactor instructions

### DIFF
--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -118,7 +118,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::invisible_:
     case Opcode::visible_:
     case Opcode::endcontext_:
-    case Opcode::subassign_:
+    case Opcode::subassign1_:
         return true;
 
     case Opcode::invalid_:
@@ -238,7 +238,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::invisible_:
     case Opcode::visible_:
     case Opcode::endcontext_:
-    case Opcode::subassign_:
+    case Opcode::subassign1_:
         return;
 
     case Opcode::invalid_:
@@ -452,7 +452,7 @@ void BC::print(CallSite* cs) {
     case Opcode::aslogical_:
     case Opcode::lgl_or_:
     case Opcode::lgl_and_:
-    case Opcode::subassign_:
+    case Opcode::subassign1_:
     case Opcode::subassign2_:
         break;
     case Opcode::promise_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -141,7 +141,7 @@ BC BC::stvar2(SEXP sym) {
     i.pool = Pool::insert(sym);
     return BC(Opcode::stvar2_, i);
 }
-BC BC::subassign() { return BC(Opcode::subassign_); }
+BC BC::subassign1() { return BC(Opcode::subassign1_); }
 BC BC::subassign2(SEXP sym) {
     assert(sym == R_NilValue ||
            (TYPEOF(sym) == SYMSXP && strlen(CHAR(PRINTNAME(sym)))));

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -239,7 +239,7 @@ class BC {
     inline static BC stvar(SEXP sym);
     inline static BC stvar2(SEXP sym);
     inline static BC missing(SEXP sym);
-    inline static BC subassign();
+    inline static BC subassign1();
     inline static BC subassign2(SEXP sym);
     inline static BC length();
     inline static BC names();
@@ -473,7 +473,7 @@ class BC {
         case Opcode::invisible_:
         case Opcode::visible_:
         case Opcode::endcontext_:
-        case Opcode::subassign_:
+        case Opcode::subassign1_:
         case Opcode::length_:
         case Opcode::names_:
         case Opcode::set_names_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -436,7 +436,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                         if (fun2 == symbol::DoubleBracket)
                             cs << BC::subassign2(target);
                         else
-                            cs << BC::subassign();
+                            cs << BC::subassign1();
 
                         cs << (superAssign ? BC::stvar2(target) : BC::stvar(target));
                         cs << BC::br(nextBranch);

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -2,7 +2,7 @@
 #error "DEF_INSTR must be defined before including insns.h"
 #endif
 
-//        name       imm   pop   push pure
+// DEF_INSTR(name, imm, pop, push, pure)
 
 /**
  * invalid_:: Opcode 0 acts as a sentinnel for unintialiazed Code.
@@ -15,26 +15,9 @@ DEF_INSTR(invalid_, 0, 0, 0, 0)
 DEF_INSTR(nop_, 0, 0, 0, 1)
 
 /**
- * push_:: take immediate CP index, and push CP value on object stack.
- */
-DEF_INSTR(push_, 1, 0, 1, 1)
-
-/**
- * push_code_:: take immediate code object index, and push code object onto obj
- * stack
- */
-DEF_INSTR(push_code_, 1, 0, 1, 1)
-
-/**
- * ldfun_:: take immediate CP index of dd symbol (eg. ..1), find binding in env
- * and push value
+ * ldfun_:: take immediate CP index of symbol, find function bound to that name and push it on stack.
  */
 DEF_INSTR(ldfun_, 1, 0, 1, 0)
-
-/**
- * ldddvar_:: loads the ellipsis values (such as ..1, ..2) and pushes them on stack.
- */
-DEF_INSTR(ldddvar_, 1, 0, 1, 0)
 
 /**
  * ldvar_:: take immediate CP index of symbol, finding binding in env and push.
@@ -42,9 +25,14 @@ DEF_INSTR(ldddvar_, 1, 0, 1, 0)
 DEF_INSTR(ldvar_, 1, 0, 1, 0)
 
 /**
- * ldvar2_:: take immediate CP index of symbol, finding binding in env and push.
+ * ldvar2_:: take immediate CP index of symbol, finding binding in enclosing env and push.
  */
 DEF_INSTR(ldvar2_, 1, 0, 1, 0)
+
+/**
+ * ldddvar_:: loads the ellipsis values (such as ..1, ..2) and pushes them on stack.
+ */
+DEF_INSTR(ldddvar_, 1, 0, 1, 0)
 
 /**
  * ldlval_:: take immediate CP index of symbol, load value from local frame.
@@ -62,6 +50,16 @@ DEF_INSTR(ldarg_, 1, 0, 1, 0)
 DEF_INSTR(ldloc_, 1, 0, 1, 1)
 
 /**
+ * stvar_:: assign tos to the immediate symbol
+ */
+DEF_INSTR(stvar_, 1, 1, 0, 0)
+
+/**
+ * stvar2_:: assign tos to the immediate symbol, lookup starts in the enclosing environment
+ */
+DEF_INSTR(stvar2_, 1, 1, 0, 1)
+
+/**
  * stloc_:: store top of stack to local variable
  */
 DEF_INSTR(stloc_, 1, 1, 0, 1)
@@ -72,10 +70,26 @@ DEF_INSTR(stloc_, 1, 1, 0, 1)
 DEF_INSTR(call_, 2, 1, 1, 0)
 
 /**
- * promise_:: take immediate CP index of Code, create promise & push on object
- * stack
+ * call_stack_:: like call, but arguments are taken from the stack
+ *               immediate are number of args and names
  */
-DEF_INSTR(promise_, 1, 0, 1, 1)
+DEF_INSTR(call_stack_, 2, -1, 1, 0)
+
+/**
+ * static_call_stack_:: like call_stack, but call target is immediate
+ */
+DEF_INSTR(static_call_stack_, 2, -1, 1, 0)
+
+/**
+ * dispatch_:: similar to call, but receiver is tos and 3rd immediate
+ *             is selector
+ */
+DEF_INSTR(dispatch_, 2, 1, 1, 0)
+
+/**
+ * dispatch_stack_:: similar to dispatch, but all args on stack
+ */
+DEF_INSTR(dispatch_stack_, 2, -1, 1, 0)
 
 /**
  * close_:: pop body and argument list, create closure, and push on object stack
@@ -83,9 +97,16 @@ DEF_INSTR(promise_, 1, 0, 1, 1)
 DEF_INSTR(close_, 0, 3, 1, 1)
 
 /**
- * ret_:: terminates execution and pops result off object stack
+ * isfun_:: pop object stack, convert to RIR code or assert error, push code to
+ * object stack
  */
-DEF_INSTR(ret_, 0, 1, 0, 1)
+DEF_INSTR(isfun_, 0, 1, 1, 1)
+
+/**
+ * promise_:: take immediate CP index of Code, create promise & push on object
+ * stack
+ */
+DEF_INSTR(promise_, 1, 0, 1, 1)
 
 /**
  * force_:: pop from objet stack, evaluate, push promise's value
@@ -95,56 +116,15 @@ DEF_INSTR(ret_, 0, 1, 0, 1)
 DEF_INSTR(force_, 0, 1, 1, 0)
 
 /**
- * pop_:: pop from object stack
+ * push_:: take immediate CP index, and push CP value on object stack.
  */
-DEF_INSTR(pop_, 0, 1, 0, 1)
+DEF_INSTR(push_, 1, 0, 1, 1)
 
 /**
- * asast_:: pop a promise off the object stack, push its AST on object stack
-
- TODO: we do not use now, might not work... why?
+ * push_code_:: take immediate code object index, and push code object onto obj
+ * stack
  */
-DEF_INSTR(asast_, 0, 1, 1, 1)
-
-/**
- * stvar_:: assign tos to the immediate symbol
- */
-DEF_INSTR(stvar_, 1, 1, 0, 0)
-
-/**
- * stvar2_:: assign tos to the immediate symbol
- */
-DEF_INSTR(stvar2_, 1, 1, 0, 1)
-
-/**
- * asbool_:: pop object stack, convert to Logical vector of size 1 and push on object stack. Throws an error if the result would be NA.
- */
-DEF_INSTR(asbool_, 0, 1, 1, 0)
-
-/**
- * brtrue_:: pop object stack, if TRUE branch to immediate offset
- */
-DEF_INSTR(brtrue_, 1, 1, 0, 1)
-
-/**
- * brfalse_:: pop object stack, if FALSE branch to immediate offset
- */
-DEF_INSTR(brfalse_, 1, 1, 0, 1)
-
-/**
- * br_:: branch to immediate offset
- */
-DEF_INSTR(br_, 1, 0, 0, 1)
-
-/**
- * invisible_:: set invisible flag, so that value will not be printed. This is a global flag, many operations implicitly clear it.
- */
-DEF_INSTR(invisible_, 0, 0, 0, 1)
-
-/**
- * visible_:: reset invisible flag
- */
-DEF_INSTR(visible_, 0, 0, 0, 1)
+DEF_INSTR(push_code_, 1, 0, 1, 1)
 
 /**
  * dup_:: pop value from object stack, push it twice
@@ -157,24 +137,54 @@ DEF_INSTR(dup_, 0, 1, 2, 1)
 DEF_INSTR(dup2_, 0, 2, 4, 1)
 
 /**
- * add_:: pop two values from object stack, add them, push result on object
- * stack
+ * pop_:: pop from object stack
+ */
+DEF_INSTR(pop_, 0, 1, 0, 1)
 
- Works on any SEXP.
+/**
+ * swap_:: swap two elements tos
+ */
+DEF_INSTR(swap_, 0, 2, 2, 1)
+
+/**
+ * put_:: put tos at the n-th pos in the stack
+ */
+DEF_INSTR(put_, 1, 0, 0, 1)
+
+/**
+ * pick_:: remove n-th element on stack and push it tos
+ */
+DEF_INSTR(pick_, 1, 0, 0, 1)
+
+/**
+ * pull_ :: copy a value from the stack. examples: pull(0) == dup(), pull(1) takes 2nd
+            element on stack and pushes it
+ */
+DEF_INSTR(pull_, 1, 0, 1, 1)
+
+/**
+ * add_:: pop two values from object stack, add them, push result on object
+ * stack. Works on any SEXP.
  */
 DEF_INSTR(add_, 0, 2, 1, 0)
-DEF_INSTR(mul_, 0, 2, 1, 0)
-DEF_INSTR(div_, 0, 2, 1, 0)
-DEF_INSTR(pow_, 0, 2, 1, 0)
-DEF_INSTR(idiv_, 0, 2, 1, 0)
-DEF_INSTR(mod_, 0, 2, 1, 0)
-DEF_INSTR(sub_, 0, 2, 1, 0)
 
 /**
  * uplus_:: unary plus
  */
 DEF_INSTR(uplus_, 0, 1, 1, 0)
+
+/**
+ * inc_ :: increment tos integer
+ */
+DEF_INSTR(inc_, 0, 1, 1, 1)
+
+DEF_INSTR(sub_, 0, 2, 1, 0)
 DEF_INSTR(uminus_, 0, 1, 1, 0)
+DEF_INSTR(mul_, 0, 2, 1, 0)
+DEF_INSTR(div_, 0, 2, 1, 0)
+DEF_INSTR(idiv_, 0, 2, 1, 0)
+DEF_INSTR(mod_, 0, 2, 1, 0)
+DEF_INSTR(pow_, 0, 2, 1, 0)
 
 /**
  * lt_:: relational operator <
@@ -192,95 +202,6 @@ DEF_INSTR(ne_, 0, 2, 1, 0)
 DEF_INSTR(not_, 0, 1, 1, 0)
 
 /**
- * guard_fun_:: takes symbol, target, id, checks findFun(symbol) == target
- */
-DEF_INSTR(guard_fun_, 3, 0, 0, 1)
-DEF_INSTR(guard_env_, 1, 0, 0, 1)
-
-/**
- * isfun_:: pop object stack, convert to RIR code or assert error, push code to
- * object stack
- */
-DEF_INSTR(isfun_, 0, 1, 1, 1)
-
-/**
- * is_:: immediate type tag (SEXPTYPE), push T/F
- */
-DEF_INSTR(is_, 1, 1, 1, 1)
-
-/**
- * extract2_1_:: do a[[b]], where a and b are on the stack and a is no obj
- */
-DEF_INSTR(extract2_1_, 0, 2, 1, 1)
-
-/**
- * extract1_1_:: do a[b], where a and b are on the stack and a is no obj
- */
-DEF_INSTR(extract1_1_, 0, 2, 1, 1)
-
-/**
- * extract2_2_:: do a[[b,c]], where a, b and c are on the stack and a is no obj
- */
-DEF_INSTR(extract2_2_, 0, 3, 1, 1)
-
-/**
- * extract1_2_:: do a[b,c], where a, b and c are on the stack and a is no obj
- */
-DEF_INSTR(extract1_2_, 0, 3, 1, 1)
-
-/**
- * brobj_:: branch if tos is object
- */
-DEF_INSTR(brobj_, 1, 1, 1, 1)
-
-/**
- * dispatch_stack_:: similar to dispatch, but all args on stack
- */
-DEF_INSTR(dispatch_stack_, 2, -1, 1, 0)
-
-/**
- * dispatch_:: similar to call, but receiver is tos and 3rd immediate
- *             is selector
- */
-DEF_INSTR(dispatch_, 2, 1, 1, 0)
-
-/**
- * swap_:: swap two elements tos
- */
-DEF_INSTR(swap_, 0, 2, 2, 1)
-
-/**
- * pick_:: remove n-th element on stack and push it tos
- */
-DEF_INSTR(pick_, 1, 0, 0, 1)
-
-/**
- * put_:: put tos at the n-th pos in the stack
- */
-DEF_INSTR(put_, 1, 0, 0, 1)
-
-/**
- * call_stack_:: like call, but arguments are taken from the stack
- *               immediate are number of args and names
- */
-DEF_INSTR(call_stack_, 2, -1, 1, 0)
-
-/**
- * static_call_stack_:: like call_stack, but call target is immediate
- */
-DEF_INSTR(static_call_stack_, 2, -1, 1, 0)
-
-/**
- * set_shared_:: marks tos to be shared (ie. named = 2)
- */
-DEF_INSTR(set_shared_, 0, 1, 1, 1)
-
-/**
- * make_unique_:: duplicates tos if it is shared (ie. named > 1)
- */
-DEF_INSTR(make_unique_, 0, 1, 1, 1)
-
-/**
  * lgl_or_:: computes the logical (ternary) or of the two tos vals
  */
 DEF_INSTR(lgl_or_, 0, 2, 1, 1)
@@ -296,41 +217,21 @@ DEF_INSTR(lgl_and_, 0, 2, 1, 1)
 DEF_INSTR(aslogical_, 0, 1, 1, 0)
 
 /**
- * beginloop_:: begins loop context, break and continue target immediate (this is the target for break and next long jumps)
+ * asbool_:: pop object stack, convert to Logical vector of size 1 and push on object stack. Throws an error if the result would be NA.
  */
-DEF_INSTR(beginloop_, 1, 0, 1, 1)
+DEF_INSTR(asbool_, 0, 1, 1, 0)
 
 /**
- * endcontext_:: ends a context. Takes a context as input and removes it from the stack (the context to be removed does not have to be top one)
+ * asast_:: pop a promise off the object stack, push its AST on object stack
 
-TODO black magic here
+ TODO: we do not use now, might not work... why?
  */
-DEF_INSTR(endcontext_, 0, 1, 0, 0)
-
-/**
- * inc_ :: increment tos integer
- */
-DEF_INSTR(inc_, 0, 1, 1, 1)
+DEF_INSTR(asast_, 0, 1, 1, 1)
 
 /**
- * for_seq_size_ :: get size of the for loop sequence
+ * is_:: immediate type tag (SEXPTYPE), push T/F
  */
-DEF_INSTR(for_seq_size_, 0, 0, 1, 0)
-
-/**
- * return_ :: return instruction. Non-local return instruction as opposed to ret_.
- */
-DEF_INSTR(return_, 0, 1, 0, 0)
-
-/**
- * subassign_ :: [<-(a,b,c)
- */
-DEF_INSTR(subassign_, 0, 3, 1, 1)
-
-/**
- * subassign2_ :: [[<-(a,b,c)
- */
-DEF_INSTR(subassign2_, 1, 3, 1, 1)
+DEF_INSTR(is_, 1, 1, 1, 1)
 
 /**
  * missing_ :: check if symb is missing
@@ -338,6 +239,62 @@ DEF_INSTR(subassign2_, 1, 3, 1, 1)
  TODO we want to rename to isMissing
  */
 DEF_INSTR(missing_, 1, 0, 1, 1)
+
+/**
+ * brobj_:: branch if tos is object
+ */
+DEF_INSTR(brobj_, 1, 1, 1, 1)
+
+/**
+ * brtrue_:: pop object stack, if TRUE branch to immediate offset
+ */
+DEF_INSTR(brtrue_, 1, 1, 0, 1)
+
+/**
+ * brfalse_:: pop object stack, if FALSE branch to immediate offset
+ */
+DEF_INSTR(brfalse_, 1, 1, 0, 1)
+
+/**
+ * br_:: branch to immediate offset
+ */
+DEF_INSTR(br_, 1, 0, 0, 1)
+
+/**
+ * extract1_1_:: do a[b], where a and b are on the stack and a is no obj
+ */
+DEF_INSTR(extract1_1_, 0, 2, 1, 1)
+
+/**
+ * extract1_2_:: do a[b,c], where a, b and c are on the stack and a is no obj
+ */
+DEF_INSTR(extract1_2_, 0, 3, 1, 1)
+
+/**
+ * subassign_ :: [<-(a,b,c)
+ */
+DEF_INSTR(subassign1_, 0, 3, 1, 1)
+
+/**
+ * extract2_1_:: do a[[b]], where a and b are on the stack and a is no obj
+ */
+DEF_INSTR(extract2_1_, 0, 2, 1, 1)
+
+/**
+ * extract2_2_:: do a[[b,c]], where a, b and c are on the stack and a is no obj
+ */
+DEF_INSTR(extract2_2_, 0, 3, 1, 1)
+
+/**
+ * subassign2_ :: [[<-(a,b,c)
+ */
+DEF_INSTR(subassign2_, 1, 3, 1, 1)
+
+/**
+ * guard_fun_:: takes symbol, target, id, checks findFun(symbol) == target
+ */
+DEF_INSTR(guard_fun_, 3, 0, 0, 1)
+DEF_INSTR(guard_env_, 1, 0, 0, 1)
 
 /**
  * seq_ :: seq(scalar, scalar, scalar)
@@ -355,11 +312,6 @@ DEF_INSTR(colon_, 0, 2, 1, 0)
 DEF_INSTR(names_, 0, 1, 1, 1)
 
 /**
- * length_ :: get length of a vector
- */
-DEF_INSTR(length_, 0, 1, 1, 1)
-
-/**
  * set_names_ :: set names of a vector, takes vector and names, puts vector back
  */
 DEF_INSTR(set_names_, 0, 2, 1, 1)
@@ -370,10 +322,56 @@ DEF_INSTR(set_names_, 0, 2, 1, 1)
 DEF_INSTR(alloc_, 1, 1, 1, 1)
 
 /**
- * pull_ :: copy a value from the stack. examples: pull(0) == dup(), pull(1) takes 2nd
-            element on stack and pushes it
+ * length_ :: get length of a vector
  */
-DEF_INSTR(pull_, 1, 0, 1, 1)
+DEF_INSTR(length_, 0, 1, 1, 1)
+
+/**
+ * for_seq_size_ :: get size of the for loop sequence
+ */
+DEF_INSTR(for_seq_size_, 0, 0, 1, 0)
+
+/**
+ * visible_:: reset invisible flag
+ */
+DEF_INSTR(visible_, 0, 0, 0, 1)
+
+/**
+ * invisible_:: set invisible flag, so that value will not be printed. This is a global flag, many operations implicitly clear it.
+ */
+DEF_INSTR(invisible_, 0, 0, 0, 1)
+
+/**
+ * set_shared_:: marks tos to be shared (ie. named = 2)
+ */
+DEF_INSTR(set_shared_, 0, 1, 1, 1)
+
+/**
+ * make_unique_:: duplicates tos if it is shared (ie. named > 1)
+ */
+DEF_INSTR(make_unique_, 0, 1, 1, 1)
+
+/**
+ * beginloop_:: begins loop context, break and continue target immediate (this is the target for break and next long jumps)
+ */
+DEF_INSTR(beginloop_, 1, 0, 1, 1)
+
+/**
+ * endcontext_:: ends a context. Takes a context as input and removes it from the stack (the context to be removed does not have to be top one)
+
+TODO black magic here
+ */
+DEF_INSTR(endcontext_, 0, 1, 0, 0)
+
+/**
+ * return_ :: return instruction. Non-local return instruction as opposed to ret_.
+ */
+DEF_INSTR(return_, 0, 1, 0, 0)
+
+/**
+ * ret_:: terminates execution and pops result off object stack
+ */
+DEF_INSTR(ret_, 0, 1, 0, 1)
 
 /**
  * int3_ :: low-level breakpoint


### PR DESCRIPTION
- renamed `subassign_` to `subassign1_` to reflect the new naming convention
- reordered the instructions to match in `interp.cpp` and `insns.h`
- fixed `ldfun_` description