### PR TITLE
 Closure conversion, sort of ;) 

### DIFF
--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -16,7 +16,7 @@ void ElideEnv::apply(Function* function) {
     Visitor::run(function->entry, [&](Instruction* i) {
         if (i->hasEnv() && !StVar::Cast(i))
             envNeeded.insert(i->env());
-        if (!Env::isEnv(i) && i->hasEnv())
+        if (!Env::isPirEnv(i) && i->hasEnv())
             envDependency[i] = i->env();
     });
 
@@ -34,12 +34,12 @@ void ElideEnv::apply(Function* function) {
         auto ip = bb->begin();
         while (ip != bb->end()) {
             Instruction* i = *ip;
-            if (Env::isEnv(i)) {
+            if (Env::isPirEnv(i)) {
                 if (envNeeded.find(i) == envNeeded.end())
                     ip = bb->remove(ip);
                 else
                     ip++;
-            } else if (i->hasEnv() &&
+            } else if (i->hasEnv() && Env::isPirEnv(i->env()) &&
                        envNeeded.find(i->env()) == envNeeded.end()) {
                 ip = bb->remove(ip);
             } else {

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -54,11 +54,10 @@ class TheInliner {
                     auto ip = bb->begin();
                     while (ip != bb->end()) {
                         auto next = ip + 1;
-                        auto m = MkEnv::Cast(*ip);
                         auto ld = LdArg::Cast(*ip);
-                        if (m) {
-                            if (m->parent() == Env::theContext())
-                                m->parent(cls->env());
+                        Instruction* i = *ip;
+                        if (i->hasEnv() && i->env() == Env::theParent()) {
+                            i->env(cls->env());
                         }
                         if (ld) {
                             ld->replaceUsesWith(arguments[ld->id]);

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -39,21 +39,29 @@ class TheScopeResolution {
                     // LdVarSuper where the parent environment is known and
                     // local, can be replaced by a simple LdVar
                     auto e = Env::parentEnv(sld->env());
-                    if (e != Env::theContext()) {
+                    if (e) {
                         auto r = new LdVar(sld->varName, e);
                         bb->replace(ip, r);
                     }
                 } else if (ss) {
                     // StVarSuper where the parent environment is known and
-                    // local, can be replaced by simple StVar
+                    // local, can be replaced by simple StVar, if the variable
+                    // exists in the super env.
                     auto e = Env::parentEnv(ss->env());
-                    if (e != Env::theContext()) {
-                        auto r = new StVar(ss->varName, ss->arg<0>().val(), e);
-                        bb->replace(ip, r);
+                    auto aload = analysis.loads.at(ss);
+                    if (e && aload.env != UnknownParent) {
+                        if ((Env::isPirEnv(aload.env) &&
+                             !aload.result.isUnknown()) ||
+                            Env::isStaticEnv(aload.env)) {
+                            auto r = new StVar(ss->varName, ss->arg<0>().val(),
+                                               aload.env);
+                            bb->replace(ip, r);
+                        }
                     }
                 } else if (s) {
                     // Dead store to non-escaping environment can be removed
-                    if (!analysis.finalState[s->env()].leaked &&
+                    if (Env::isPirEnv(s->env()) &&
+                        !analysis.finalState[s->env()].leaked &&
                         analysis.observedStores.find(s) ==
                             analysis.observedStores.end())
                         next = bb->remove(ip);
@@ -63,43 +71,49 @@ class TheScopeResolution {
                     auto aload = analysis.loads.at(ld);
                     auto aval = aload.result;
                     bool localVals = true;
-                    aval.eachSource([&](ValOrig& src) {
-                        // inter-procedural scope analysis can drag in values
-                        // from other functions, which we cannot use here!
-                        if (src.origin->bb()->owner != function) {
-                            localVals = false;
-                        }
-                    });
-                    if (localVals) {
-                        aval.ifSingleValue([&](Value* val) {
-                            if (ldf) {
-                                auto f = new Force(val);
-                                // TODO
-                                // !(PirType(RType::closure) >= phi->type)
-                                ld->replaceUsesWith(f);
-                                bb->replace(ip, f);
-                            } else {
-                                ld->replaceUsesWith(val);
-                                next = bb->remove(ip);
+                    if (aval.isUnknown() && aload.env != UnknownParent) {
+                        // We have no clue what we load, but we know from where
+                        ld->env(aload.env);
+                    } else {
+                        aval.eachSource([&](ValOrig& src) {
+                            // inter-procedural scope analysis can drag in
+                            // values
+                            // from other functions, which we cannot use here!
+                            if (src.origin->bb()->owner != function) {
+                                localVals = false;
                             }
                         });
-                        if (!aval.isSingleValue() && !aval.isUnknown()) {
-                            auto phi = new Phi;
-                            aval.eachSource([&](ValOrig& src) {
-                                phi->addInput(src.origin->bb(), src.val);
+                        if (localVals) {
+                            aval.ifSingleValue([&](Value* val) {
+                                if (ldf) {
+                                    auto f = new Force(val);
+                                    // TODO
+                                    // !(PirType(RType::closure) >= phi->type)
+                                    ld->replaceUsesWith(f);
+                                    bb->replace(ip, f);
+                                } else {
+                                    ld->replaceUsesWith(val);
+                                    next = bb->remove(ip);
+                                }
                             });
-                            phi->updateType();
-                            if (ldf) {
-                                auto f = new Force(phi);
-                                // TODO
-                                // !(PirType(RType::closure) >= phi->type)
-                                ld->replaceUsesWith(f);
-                                bb->replace(ip, phi);
-                                next = bb->insert(ip + 1, f);
-                                next++;
-                            } else {
-                                ld->replaceUsesWith(phi);
-                                bb->replace(ip, phi);
+                            if (!aval.isSingleValue() && !aval.isUnknown()) {
+                                auto phi = new Phi;
+                                aval.eachSource([&](ValOrig& src) {
+                                    phi->addInput(src.origin->bb(), src.val);
+                                });
+                                phi->updateType();
+                                if (ldf) {
+                                    auto f = new Force(phi);
+                                    // TODO
+                                    // !(PirType(RType::closure) >= phi->type)
+                                    ld->replaceUsesWith(f);
+                                    bb->replace(ip, phi);
+                                    next = bb->insert(ip + 1, f);
+                                    next++;
+                                } else {
+                                    ld->replaceUsesWith(phi);
+                                    bb->replace(ip, phi);
+                                }
                             }
                         }
                     }

--- a/rir/src/compiler/pir/env.cpp
+++ b/rir/src/compiler/pir/env.cpp
@@ -1,22 +1,46 @@
 #include "env.h"
 #include "pir_impl.h"
 
+#include "utils/capture_out.h"
+
+#include <cassert>
+
 namespace rir {
 namespace pir {
 
 void Env::printRef(std::ostream& out) {
-    if (this == theContext())
-        out << "?";
-    else
-        assert(false);
+    if (this == theParent()) {
+        out << "parent?";
+        return;
+    }
+    if (this == nil()) {
+        out << "nil";
+        return;
+    }
+    assert(rho);
+    std::string val;
+    {
+        CaptureOut rec;
+        Rf_PrintValue(rho);
+        val = rec();
+    }
+    out << val.substr(0, val.length() - 1);
 }
 
-bool Env::isEnv(Value* v) {
+bool Env::isStaticEnv(Value* v) {
+    return Env::Cast(v) && v != Env::theParent() && v != Env::nil();
+}
+
+bool Env::isPirEnv(Value* v) {
+    return MkEnv::Cast(v) || LdFunctionEnv::Cast(v);
+}
+
+bool Env::isAnyEnv(Value* v) {
     return Env::Cast(v) || MkEnv::Cast(v) || LdFunctionEnv::Cast(v);
 }
 
 Value* Env::parentEnv(Value* e) {
-    assert(isEnv(e));
+    assert(isAnyEnv(e));
     if (Cast(e))
         return Cast(e)->parent;
     if (MkEnv::Cast(e))

--- a/rir/src/compiler/pir/env.h
+++ b/rir/src/compiler/pir/env.h
@@ -14,22 +14,27 @@ namespace pir {
 class Instruction;
 
 /*
- * Statically known environments.
- *
- * Currently only "theContext"-singleton is used, to denote an unknown parent
- * envrionment.
+ * Statically known envs.
  *
  */
 class Env : public Value {
-  public:
-    Env* parent = nullptr;
+    Env(SEXP rho, Env* parent)
+        : Value(RType::env, Tag::Env), rho(rho), parent(parent) {}
+    friend class Module;
 
-    static Env* theContext() {
-        static Env e;
-        return &e;
+  public:
+    SEXP rho;
+    Env* parent;
+
+    static Env* nil() {
+        static Env u(nullptr, nullptr);
+        return &u;
     }
 
-    Env() : Value(RType::env, Tag::Env) {}
+    static Env* theParent() {
+        static Env u(nullptr, nullptr);
+        return &u;
+    }
 
     void printRef(std::ostream& out);
 
@@ -37,7 +42,10 @@ class Env : public Value {
         return v->tag == Tag::Env ? static_cast<Env*>(v) : nullptr;
     }
 
-    static bool isEnv(Value* v);
+    static bool isPirEnv(Value* v);
+    static bool isStaticEnv(Value* v);
+    static bool isAnyEnv(Value* v);
+
     static bool isParentEnv(Value* a, Value* b);
     static Value* parentEnv(Value* e);
 };

--- a/rir/src/compiler/pir/function.h
+++ b/rir/src/compiler/pir/function.h
@@ -23,6 +23,8 @@ class Function : public Code {
     Function(const std::vector<SEXP>& a) : argNames(a) {}
 
   public:
+    Env* closureEnv;
+
     std::vector<SEXP> argNames;
     std::vector<Promise*> defaultArgs;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -70,6 +70,7 @@ class Instruction : public Value {
 
     virtual size_t nargs() const = 0;
     virtual Value* env() const = 0;
+    virtual void env(Value*) = 0;
 
     virtual bool mightIO() const = 0;
     virtual bool changesEnv() const = 0;
@@ -240,6 +241,12 @@ class FixedLenInstruction
         return arg(ARGS - 1).val();
     }
 
+    void env(Value* v) override {
+        // TODO find a better way
+        assert(ENV > EnvAccess::None);
+        arg(ARGS - 1).val() = v;
+    }
+
     FixedLenInstruction(PirType resultType, Value* env)
         : Super(resultType, ArgsZip(env)) {
         assert(env);
@@ -310,6 +317,12 @@ class VarLenInstruction
         // TODO find a better way
         assert(ENV != EnvAccess::None);
         return arg(0).val();
+    }
+
+    void env(Value* v) override {
+        // TODO find a better way
+        assert(ENV != EnvAccess::None);
+        arg(0).val() = v;
     }
 
     void pushArg(Value* a) {

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -56,9 +56,25 @@ void Module::VersionedFunction::saveVersion() {
     translations.push_back(f);
 }
 
+Env* Module::getEnv(SEXP rho) {
+    if (rho == R_NilValue)
+        return Env::nil();
+
+    if (environments.count(rho))
+        return environments.at(rho);
+
+    assert(TYPEOF(rho) == ENVSXP);
+    Env* parent = getEnv(ENCLOS(rho));
+    Env* env = new Env(rho, parent);
+    environments[rho] = env;
+    return env;
+}
+
 Module::~Module() {
     for (auto f : functions)
         f.second.deallocatePirFunctions();
+    for (auto e : environments)
+        delete e.second;
 }
 }
 }

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -2,6 +2,7 @@
 #define PIR_MODULE_H
 
 #include <functional>
+#include "R/r.h"
 #include <iostream>
 #include <unordered_map>
 #include <vector>
@@ -11,11 +12,16 @@
 namespace rir {
 namespace pir {
 
+class Env;
 class Function;
 
 class Module {
+    std::unordered_map<SEXP, Env*> environments;
+
   public:
     Function* declare(rir::Function*, const std::vector<SEXP>& a);
+    Env* getEnv(SEXP);
+
     void print(std::ostream& out = std::cout);
     void printEachVersion(std::ostream& out = std::cout);
 

--- a/rir/src/compiler/translations/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir.cpp
@@ -62,14 +62,15 @@ Function* Rir2PirCompiler::compileFunction(SEXP closure) {
         fmls.push_back(it.tag());
 
     rir::Function* srcFunction = tbl->first();
-    return compileFunction(srcFunction, fmls);
+    return compileFunction(srcFunction, fmls, module->getEnv(CLOENV(closure)));
 }
 
 Function* Rir2PirCompiler::compileFunction(rir::Function* srcFunction,
-                                           const std::vector<SEXP>& args) {
+                                           const std::vector<SEXP>& args,
+                                           Value* closureEnv) {
     Function* pirFunction = module->declare(srcFunction, args);
 
-    Builder builder(pirFunction, Env::theContext());
+    Builder builder(pirFunction, closureEnv);
 
     {
         Rir2Pir rir2pir(*this, builder, srcFunction, srcFunction->body());
@@ -212,7 +213,7 @@ Value* Rir2Pir::translate() {
             DispatchTable* dt = DispatchTable::unpack(code);
             rir::Function* function = dt->first();
 
-            Function* innerF = cmp.compileFunction(function, fmls);
+            Function* innerF = cmp.compileFunction(function, fmls, Env::theParent());
 
             state.push(insert(new MkFunCls(innerF, insert.env)));
 

--- a/rir/src/compiler/translations/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir.h
@@ -12,7 +12,7 @@ class Rir2PirCompiler {
   public:
     Rir2PirCompiler(Module* module) : module(module) {}
     Function* compileFunction(SEXP);
-    Function* compileFunction(rir::Function*, const std::vector<SEXP>&);
+    Function* compileFunction(rir::Function*, const std::vector<SEXP>&, Value* closureEnv);
     void optimizeModule();
     Module* getModule() { return module; }
 

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -6,13 +6,13 @@ namespace pir {
 
 BB* Builder::createBB() { return new BB(code, ++function->maxBBId); }
 
-Builder::Builder(Function* fun, Env* enclos)
+Builder::Builder(Function* fun, Value* closureEnv)
     : function(fun), code(fun), env(nullptr), bb(fun->entry) {
     bb = function->entry = createBB();
     std::vector<Value*> args;
     for (size_t i = 0; i < fun->argNames.size(); ++i)
         args.push_back(this->operator()(new LdArg(i)));
-    env = this->operator()(new MkEnv(enclos, fun->argNames, args.data()));
+    env = this->operator()(new MkEnv(closureEnv, fun->argNames, args.data()));
 }
 Builder::Builder(Function* fun, Promise* prom)
     : function(fun), code(prom), env(nullptr), bb(prom->entry) {

--- a/rir/src/compiler/util/builder.h
+++ b/rir/src/compiler/util/builder.h
@@ -14,7 +14,7 @@ class Builder {
     Value* env;
     BB* bb;
     Builder(Function* fun, Promise* prom);
-    Builder(Function* fun, Env* enclos);
+    Builder(Function* fun, Value* closureEnv);
 
     Value* buildDefaultEnv(Function* fun);
 


### PR DESCRIPTION
When we know that a load will hit the outer environment (called
theContext, or ? in pir), we do not want to keep the local
environment alive. For example in `function() a`, we know that
`a` is gonna be loaded from the closure environment.
    
So this optimization transforms:

        env     e0.0  = MkEnv            (parent=?)
        val^?   %0.1  = LdVar            (a, e0.0)

to

        val^?   %0.0  = LdVar            (a, ?)