### PR TITLE
Environment handling in RIR

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -80,7 +80,8 @@ REXPORT SEXP rir_eval(SEXP what, SEXP env) {
         f = isValidClosureSEXP(what);
     if (f == nullptr)
         Rf_error("Not rir compiled code");
-    return evalRirCode(f->body(), globalContext(), env, 0);
+    EnvironmentProxy ep(env);
+    return evalRirCode(f->body(), globalContext(), &ep);
 }
 
 REXPORT SEXP rir_body(SEXP cls) {

--- a/rir/src/compiler/pir_compiler.cpp
+++ b/rir/src/compiler/pir_compiler.cpp
@@ -373,6 +373,9 @@ class CodeCompiler {
             assert(false);
 
         // Unsupported opcodes:
+        case Opcode::make_env_:
+        case Opcode::get_env_:
+        case Opcode::set_env_:
         case Opcode::ldloc_:
         case Opcode::stloc_:
         case Opcode::ldlval_:

--- a/rir/src/interpreter/call_support.h
+++ b/rir/src/interpreter/call_support.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "R/Protect.h"
+#include "runtime.h"
+
+namespace rir {
+
+class EnvironmentProxy;
+
+/*
+ * This class holds either a valid constructed argument list
+ * (ie. a linked list of promises), or data used for delayed
+ * construction of the list.
+ */
+class ArgumentListProxy {
+  private:
+    bool validArgslist_ = true;
+    union {
+        SEXP argslist_;
+        struct {
+            Code* caller;
+            SEXP call;
+            bool onStack;
+            uint32_t nargs;
+            CallSite* cs;
+            EnvironmentProxy* ep;
+            Context* ctx;
+        } ctxt_;
+    };
+
+    void create();
+
+  public:
+    explicit ArgumentListProxy(SEXP argslist) : argslist_{argslist} {}
+    explicit ArgumentListProxy(Code* caller, SEXP call, bool argsOnStack,
+                               uint32_t nargs, CallSite* cs,
+                               EnvironmentProxy* ep, Context* ctx)
+        : validArgslist_{false},
+          ctxt_{caller, call, argsOnStack, nargs, cs, ep, ctx} {}
+
+    SEXP argslist() {
+        if (!validArgslist_)
+            create();
+        return argslist_;
+    }
+
+    ~ArgumentListProxy() = default;
+    ArgumentListProxy(ArgumentListProxy const&) = delete;
+    ArgumentListProxy(ArgumentListProxy&&) = delete;
+    ArgumentListProxy& operator=(ArgumentListProxy const&) = delete;
+    ArgumentListProxy& operator=(ArgumentListProxy&&) = delete;
+    static void* operator new(size_t) = delete;
+};
+
+/*
+ * This class holds either a valid R environment, or data to create
+ * the environment lazily. In the lazy case, either we create the
+ * environment at the start of evaluating RIR Code, or explicitly
+ * using a special instruction.
+ */
+class EnvironmentProxy {
+  private:
+    bool validREnv_ = true;
+    bool createEnvironment_ = false;
+    union {
+        SEXP env_;
+        struct {
+            SEXP call;
+            SEXP callee;
+            ArgumentListProxy* ap;
+            RCNTXT* cntxt;
+        } ctxt_;
+    };
+    EnvironmentProxy* parent_ = nullptr;
+
+  public:
+    explicit EnvironmentProxy(SEXP env) : env_{env} {
+        if (!env_)
+            error("'rho' cannot be C NULL: detected in C-level eval");
+        if (!isEnvironment(env_))
+            error(
+                "'rho' must be an environment not %s: detected in C-level eval",
+                type2char(TYPEOF(env_)));
+    }
+
+    explicit EnvironmentProxy(bool eager, SEXP call, SEXP callee,
+                              ArgumentListProxy* ap, RCNTXT* cntxt,
+                              EnvironmentProxy* parent)
+        : validREnv_{false}, createEnvironment_{eager},
+          ctxt_{call, callee, ap, cntxt}, parent_{parent} {}
+
+    void init();
+
+    SEXP env() {
+        SLOWASSERT(validREnv_ && "attempt to access non-existent environment");
+        return env_;
+    }
+
+    void set(SEXP env) {
+        SLOWASSERT(env && TYPEOF(env) == ENVSXP && "setting to invalid env");
+        env_ = env;
+    }
+
+    void make(SEXP parent) {
+        // create a new env, save it to env_ (return old?)
+        assert(false && "not implemented yet");
+    }
+
+    ~EnvironmentProxy() = default;
+    EnvironmentProxy(EnvironmentProxy const&) = delete;
+    EnvironmentProxy(EnvironmentProxy&&) = delete;
+    EnvironmentProxy& operator=(EnvironmentProxy const&) = delete;
+    EnvironmentProxy& operator=(EnvironmentProxy&&) = delete;
+    static void* operator new(size_t) = delete;
+};
+
+} // namespace rir

--- a/rir/src/interpreter/call_support.h
+++ b/rir/src/interpreter/call_support.h
@@ -68,7 +68,6 @@ class EnvironmentProxy {
             SEXP call;
             SEXP callee;
             ArgumentListProxy* ap;
-            RCNTXT* cntxt;
         } ctxt_;
     };
     EnvironmentProxy* parent_ = nullptr;
@@ -84,10 +83,9 @@ class EnvironmentProxy {
     }
 
     explicit EnvironmentProxy(bool eager, SEXP call, SEXP callee,
-                              ArgumentListProxy* ap, RCNTXT* cntxt,
-                              EnvironmentProxy* parent)
-        : validREnv_{false}, createEnvironment_{eager},
-          ctxt_{call, callee, ap, cntxt}, parent_{parent} {}
+                              ArgumentListProxy* ap, EnvironmentProxy* parent)
+        : validREnv_{false}, createEnvironment_{eager}, ctxt_{call, callee, ap},
+          parent_{parent} {}
 
     void init();
 

--- a/rir/src/interpreter/call_support.h
+++ b/rir/src/interpreter/call_support.h
@@ -19,27 +19,21 @@ class ArgumentListProxy {
         SEXP argslist_;
         struct {
             Code* caller;
-            SEXP call;
             bool onStack;
-            uint32_t nargs;
-            CallSite* cs;
-            EnvironmentProxy* ep;
+            uint32_t id;
         } ctxt_;
     };
 
-    void create();
+    void create(EnvironmentProxy* ep);
 
   public:
     explicit ArgumentListProxy(SEXP argslist) : argslist_{argslist} {}
-    explicit ArgumentListProxy(Code* caller, SEXP call, bool argsOnStack,
-                               uint32_t nargs, CallSite* cs,
-                               EnvironmentProxy* ep)
-        : validArgslist_{false},
-          ctxt_{caller, call, argsOnStack, nargs, cs, ep} {}
+    explicit ArgumentListProxy(Code* caller, bool argsOnStack, uint32_t id)
+        : validArgslist_{false}, ctxt_{caller, argsOnStack, id} {}
 
-    SEXP argslist() {
+    SEXP argslist(EnvironmentProxy* ep) {
         if (!validArgslist_)
-            create();
+            create(ep);
         return argslist_;
     }
 

--- a/rir/src/interpreter/call_support.h
+++ b/rir/src/interpreter/call_support.h
@@ -24,7 +24,6 @@ class ArgumentListProxy {
             uint32_t nargs;
             CallSite* cs;
             EnvironmentProxy* ep;
-            Context* ctx;
         } ctxt_;
     };
 
@@ -34,9 +33,9 @@ class ArgumentListProxy {
     explicit ArgumentListProxy(SEXP argslist) : argslist_{argslist} {}
     explicit ArgumentListProxy(Code* caller, SEXP call, bool argsOnStack,
                                uint32_t nargs, CallSite* cs,
-                               EnvironmentProxy* ep, Context* ctx)
+                               EnvironmentProxy* ep)
         : validArgslist_{false},
-          ctxt_{caller, call, argsOnStack, nargs, cs, ep, ctx} {}
+          ctxt_{caller, call, argsOnStack, nargs, cs, ep} {}
 
     SEXP argslist() {
         if (!validArgslist_)

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1457,9 +1457,9 @@ SEXP evalRirCode(Code* c, Context* ctx, EnvironmentProxy* ep) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            SEXP closure = ostack_at(ctx, 0); // get the closure itself
-            res = doCall(c, closure, false, n, id, ep, ctx);
-            ostack_pop(ctx);
+            SEXP callee = ostack_at(ctx, 0);
+            res = doCall(c, callee, false, n, id, ep, ctx);
+            ostack_pop(ctx); // callee
             ostack_push(ctx, res);
             NEXT();
         }
@@ -1469,8 +1469,8 @@ SEXP evalRirCode(Code* c, Context* ctx, EnvironmentProxy* ep) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            SEXP closure = ostack_at(ctx, n);
-            res = doCall(c, closure, true, n, id, ep, ctx);
+            SEXP callee = ostack_at(ctx, n);
+            res = doCall(c, callee, true, n, id, ep, ctx);
             ostack_pop(ctx); // callee
             ostack_push(ctx, res);
             NEXT();
@@ -1481,8 +1481,8 @@ SEXP evalRirCode(Code* c, Context* ctx, EnvironmentProxy* ep) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            SEXP closure = cp_pool_at(ctx, *c->callSite(id)->target());
-            res = doCall(c, closure, true, n, id, ep, ctx);
+            SEXP callee = cp_pool_at(ctx, *c->callSite(id)->target());
+            res = doCall(c, callee, true, n, id, ep, ctx);
             ostack_push(ctx, res);
             NEXT();
         }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1226,6 +1226,27 @@ SEXP evalRirCode(Code* c, Context* ctx, EnvironmentProxy* ep) {
 
         INSTRUCTION(nop_) NEXT();
 
+        INSTRUCTION(make_env_) {
+            SEXP parent = ostack_pop(ctx);
+            assert(TYPEOF(parent) == ENVSXP &&
+                   "Non-environment used as environment parent.");
+            res = Rf_NewEnvironment(R_NilValue, R_NilValue, parent);
+            ostack_push(ctx, res);
+            NEXT();
+        }
+
+        INSTRUCTION(get_env_) {
+            ostack_push(ctx, ep->env());
+            NEXT();
+        }
+
+        INSTRUCTION(set_env_) {
+            SEXP e = ostack_pop(ctx);
+            assert(TYPEOF(e) == ENVSXP && "Expected an environment on TOS.");
+            ep->set(e);
+            NEXT();
+        }
+
         INSTRUCTION(ldfun_) {
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -614,7 +614,7 @@ SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
         if (argsOnStack)
             call = p(fixupAST(call, ctx, nargs));
 
-        ArgumentListProxy ap(caller, call, argsOnStack, nargs, cs, ep, ctx);
+        ArgumentListProxy ap(caller, call, argsOnStack, nargs, cs, ep);
 
         result = rirCallClosure(call, callee, &ap, ep, ctx);
 
@@ -758,15 +758,15 @@ void ArgumentListProxy::create() {
     SEXP argslist;
     if (ctxt_.onStack) {
         argslist = createArgsListStack(ctxt_.caller, ctxt_.nargs, ctxt_.cs,
-                                       ctxt_.ep, ctxt_.ctx, false);
-        ostack_popn(ctxt_.ctx, ctxt_.nargs);
+                                       ctxt_.ep, globalContext(), false);
+        ostack_popn(globalContext(), ctxt_.nargs);
         // Also patch the node stack top in the context -- arguments need
         // to be removed in case of non-local return
         RCNTXT* cntxt = findClosureReturnContext();
         cntxt->nodestack -= ctxt_.nargs;
     } else {
         argslist = createArgsList(ctxt_.caller, ctxt_.call, ctxt_.nargs,
-                                  ctxt_.cs, ctxt_.ep, ctxt_.ctx, false);
+                                  ctxt_.cs, ctxt_.ep, globalContext(), false);
     }
 
     argslist_ = argslist;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3,11 +3,11 @@
 
 #include "R/Funtab.h"
 #include "R/Protect.h"
+#include "call_support.h"
 #include "interp.h"
 #include "interp_context.h"
 #include "interpreter/deoptimizer.h"
 #include "runtime.h"
-#include "runtime/DispatchTable.h"
 
 #define NOT_IMPLEMENTED assert(false)
 
@@ -152,6 +152,7 @@ void tryOptimizeClosure(DispatchTable* table, size_t offset, Context* ctx) {
                 fun->invocationCount = oldFun->invocationCount;
                 fun->envLeaked = oldFun->envLeaked;
                 fun->envChanged = oldFun->envChanged;
+                fun->signature = oldFun->signature;
 
                 // Update the dispatch table
                 table->put(offset, fun);
@@ -165,7 +166,7 @@ void closureDebug(SEXP call, SEXP op, SEXP rho, SEXP newrho, RCNTXT* cntxt) {
     // TODO!!!
 }
 
-void endClosureDebug(SEXP op, SEXP call, SEXP rho) {
+void endClosureDebug(SEXP call, SEXP op, SEXP rho) {
     // TODO!!!
 }
 
@@ -190,8 +191,8 @@ INLINE void __listAppend(SEXP* front, SEXP* last, SEXP value, SEXP name) {
     *last = app;
 }
 
-SEXP createArgsListStack(Code* c, size_t nargs, CallSite* cs, SEXP env,
-                         Context* ctx, bool eager) {
+SEXP createArgsListStack(Code* c, size_t nargs, CallSite* cs,
+                         EnvironmentProxy* ep, Context* ctx, bool eager) {
     SEXP result = R_NilValue;
     SEXP pos = result;
 
@@ -207,12 +208,12 @@ SEXP createArgsListStack(Code* c, size_t nargs, CallSite* cs, SEXP env,
             // We have to wrap them in a promise, otherwise they are treated
             // as expressions to be evaluated, when in fact they are meant to be
             // asts as values
-            SEXP promise = Rf_mkPROMISE(arg, env);
+            SEXP promise = Rf_mkPROMISE(arg, ep->env());
             SET_PRVALUE(promise, arg);
             __listAppend(&result, &pos, promise, R_NilValue);
         } else {
             if (eager && TYPEOF(arg) == PROMSXP) {
-                arg = Rf_eval(arg, env);
+                arg = Rf_eval(arg, ep->env());
             }
             __listAppend(&result, &pos, arg, name);
         }
@@ -223,8 +224,8 @@ SEXP createArgsListStack(Code* c, size_t nargs, CallSite* cs, SEXP env,
     return result;
 }
 
-SEXP createArgsList(Code* c, SEXP call, size_t nargs, CallSite* cs, SEXP env,
-                    Context* ctx, bool eager) {
+SEXP createArgsList(Code* c, SEXP call, size_t nargs, CallSite* cs,
+                    EnvironmentProxy* ep, Context* ctx, bool eager) {
     SEXP result = R_NilValue;
     SEXP pos = result;
 
@@ -240,18 +241,18 @@ SEXP createArgsList(Code* c, SEXP call, size_t nargs, CallSite* cs, SEXP env,
         // and
         // flatten the ellipsis
         if (argi == DOTS_ARG_IDX) {
-            SEXP ellipsis = findVar(R_DotsSymbol, env);
+            SEXP ellipsis = Rf_findVar(R_DotsSymbol, ep->env());
             if (TYPEOF(ellipsis) == DOTSXP) {
                 while (ellipsis != R_NilValue) {
                     name = TAG(ellipsis);
                     if (eager) {
                         SEXP arg = CAR(ellipsis);
                         if (arg != R_MissingArg)
-                            arg = Rf_eval(CAR(ellipsis), env);
+                            arg = Rf_eval(CAR(ellipsis), ep->env());
                         assert(TYPEOF(arg) != PROMSXP);
                         __listAppend(&result, &pos, arg, name);
                     } else {
-                        SEXP promise = Rf_mkPROMISE(CAR(ellipsis), env);
+                        SEXP promise = Rf_mkPROMISE(CAR(ellipsis), ep->env());
                         __listAppend(&result, &pos, promise, name);
                     }
                     ellipsis = CDR(ellipsis);
@@ -263,13 +264,12 @@ SEXP createArgsList(Code* c, SEXP call, size_t nargs, CallSite* cs, SEXP env,
             __listAppend(&result, &pos, R_MissingArg, R_NilValue);
         } else {
             if (eager) {
-                SEXP arg =
-                    evalRirCode(c->function()->codeAt(argi), ctx, env, 0);
+                SEXP arg = evalRirCode(c->function()->codeAt(argi), ctx, ep);
                 assert(TYPEOF(arg) != PROMSXP);
                 __listAppend(&result, &pos, arg, name);
             } else {
                 Code* arg = c->function()->codeAt(argi);
-                SEXP promise = createPromise(arg, env);
+                SEXP promise = createPromise(arg, ep->env());
                 __listAppend(&result, &pos, promise, name);
             }
         }
@@ -295,7 +295,7 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
         hashed.  */
     SEXP newrho, a, f;
 
-    SEXP actuals = matchArgs(FORMALS(op), arglist, call);
+    SEXP actuals = Rf_matchArgs(FORMALS(op), arglist, call);
     PROTECT(newrho = Rf_NewEnvironment(FORMALS(op), actuals, CLOENV(op)));
 
     /* Turn on reference counting for the binding cells so local
@@ -342,7 +342,7 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
     /*  Fix up any extras that were supplied by usemethod. */
 
     if (suppliedvars != R_NilValue)
-        addMissingVarsToNewEnv(newrho, suppliedvars);
+        Rf_addMissingVarsToNewEnv(newrho, suppliedvars);
 
     if (R_envHasNoSpecialSymbols(newrho))
         SET_NO_SPECIAL_SYMBOLS(newrho);
@@ -354,59 +354,49 @@ static SEXP closureArgumentAdaptor(SEXP call, SEXP op, SEXP arglist, SEXP rho,
     return newrho;
 }
 
-SEXP rirCallTrampoline(RCNTXT* cntxt, Code* code, SEXP env, unsigned nargs,
+SEXP rirCallTrampoline(RCNTXT* cntxt, Code* code, EnvironmentProxy* ep,
                        Context* ctx) {
     if ((SETJMP(cntxt->cjmpbuf))) {
         if (R_ReturnedValue == R_RestartToken) {
             cntxt->callflag = CTXT_RETURN; /* turn restart off */
             R_ReturnedValue = R_NilValue;  /* remove restart token */
-            return evalRirCode(code, ctx, env, nargs);
+            return evalRirCode(code, ctx, ep);
         } else {
             return R_ReturnedValue;
         }
     }
-    return evalRirCode(code, ctx, env, nargs);
+    return evalRirCode(code, ctx, ep);
 }
 
-static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
-                           unsigned nargs, Context* ctx) {
+static SEXP rirCallClosure(SEXP call, SEXP callee, ArgumentListProxy* ap,
+                           EnvironmentProxy* ep, Context* ctx) {
 
     DispatchTable* vtable = DispatchTable::unpack(BODY(callee));
     Function* fun = vtable->first();
-
-    // NOTE(mhyee): The introduction of a dispatch table for different function
-    // versions changes many things. This function handles a closure call, and
-    // will optimize the closure function and update the linked list of
-    // functions, so that subsequent closure calls pick the most optimized
-    // version.
-    // This does not introduce a new item into the dispatch table!
 
     tryOptimizeClosure(vtable, 0, ctx);
 
     fun->registerInvocation();
 
-    // match formal arguments and create the env of this new activation record
-    SEXP newEnv =
-        closureArgumentAdaptor(call, callee, actuals, env, R_NilValue);
-
-    ostack_push(ctx, newEnv);
-
     RCNTXT cntxt;
-    initClosureContext(&cntxt, call, newEnv, env, actuals, callee);
+    initClosureContext(&cntxt, call, R_NilValue, ep->env(), R_NilValue, callee);
+
+    EnvironmentProxy newEp(fun->signature->createEnvironment, call, callee, ap,
+                           &cntxt, ep);
 
     // Exec the closure
-    closureDebug(call, callee, env, newEnv, &cntxt);
+    closureDebug(call, callee, ep->env(), R_NilValue, &cntxt);
+
     Code* code = fun->body();
+    SEXP result = rirCallTrampoline(&cntxt, code, &newEp, ctx);
 
-    SEXP result = rirCallTrampoline(&cntxt, code, newEnv, nargs, ctx);
-
-    endClosureDebug(callee, call, env);
+    endClosureDebug(call, callee, ep->env());
 
     endClosureContext(&cntxt, result);
 
-    if (!fun->envLeaked && FRAME_LEAKED(newEnv))
+    if (!fun->envLeaked && FRAME_LEAKED(newEp.env()))
         fun->envLeaked = true;
-    if (!fun->envChanged && FRAME_CHANGED(newEnv))
+    if (!fun->envChanged && FRAME_CHANGED(newEp.env()))
         fun->envChanged = true;
 
     if (fun->deopt) {
@@ -414,7 +404,6 @@ static SEXP rirCallClosure(SEXP call, SEXP env, SEXP callee, SEXP actuals,
         // SET_BODY(callee, fun->origin);
     }
 
-    ostack_pop(ctx); // newEnv
     return result;
 }
 
@@ -533,11 +522,17 @@ INLINE SEXP fixupAST(SEXP call, Context* ctx, size_t nargs) {
     return call;
 }
 
-SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
-            uint32_t id, SEXP env, Context* ctx) {
+INLINE bool callingR(SEXP callee) {
+    return TYPEOF(callee) == SPECIALSXP || TYPEOF(callee) == BUILTINSXP ||
+           (TYPEOF(callee) == CLOSXP && TYPEOF(BODY(callee)) != EXTERNALSXP);
+}
 
-    assert(TYPEOF(callee) == SPECIALSXP || TYPEOF(callee) == BUILTINSXP ||
-           TYPEOF(callee) == CLOSXP);
+INLINE bool callingRir(SEXP callee) {
+    return TYPEOF(callee) == CLOSXP && TYPEOF(BODY(callee)) == EXTERNALSXP;
+}
+
+SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
+            uint32_t id, EnvironmentProxy* ep, Context* ctx) {
 
     CallSite* cs = caller->callSite(id);
     SEXP call = cp_pool_at(ctx, cs->call);
@@ -546,80 +541,93 @@ SEXP doCall(Code* caller, SEXP callee, bool argsOnStack, uint32_t nargs,
 
     SEXP result = nullptr;
 
-    do {
-        // ===============================================
-        // SPECIALSXPs do not take argslist
-        if (TYPEOF(callee) == SPECIALSXP) {
-            assert(call != R_NilValue);
+    if (callingR(callee)) {
+
+        do {
+            // ===============================================
+            // SPECIALSXPs do not take argslist
+            if (TYPEOF(callee) == SPECIALSXP) {
+                assert(call != R_NilValue);
+                Protect p;
+                if (argsOnStack) {
+                    call = fixupAST(call, ctx, nargs);
+                    p(call);
+                    ostack_popn(ctx, nargs);
+                }
+                // get the ccode
+                CCODE f = getBuiltin(callee);
+                int flag = getFlag(callee);
+                R_Visible = static_cast<Rboolean>(flag != 1);
+                warnSpecial(callee, call);
+                // call it with the AST only
+                result = f(call, callee, CDR(call), ep->env());
+                if (flag < 2)
+                    R_Visible = static_cast<Rboolean>(flag != 1);
+                break;
+            }
+
+            // ===============================================
+            // BUILTINSXP or CLOSXP
+
+            // create the argslist
+            bool eager = TYPEOF(callee) == BUILTINSXP;
+            SEXP argslist;
             Protect p;
             if (argsOnStack) {
                 call = fixupAST(call, ctx, nargs);
                 p(call);
+                argslist =
+                    createArgsListStack(caller, nargs, cs, ep, ctx, eager);
                 ostack_popn(ctx, nargs);
-            }
-            // get the ccode
-            CCODE f = getBuiltin(callee);
-            int flag = getFlag(callee);
-            R_Visible = static_cast<Rboolean>(flag != 1);
-            warnSpecial(callee, call);
-            // call it with the AST only
-            result = f(call, callee, CDR(call), env);
-            if (flag < 2)
-                R_Visible = static_cast<Rboolean>(flag != 1);
-            break;
-        }
-
-        // ===============================================
-        // BUILTINSXP or CLOSXP
-
-        // create the argslist
-        bool eager = TYPEOF(callee) == BUILTINSXP;
-        SEXP argslist;
-        Protect p;
-        if (argsOnStack) {
-            call = fixupAST(call, ctx, nargs);
-            p(call);
-            argslist = createArgsListStack(caller, nargs, cs, env, ctx, eager);
-            ostack_popn(ctx, nargs);
-        } else {
-            argslist = createArgsList(caller, call, nargs, cs, env, ctx, eager);
-        }
-        p(argslist);
-
-        if (TYPEOF(callee) == BUILTINSXP) {
-            // get the ccode
-            CCODE f = getBuiltin(callee);
-            int flag = getFlag(callee);
-            if (flag < 2)
-                R_Visible = static_cast<Rboolean>(flag != 1);
-            // call it
-            result = f(call, callee, argslist, env);
-            if (flag < 2)
-                R_Visible = static_cast<Rboolean>(flag != 1);
-            break;
-        }
-
-        if (TYPEOF(callee) == CLOSXP) {
-            // if body is EXTERNALSXP, it is rir serialized code, execute it
-            // directly
-            SEXP body = BODY(callee);
-            if (TYPEOF(body) == EXTERNALSXP) {
-                assert(isValidDispatchTableSEXP(body));
-                result =
-                    rirCallClosure(call, env, callee, argslist, nargs, ctx);
             } else {
-                result = applyClosure(call, callee, argslist, env, R_NilValue);
+                argslist =
+                    createArgsList(caller, call, nargs, cs, ep, ctx, eager);
             }
-            break;
-        }
-    } while (false);
+            p(argslist);
+
+            if (TYPEOF(callee) == BUILTINSXP) {
+                // get the ccode
+                CCODE f = getBuiltin(callee);
+                int flag = getFlag(callee);
+                if (flag < 2)
+                    R_Visible = static_cast<Rboolean>(flag != 1);
+                // call it
+                result = f(call, callee, argslist, ep->env());
+                if (flag < 2)
+                    R_Visible = static_cast<Rboolean>(flag != 1);
+                break;
+            }
+
+            if (TYPEOF(callee) == CLOSXP) {
+                result = Rf_applyClosure(call, callee, argslist, ep->env(),
+                                         R_NilValue);
+                break;
+            }
+        } while (false);
+
+    } else if (callingRir(callee)) {
+
+        SEXP body = BODY(callee);
+        assert(isValidDispatchTableSEXP(body));
+
+        Protect p;
+        if (argsOnStack)
+            call = p(fixupAST(call, ctx, nargs));
+
+        ArgumentListProxy ap(caller, call, argsOnStack, nargs, cs, ep, ctx);
+
+        result = rirCallClosure(call, callee, &ap, ep, ctx);
+
+    } else {
+        assert(false && "Don't know how to run other stuff");
+    }
 
     assert(result);
     return result;
 }
 
 SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
-                SEXP env, Context* ctx) {
+                EnvironmentProxy* ep, Context* ctx) {
 
     SEXP obj = argsOnStack ? ostack_at(ctx, nargs - 1) : ostack_top(ctx);
     assert(isObject(obj));
@@ -632,21 +640,19 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
     profileCall(cs, Rf_install("*dispatch*"));
 
     SEXP actuals;
-    {
-        if (argsOnStack) {
-            call = fixupAST(call, ctx, nargs);
-            Protect p(call);
-            actuals = createArgsListStack(caller, nargs, cs, env, ctx, true);
-            ostack_popn(ctx, nargs);
-            ostack_push(ctx, actuals);
-            ostack_push(ctx, call);
-        } else {
-            actuals = createArgsList(caller, call, nargs, cs, env, ctx, false);
-            ostack_push(ctx, actuals);
-            // Patch the already evaluated object into the first entry of
-            // the promise args list
-            SET_PRVALUE(CAR(actuals), obj);
-        }
+    if (argsOnStack) {
+        call = fixupAST(call, ctx, nargs);
+        Protect p(call);
+        actuals = createArgsListStack(caller, nargs, cs, ep, ctx, true);
+        ostack_popn(ctx, nargs);
+        ostack_push(ctx, actuals);
+        ostack_push(ctx, call);
+    } else {
+        actuals = createArgsList(caller, call, nargs, cs, ep, ctx, false);
+        ostack_push(ctx, actuals);
+        // Patch the already evaluated object into the first entry of
+        // the promise args list
+        SET_PRVALUE(CAR(actuals), obj);
     }
 
     SEXP result = nullptr;
@@ -654,7 +660,7 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
         // ===============================================
         // First try S4
         if (IS_S4_OBJECT(obj) && R_has_methods(op)) {
-            result = R_possible_dispatch(call, op, actuals, env, TRUE);
+            result = R_possible_dispatch(call, op, actuals, ep->env(), TRUE);
             if (result) {
                 break;
             }
@@ -663,12 +669,12 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
         // ===============================================
         // Then try S3
         const char* generic = CHAR(PRINTNAME(selector));
-        SEXP rho1 = Rf_NewEnvironment(R_NilValue, R_NilValue, env);
+        SEXP rho1 = Rf_NewEnvironment(R_NilValue, R_NilValue, ep->env());
         ostack_push(ctx, rho1);
         RCNTXT cntxt;
-        initClosureContext(&cntxt, call, rho1, env, actuals, op);
-        bool success = Rf_usemethod(generic, obj, call, actuals, rho1, env,
-                                    R_BaseEnv, &result);
+        initClosureContext(&cntxt, call, rho1, ep->env(), actuals, op);
+        bool success = Rf_usemethod(generic, obj, call, actuals, rho1,
+                                    ep->env(), R_BaseEnv, &result);
         ostack_pop(ctx);
         endClosureContext(&cntxt, success ? result : R_NilValue);
         if (success) {
@@ -677,7 +683,7 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
 
         // ===============================================
         // Now normal dispatch
-        SEXP callee = Rf_findFun(selector, env);
+        SEXP callee = Rf_findFun(selector, ep->env());
 
         // TODO something should happen here
         if (callee == R_UnboundValue)
@@ -693,7 +699,7 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
             R_Visible = static_cast<Rboolean>(flag != 1);
             warnSpecial(callee, call);
             // call it with the AST only
-            result = f(call, callee, CDR(call), env);
+            result = f(call, callee, CDR(call), ep->env());
             if (flag < 2)
                 R_Visible = static_cast<Rboolean>(flag != 1);
             break;
@@ -703,12 +709,12 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
             CCODE f = getBuiltin(callee);
             // force all promises in the args list
             for (SEXP a = actuals; a != R_NilValue; a = CDR(a))
-                SETCAR(a, Rf_eval(CAR(a), env));
+                SETCAR(a, Rf_eval(CAR(a), ep->env()));
             int flag = getFlag(callee);
             if (flag < 2)
                 R_Visible = static_cast<Rboolean>(flag != 1);
             // call it
-            result = f(call, callee, actuals, env);
+            result = f(call, callee, actuals, ep->env());
             if (flag < 2)
                 R_Visible = static_cast<Rboolean>(flag != 1);
             break;
@@ -719,9 +725,11 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
             SEXP body = BODY(callee);
             if (TYPEOF(body) == EXTERNALSXP) {
                 assert(isValidDispatchTableSEXP(body));
-                result = rirCallClosure(call, env, callee, actuals, nargs, ctx);
+                ArgumentListProxy ap(actuals);
+                result = rirCallClosure(call, callee, &ap, ep, ctx);
             } else {
-                result = applyClosure(call, callee, actuals, env, R_NilValue);
+                result = Rf_applyClosure(call, callee, actuals, ep->env(),
+                                         R_NilValue);
             }
             break;
         }
@@ -733,6 +741,43 @@ SEXP doDispatch(Code* caller, bool argsOnStack, uint32_t nargs, uint32_t id,
     ostack_popn(ctx, 2);
     assert(result);
     return result;
+}
+
+void ArgumentListProxy::create() {
+
+    SEXP argslist;
+    if (ctxt_.onStack) {
+        argslist = createArgsListStack(ctxt_.caller, ctxt_.nargs, ctxt_.cs,
+                                       ctxt_.ep, ctxt_.ctx, false);
+        ostack_popn(ctxt_.ctx, ctxt_.nargs);
+    } else {
+        argslist = createArgsList(ctxt_.caller, ctxt_.call, ctxt_.nargs,
+                                  ctxt_.cs, ctxt_.ep, ctxt_.ctx, false);
+    }
+
+    argslist_ = argslist;
+    validArgslist_ = true;
+}
+
+void EnvironmentProxy::init() {
+    if (validREnv_)
+        return;
+    if (!createEnvironment_)
+        return;
+
+    SEXP argslist = ctxt_.ap->argslist();
+    Protect p(argslist);
+    SEXP env = closureArgumentAdaptor(ctxt_.call, ctxt_.callee, argslist,
+                                      parent_->env(), R_NilValue);
+
+    // This patches the missing values in the return context of this
+    // closure call. From now, they are also protected during gc
+    // (contexts are considered roots by the collector).
+    ctxt_.cntxt->promargs = argslist;
+    ctxt_.cntxt->cloenv = env;
+
+    env_ = env;
+    validREnv_ = true;
 }
 
 #define R_INT_MAX INT_MAX
@@ -800,7 +845,7 @@ enum op { PLUSOP, MINUSOP, TIMESOP, DIVOP, POWOP, MODOP, IDIVOP };
         static CCODE blt;                                                      \
         static int flag;                                                       \
         if (!prim) {                                                           \
-            prim = findFun(Rf_install(op), R_GlobalEnv);                       \
+            prim = Rf_findFun(Rf_install(op), R_GlobalEnv);                    \
             blt = getBuiltin(prim);                                            \
             flag = getFlag(prim);                                              \
         }                                                                      \
@@ -809,7 +854,7 @@ enum op { PLUSOP, MINUSOP, TIMESOP, DIVOP, POWOP, MODOP, IDIVOP };
         ostack_push(ctx, argslist);                                            \
         if (flag < 2)                                                          \
             R_Visible = static_cast<Rboolean>(flag != 1);                      \
-        res = blt(call, prim, argslist, env);                                  \
+        res = blt(call, prim, argslist, ep->env());                            \
         if (flag < 2)                                                          \
             R_Visible = static_cast<Rboolean>(flag != 1);                      \
         ostack_pop(ctx);                                                       \
@@ -934,7 +979,7 @@ static R_INLINE int R_integer_uminus(int x, Rboolean* pnaflag) {
         static CCODE blt;                                                      \
         static int flag;                                                       \
         if (!prim) {                                                           \
-            prim = findFun(Rf_install(op), R_GlobalEnv);                       \
+            prim = Rf_findFun(Rf_install(op), R_GlobalEnv);                    \
             blt = getBuiltin(prim);                                            \
             flag = getFlag(prim);                                              \
         }                                                                      \
@@ -943,7 +988,7 @@ static R_INLINE int R_integer_uminus(int x, Rboolean* pnaflag) {
         ostack_push(ctx, argslist);                                            \
         if (flag < 2)                                                          \
             R_Visible = static_cast<Rboolean>(flag != 1);                      \
-        res = blt(call, prim, argslist, env);                                  \
+        res = blt(call, prim, argslist, ep->env());                            \
         if (flag < 2)                                                          \
             R_Visible = static_cast<Rboolean>(flag != 1);                      \
         ostack_pop(ctx);                                                       \
@@ -1115,7 +1160,7 @@ static SEXP cachedGetVar(SEXP env, Immediate idx, Context* ctx,
     }
     SEXP sym = cp_pool_at(ctx, idx);
     SLOWASSERT(TYPEOF(sym) == SYMSXP);
-    return findVar(sym, env);
+    return Rf_findVar(sym, env);
 }
 
 #define ACTIVE_BINDING_MASK (1 << 15)
@@ -1144,7 +1189,7 @@ static void cachedSetVar(SEXP val, SEXP env, Immediate idx, Context* ctx,
     UNPROTECT(1);
 }
 
-SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
+SEXP evalRirCode(Code* c, Context* ctx, EnvironmentProxy* ep) {
 
 #ifdef THREADED_CODE
     static void* opAddr[static_cast<uint8_t>(Opcode::num_of)] = {
@@ -1156,19 +1201,13 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
 
     assert(c->magic == CODE_MAGIC);
 
+    ep->init();
+
     Locals locals(c->localsCount);
-    locals.store(0, env);
+    locals.store(0, ep->env()); // prob remove this..
 
     BindingCache bindingCache[BINDING_CACHE_SIZE];
     memset(&bindingCache, 0, sizeof(bindingCache));
-
-    if (!env) {
-        error("'rho' cannot be C NULL: detected in C-level eval");
-    }
-    if (!isEnvironment(env)) {
-        error("'rho' must be an environment not %s: detected in C-level eval",
-              type2char(TYPEOF(env)));
-    }
 
     // make sure there is enough room on the stack
     // there is some slack of 5 to make sure the call instruction can store
@@ -1190,7 +1229,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldfun_) {
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
-            res = findFun(sym, env);
+            res = Rf_findFun(sym, ep->env());
 
             // TODO something should happen here
             if (res == R_UnboundValue)
@@ -1216,7 +1255,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldvar_) {
             Immediate id = readImmediate();
             advanceImmediate();
-            res = cachedGetVar(env, id, ctx, bindingCache);
+            res = cachedGetVar(ep->env(), id, ctx, bindingCache);
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
@@ -1241,7 +1280,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldvar2_) {
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
-            res = findVar(sym, ENCLOS(env));
+            res = Rf_findVar(sym, ENCLOS(ep->env()));
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
@@ -1265,7 +1304,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldddvar_) {
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
-            res = Rf_ddfindVar(sym, env);
+            res = Rf_ddfindVar(sym, ep->env());
             R_Visible = TRUE;
 
             // TODO better errors
@@ -1289,7 +1328,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldlval_) {
             Immediate id = readImmediate();
             advanceImmediate();
-            res = cachedGetBindingCell(env, id, ctx, bindingCache);
+            res = cachedGetBindingCell(ep->env(), id, ctx, bindingCache);
             assert(res);
             res = CAR(res);
             assert(res != R_UnboundValue);
@@ -1312,7 +1351,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(ldarg_) {
             Immediate id = readImmediate();
             advanceImmediate();
-            res = cachedGetBindingCell(env, id, ctx, bindingCache);
+            res = cachedGetBindingCell(ep->env(), id, ctx, bindingCache);
             assert(res);
             res = CAR(res);
             assert(res != R_UnboundValue);
@@ -1349,13 +1388,13 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(stvar_) {
             Immediate id = readImmediate();
             advanceImmediate();
-            int wasChanged = FRAME_CHANGED(env);
+            int wasChanged = FRAME_CHANGED(ep->env());
             SEXP val = ostack_pop(ctx);
 
-            cachedSetVar(val, env, id, ctx, bindingCache);
+            cachedSetVar(val, ep->env(), id, ctx, bindingCache);
 
             if (!wasChanged)
-                CLEAR_FRAME_CHANGED(env);
+                CLEAR_FRAME_CHANGED(ep->env());
             NEXT();
         }
 
@@ -1365,7 +1404,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             SLOWASSERT(TYPEOF(sym) == SYMSXP);
             SEXP val = ostack_pop(ctx);
             INCREMENT_NAMED(val);
-            setVar(sym, val, ENCLOS(env));
+            setVar(sym, val, ENCLOS(ep->env()));
             NEXT();
         }
 
@@ -1382,9 +1421,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            // get the closure itself
-            res = ostack_at(ctx, 0);
-            res = doCall(c, res, false, n, id, env, ctx);
+            SEXP closure = ostack_at(ctx, 0); // get the closure itself
+            res = doCall(c, closure, false, n, id, ep, ctx);
             ostack_pop(ctx);
             ostack_push(ctx, res);
             NEXT();
@@ -1396,7 +1434,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             Immediate n = readImmediate();
             advanceImmediate();
             res = ostack_at(ctx, n);
-            res = doCall(c, res, true, n, id, env, ctx);
+            res = doCall(c, res, true, n, id, ep, ctx);
             ostack_pop(ctx); // callee
             ostack_push(ctx, res);
             NEXT();
@@ -1408,7 +1446,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             Immediate n = readImmediate();
             advanceImmediate();
             res = cp_pool_at(ctx, *c->callSite(id)->target());
-            res = doCall(c, res, true, n, id, env, ctx);
+            res = doCall(c, res, true, n, id, ep, ctx);
             ostack_push(ctx, res);
             NEXT();
         }
@@ -1418,7 +1456,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            ostack_push(ctx, doDispatch(c, false, n, id, env, ctx));
+            ostack_push(ctx, doDispatch(c, false, n, id, ep, ctx));
             NEXT();
         }
 
@@ -1427,7 +1465,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             Immediate n = readImmediate();
             advanceImmediate();
-            ostack_push(ctx, doDispatch(c, true, n, id, env, ctx));
+            ostack_push(ctx, doDispatch(c, true, n, id, ep, ctx));
             NEXT();
         }
 
@@ -1439,7 +1477,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             assert(isValidDispatchTableObject(body));
             SET_FORMALS(res, formals);
             SET_BODY(res, body);
-            SET_CLOENV(res, env);
+            SET_CLOENV(res, ep->env());
             Rf_setAttrib(res, Rf_install("srcref"), srcref);
             ostack_popn(ctx, 3);
             ostack_push(ctx, res);
@@ -1470,7 +1508,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             Code* promiseCode = c->function()->codeAt(id);
             // create the promise and push it on stack
-            ostack_push(ctx, createPromise(promiseCode, env));
+            ostack_push(ctx, createPromise(promiseCode, ep->env()));
             NEXT();
         }
 
@@ -1929,7 +1967,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             SLOWASSERT(TYPEOF(sym) == SYMSXP);
             SLOWASSERT(!DDVAL(sym));
-            SEXP val = R_findVarLocInFrame(env, sym).cell;
+            SEXP val = R_findVarLocInFrame(ep->env(), sym).cell;
             if (val == NULL)
                 errorcall(getSrcAt(c, pc - 1, ctx),
                           "'missing' can only be used for arguments");
@@ -2007,7 +2045,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             SEXP args = CONS_NR(idx, R_NilValue);
             args = CONS_NR(val, args);
             ostack_push(ctx, args);
-            res = do_subset_dflt(R_NilValue, R_SubsetSym, args, env);
+            res = do_subset_dflt(R_NilValue, R_SubsetSym, args, ep->env());
             ostack_popn(ctx, 3);
 
             R_Visible = TRUE;
@@ -2024,7 +2062,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             args = CONS_NR(idx, args);
             args = CONS_NR(val, args);
             ostack_push(ctx, args);
-            res = do_subset_dflt(R_NilValue, R_SubsetSym, args, env);
+            res = do_subset_dflt(R_NilValue, R_SubsetSym, args, ep->env());
             ostack_popn(ctx, 4);
 
             R_Visible = TRUE;
@@ -2042,7 +2080,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             args = CONS_NR(idx, args);
             args = CONS_NR(orig, args);
             PROTECT(args);
-            res = do_subassign_dflt(R_NilValue, R_SubassignSym, args, env);
+            res =
+                do_subassign_dflt(R_NilValue, R_SubassignSym, args, ep->env());
             ostack_popn(ctx, 3);
             UNPROTECT(1);
 
@@ -2119,7 +2158,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             SEXP args = CONS_NR(idx, R_NilValue);
             args = CONS_NR(val, args);
             ostack_push(ctx, args);
-            res = do_subset2_dflt(R_NilValue, R_Subset2Sym, args, env);
+            res = do_subset2_dflt(R_NilValue, R_Subset2Sym, args, ep->env());
             ostack_popn(ctx, 3);
 
             R_Visible = TRUE;
@@ -2137,7 +2176,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             args = CONS_NR(idx, args);
             args = CONS_NR(val, args);
             ostack_push(ctx, args);
-            res = do_subset_dflt(R_NilValue, R_Subset2Sym, args, env);
+            res = do_subset_dflt(R_NilValue, R_Subset2Sym, args, ep->env());
             ostack_popn(ctx, 4);
 
             R_Visible = TRUE;
@@ -2177,9 +2216,9 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
                     // allocated
                     // vector
                     SEXP target = cp_pool_at(ctx, targetI);
-                    bool localBinding =
-                        (target == R_NilValue) ||
-                        !R_VARLOC_IS_NULL(R_findVarLocInFrame(env, target));
+                    bool localBinding = (target == R_NilValue) ||
+                                        !R_VARLOC_IS_NULL(R_findVarLocInFrame(
+                                            ep->env(), target));
 
                     if (localBinding) {
                         int idx_ = -1;
@@ -2232,7 +2271,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             args = CONS_NR(idx, args);
             args = CONS_NR(orig, args);
             PROTECT(args);
-            res = do_subassign2_dflt(R_NilValue, R_Subassign2Sym, args, env);
+            res = do_subassign2_dflt(R_NilValue, R_Subassign2Sym, args,
+                                     ep->env());
             ostack_popn(ctx, 3);
             UNPROTECT(1);
 
@@ -2247,7 +2287,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             advanceImmediate();
             advanceImmediate();
 #ifndef UNSOUND_OPTS
-            assert(res == findFun(sym, env) && "guard_fun_ fail");
+            assert(res == Rf_findFun(sym, ep->env()) && "guard_fun_ fail");
 #endif
             NEXT();
         }
@@ -2255,7 +2295,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(guard_env_) {
             uint32_t deoptId = readImmediate();
             advanceImmediate();
-            if (FRAME_CHANGED(env) || FRAME_LEAKED(env)) {
+            if (FRAME_CHANGED(ep->env()) || FRAME_LEAKED(ep->env())) {
                 Function* fun = c->function();
                 assert(fun->body() == c && "Cannot deopt from promise");
                 fun->deopt = true;
@@ -2275,11 +2315,11 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
                 // TODO: we could call seq.default here, but it messes up the
                 // error
                 // call :(
-                prim = findFun(Rf_install("seq"), R_GlobalEnv);
+                prim = Rf_findFun(Rf_install("seq"), R_GlobalEnv);
             }
 
             // TODO: add a real guard here...
-            assert(prim == findFun(Rf_install("seq"), env));
+            assert(prim == Rf_findFun(Rf_install("seq"), ep->env()));
 
             SEXP from = ostack_at(ctx, 2);
             SEXP to = ostack_at(ctx, 1);
@@ -2313,7 +2353,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
                 SEXP argslist =
                     CONS_NR(from, CONS_NR(to, CONS_NR(by, R_NilValue)));
                 ostack_push(ctx, argslist);
-                res = applyClosure(call, prim, argslist, env, R_NilValue);
+                res = applyClosure(call, prim, argslist, ep->env(), R_NilValue);
                 ostack_pop(ctx);
             }
 
@@ -2456,7 +2496,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
             Opcode** oldPc = (Opcode**)(cntxt + 1);
             *oldPc = pc;
 
-            Rf_begincontext(cntxt, CTXT_LOOP, R_NilValue, env, R_BaseEnv,
+            Rf_begincontext(cntxt, CTXT_LOOP, R_NilValue, ep->env(), R_BaseEnv,
                             R_NilValue, R_NilValue);
             // (ab)use the unused cenddata field to store sp
             cntxt->cenddata = (void*)ostack_length(ctx);
@@ -2498,7 +2538,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs) {
         INSTRUCTION(return_) {
             res = ostack_top(ctx);
             // this restores stack pointer to the value from the target context
-            Rf_findcontext(CTXT_BROWSER | CTXT_FUNCTION, env, res);
+            Rf_findcontext(CTXT_BROWSER | CTXT_FUNCTION, ep->env(), res);
             // not reached
             NEXT();
         }
@@ -2537,12 +2577,11 @@ SEXP rirExpr(SEXP f) {
 
 SEXP rirEval_f(SEXP what, SEXP env) {
     assert(TYPEOF(what) == EXTERNALSXP);
-    assert(TYPEOF(env) == ENVSXP);
 
-    // TODO we do not really need the arg counts now
+    EnvironmentProxy ep(env);
 
     if (isValidCodeObject(what))
-        return evalRirCode((Code*)what, globalContext(), env, 0);
+        return evalRirCode((Code*)what, globalContext(), &ep);
 
     if (DispatchTable::check(what)) {
         auto table = DispatchTable::unpack(what);
@@ -2553,7 +2592,7 @@ SEXP rirEval_f(SEXP what, SEXP env) {
         Function* fun = table->at(offset);
         fun->registerInvocation();
 
-        return evalRirCode(fun->body(), globalContext(), env, 0);
+        return evalRirCode(fun->body(), globalContext(), &ep);
     }
 
     assert(false && "Expected a code object or a dispatch table");

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -5,6 +5,7 @@
 
 #undef length
 
+#include "call_support.h"
 #include "interp_context.h"
 #include "interp_data.h"
 
@@ -12,7 +13,7 @@
 extern "C" {
 #endif
 
-SEXP evalRirCode(Code* c, Context* ctx, SEXP env, unsigned numArgs);
+SEXP evalRirCode(Code* c, Context* ctx, rir::EnvironmentProxy* ep);
 
 SEXP rirExpr(SEXP f);
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -71,6 +71,9 @@ bool BC::operator==(const BC& other) const {
         return immediate.loc == other.immediate.loc;
 
     case Opcode::nop_:
+    case Opcode::make_env_:
+    case Opcode::get_env_:
+    case Opcode::set_env_:
     case Opcode::extract1_1_:
     case Opcode::extract1_2_:
     case Opcode::extract2_1_:
@@ -191,6 +194,9 @@ void BC::write(CodeStream& cs) const {
         return;
 
     case Opcode::nop_:
+    case Opcode::make_env_:
+    case Opcode::get_env_:
+    case Opcode::set_env_:
     case Opcode::extract1_1_:
     case Opcode::extract1_2_:
     case Opcode::extract2_1_:
@@ -405,6 +411,9 @@ void BC::print(CallSite* cs) {
         Rprintf("\n");
         break;
     case Opcode::nop_:
+    case Opcode::make_env_:
+    case Opcode::get_env_:
+    case Opcode::set_env_:
     case Opcode::force_:
     case Opcode::pop_:
     case Opcode::seq_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -19,6 +19,9 @@ namespace rir {
 class CodeStream;
 
 BC BC::nop() { return BC(Opcode::nop_); }
+BC BC::makeEnv() { return BC(Opcode::make_env_); }
+BC BC::getEnv() { return BC(Opcode::get_env_); }
+BC BC::setEnv() { return BC(Opcode::set_env_); }
 BC BC::ret() { return BC(Opcode::ret_); }
 BC BC::return_() { return BC(Opcode::return_); }
 BC BC::force() { return BC(Opcode::force_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -225,6 +225,9 @@ class BC {
     // ==== Factory methods
     // to create new BC objects, which can be streamed to a CodeStream
     inline static BC nop();
+    inline static BC makeEnv();
+    inline static BC getEnv();
+    inline static BC setEnv();
     inline static BC push(SEXP constant);
     inline static BC push(double constant);
     inline static BC push(int constant);
@@ -435,6 +438,9 @@ class BC {
             immediate.loc = *(NumLocalsT*)pc;
             break;
         case Opcode::nop_:
+        case Opcode::make_env_:
+        case Opcode::get_env_:
+        case Opcode::set_env_:
         case Opcode::for_seq_size_:
         case Opcode::extract1_1_:
         case Opcode::extract2_1_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -27,7 +27,7 @@ DEF_INSTR(get_env_, 0, 0, 1, 1)
 /**
  * set_env_:: make tos environment the current env
  */
-DEF_INSTR(set_env_, 0, 1, 0, 1)
+DEF_INSTR(set_env_, 0, 1, 0, 0)
 
 /**
  * ldfun_:: take immediate CP index of symbol, find function bound to that name

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -10,12 +10,28 @@
 DEF_INSTR(invalid_, 0, 0, 0, 0)
 
 /**
-  * nop_:: do nothing.
-  */
+ * nop_:: do nothing.
+ */
 DEF_INSTR(nop_, 0, 0, 0, 1)
 
 /**
- * ldfun_:: take immediate CP index of symbol, find function bound to that name and push it on stack.
+ * make_env_:: create a new empty environment with the parent taken from TOS
+ */
+DEF_INSTR(make_env_, 0, 1, 1, 1)
+
+/**
+ * get_env_:: push current env to tos
+ */
+DEF_INSTR(get_env_, 0, 0, 1, 1)
+
+/**
+ * set_env_:: make tos environment the current env
+ */
+DEF_INSTR(set_env_, 0, 1, 0, 1)
+
+/**
+ * ldfun_:: take immediate CP index of symbol, find function bound to that name
+ * and push it on stack.
  */
 DEF_INSTR(ldfun_, 1, 0, 1, 0)
 

--- a/rir/src/runtime/FunctionSignature.h
+++ b/rir/src/runtime/FunctionSignature.h
@@ -57,6 +57,8 @@ struct FunctionSignature {
     }
 
     void print() const {
+        Rprintf("    environment?   %s\n",
+                createEnvironment ? "true" : "false");
         Rprintf("    on stack?      %s\n", argsOnStack ? "true" : "false");
         Rprintf("    args (%u):\n", arguments.size());
         for (auto arg : arguments)
@@ -66,6 +68,7 @@ struct FunctionSignature {
 
     FunctionSignature() = default;
 
+    bool createEnvironment = true;
     bool argsOnStack = false;
     std::vector<ArgumentType> arguments;
 };


### PR DESCRIPTION
This PR introduces two main changes in preparation for PIR and some minor code improvements.
1) Environments are now created on the callee side of a call. This is accomplished by using two classes called proxies to hold either the work that is already done, or data to make it possible to perform the work at a later time.
2) Some initial versions of environment manipulation instructions: making new and getting and setting current env.

I tried to make it nice, but I fear I failed... comments on how to achieve the delayed creation in a better way are welcome.