### PR TITLE
Do not assume we know about absent values for tainted envs

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -249,9 +249,14 @@ class AbstractREnvironmentHierarchy
         while (env != UnknownParent) {
             if (this->count(env) == 0)
                 return AbstractLoad(env, AbstractPirValue::tainted());
-            const AbstractPirValue& res = this->at(env).get(e);
+            auto aenv = this->at(env);
+            const AbstractPirValue& res = aenv.get(e);
             if (!res.isUnknown())
                 return AbstractLoad(env, res);
+            // Tainted environment, we can't bet on absent values being
+            // actually absent.
+            if (aenv.tainted)
+                return AbstractLoad(env, AbstractPirValue::tainted());
             env = (*this).at(env).parentEnv;
         }
         return AbstractLoad(env, AbstractPirValue::tainted());


### PR DESCRIPTION
Our environment analysis did not correctly handle tainted envs.

For example in this case, with two environments:

    [a -> 1](tainted)  ->   [b -> 1]

when we load 'a' we know that it comes from the first env. But if
we load 'b', the first environment is tainted, so we do not
know if 'b' is really absent. therefore it could come from the
first, or second env.