### PR TITLE
[travis] remove failing curl test and reenable ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - TEST_MC_CORES=$CORES ./tools/gnur-make-tests $CHECK
 
 cache:
+  ccache: true
   directories:
   - external
 


### PR DESCRIPTION
this updates the gnur repo, to disable a test and it also reenables ccache