### PR TITLE
Interpreter cleanup

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -536,82 +536,76 @@ INLINE SEXP fixupAST(SEXP call, Context* ctx, size_t nargs) {
 SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
             uint32_t id, SEXP env, Context* ctx) {
 
+    assert(TYPEOF(callee) == SPECIALSXP || TYPEOF(callee) == BUILTINSXP ||
+           TYPEOF(callee) == CLOSXP);
+
     CallSite* cs = caller->callSite(id);
     SEXP call = cp_pool_at(ctx, cs->call);
 
     profileCall(cs, callee);
 
-    Protect p;
-    if (argsOnStack)
-        if (TYPEOF(callee) == SPECIALSXP || TYPEOF(callee) == CLOSXP) {
+    if (TYPEOF(callee) == SPECIALSXP) {
+        assert(call != R_NilValue);
+        Protect p;
+        if (argsOnStack) {
             call = fixupAST(call, ctx, nargs);
             p(call);
-        }
-
-    SEXP result;
-
-    switch (TYPEOF(callee)) {
-    case SPECIALSXP: {
-        assert(call != R_NilValue);
-        if (argsOnStack)
             ostack_popn(ctx, nargs);
+        }
         // get the ccode
         CCODE f = getBuiltin(callee);
         int flag = getFlag(callee);
         R_Visible = static_cast<Rboolean>(flag != 1);
         warnSpecial(callee, call);
         // call it with the AST only
-        result = f(call, callee, CDR(call), env);
+        SEXP result = f(call, callee, CDR(call), env);
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
-        break;
+        return result;
     }
-    case BUILTINSXP: {
-        // create the argslist
-        SEXP argslist;
-        if (argsOnStack) {
-            argslist = createArgsListStack(caller, nargs, cs, env, ctx, true);
-            ostack_popn(ctx, nargs);
-        } else {
-            argslist = createArgsList(caller, call, nargs, cs, env, ctx, true);
-        }
-        p(argslist);
+
+    // create the argslist
+    bool eager = TYPEOF(callee) == BUILTINSXP;
+    SEXP argslist;
+    Protect p;
+    if (argsOnStack) {
+        call = fixupAST(call, ctx, nargs);
+        p(call);
+        argslist = createArgsListStack(caller, nargs, cs, env, ctx, eager);
+        ostack_popn(ctx, nargs);
+    } else {
+        argslist = createArgsList(caller, call, nargs, cs, env, ctx, eager);
+    }
+    p(argslist);
+
+    if (TYPEOF(callee) == BUILTINSXP) {
         // get the ccode
         CCODE f = getBuiltin(callee);
         int flag = getFlag(callee);
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
         // call it
-        result = f(call, callee, argslist, env);
+        SEXP result = f(call, callee, argslist, env);
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
-        break;
+        return result;
     }
-    case CLOSXP: {
-        // create the argslist
-        SEXP argslist;
-        if (argsOnStack) {
-            argslist = createArgsListStack(caller, nargs, cs, env, ctx, false);
-            ostack_popn(ctx, nargs);
-        } else {
-            argslist = createArgsList(caller, call, nargs, cs, env, ctx, false);
-        }
-        p(argslist);
+
+    if (TYPEOF(callee) == CLOSXP) {
         // if body is EXTERNALSXP, it is rir serialized code, execute it
         // directly
-        SEXP body = BODY(callee);
+        SEXP body = BODY(callee), result;
         if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidDispatchTableSEXP(body));
             result = rirCallClosure(call, env, callee, argslist, nargs, ctx);
         } else {
             result = applyClosure(call, callee, argslist, env, R_NilValue);
         }
-        break;
+        return result;
     }
-    default:
-        assert(false && "Don't know how to run other stuff");
-    }
-    return result;
+
+    // not reached
+    return R_NilValue;
 }
 
 SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
@@ -624,18 +618,14 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
     SEXP call = cp_pool_at(ctx, cs->call);
     SEXP selector = cp_pool_at(ctx, *cs->selector());
     SEXP op = SYMVALUE(selector);
-    SEXP actuals;
 
     profileCall(cs, Rf_install("*dispatch*"));
 
+    SEXP actuals;
     {
-        Protect p;
         if (argsOnStack) {
             call = fixupAST(call, ctx, nargs);
-            p(call);
-        }
-
-        if (argsOnStack) {
+            Protect p(call);
             actuals = createArgsListStack(caller, nargs, cs, env, ctx, true);
             ostack_popn(ctx, nargs);
             ostack_push(ctx, actuals);
@@ -650,7 +640,6 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
     }
 
     SEXP result = nullptr;
-
     do {
         // ===============================================
         // First try S4
@@ -1196,7 +1185,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             // TODO something should happen here
             if (res == R_UnboundValue)
                 assert(false && "Unbound var");
-            else if (res == R_MissingArg)
+            if (res == R_MissingArg)
                 assert(false && "Missing argument");
 
             switch (TYPEOF(res)) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -91,7 +91,7 @@ void endClosureContext(RCNTXT* cntxt, SEXP result) {
 }
 
 INLINE SEXP createPromise(Code* code, SEXP env) {
-    SEXP p = mkPROMISE((SEXP)code, env);
+    SEXP p = Rf_mkPROMISE((SEXP)code, env);
     return p;
 }
 
@@ -207,7 +207,7 @@ SEXP createArgsListStack(Code* c, size_t nargs, CallSite* cs, SEXP env,
             // We have to wrap them in a promise, otherwise they are treated
             // as expressions to be evaluated, when in fact they are meant to be
             // asts as values
-            SEXP promise = mkPROMISE(arg, env);
+            SEXP promise = Rf_mkPROMISE(arg, env);
             SET_PRVALUE(promise, arg);
             __listAppend(&result, &pos, promise, R_NilValue);
         } else {
@@ -251,7 +251,7 @@ SEXP createArgsList(Code* c, SEXP call, size_t nargs, CallSite* cs, SEXP env,
                         assert(TYPEOF(arg) != PROMSXP);
                         __listAppend(&result, &pos, arg, name);
                     } else {
-                        SEXP promise = mkPROMISE(CAR(ellipsis), env);
+                        SEXP promise = Rf_mkPROMISE(CAR(ellipsis), env);
                         __listAppend(&result, &pos, promise, name);
                     }
                     ellipsis = CDR(ellipsis);
@@ -502,7 +502,7 @@ INLINE SEXP fixupAST(SEXP call, Context* ctx, size_t nargs) {
         // then they are converted to consts (named = 2) which is bad.
         // therefore we wrap them in fake promises.
         if (TYPEOF(p) != PROMSXP) {
-            p = mkPROMISE(getterPlaceholderSym, R_NilValue);
+            p = Rf_mkPROMISE(getterPlaceholderSym, R_NilValue);
             SET_PRVALUE(p, target);
         }
 
@@ -520,7 +520,7 @@ INLINE SEXP fixupAST(SEXP call, Context* ctx, size_t nargs) {
 
             SEXP p = val;
             if (TYPEOF(p) != PROMSXP) {
-                p = mkPROMISE(setterPlaceholderSym, R_NilValue);
+                p = Rf_mkPROMISE(setterPlaceholderSym, R_NilValue);
                 SET_PRVALUE(p, val);
             }
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -594,7 +594,8 @@ SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
     if (TYPEOF(callee) == CLOSXP) {
         // if body is EXTERNALSXP, it is rir serialized code, execute it
         // directly
-        SEXP body = BODY(callee), result;
+        SEXP body = BODY(callee);
+        SEXP result;
         if (TYPEOF(body) == EXTERNALSXP) {
             assert(isValidDispatchTableSEXP(body));
             result = rirCallClosure(call, env, callee, argslist, nargs, ctx);
@@ -605,7 +606,7 @@ SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
     }
 
     // not reached
-    return R_NilValue;
+    assert(false);
 }
 
 SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
@@ -666,7 +667,7 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
         }
 
         // ===============================================
-        // Now normal dispatch (mostly a copy from doCall)
+        // Now normal dispatch
         SEXP callee = Rf_findFun(selector, env);
 
         // TODO something should happen here


### PR DESCRIPTION
Mainly unify `doCall` with `doCallStack` and `doDispatch` with `doDispatchStack` to reduce some code duplication.