### PR TITLE
Rename fun cls

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -128,7 +128,7 @@ REXPORT SEXP pir_compile(SEXP what) {
     pir::Module* m = new pir::Module;
     pir::Rir2PirCompiler cmp(m);
     cmp.setVerbose(true);
-    cmp.compileFunction(what);
+    cmp.compileClosure(what);
     cmp.optimizeModule();
     delete m;
     return R_NilValue;

--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -51,7 +51,7 @@ void AbstractPirValue::print(std::ostream& out) {
 }
 
 AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
-    while (env != UnknownParent) {
+    while (env != AbstractREnvironment::UnknownParent) {
         if (this->count(env) == 0)
             return AbstractLoad(env, AbstractPirValue::tainted());
         auto aenv = this->at(env);
@@ -63,10 +63,14 @@ AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
         if (aenv.tainted)
             return AbstractLoad(env, AbstractPirValue::tainted());
         env = at(env).parentEnv;
-        if (env == UnknownParent && Env::parentEnv(env))
+        if (env == AbstractREnvironment::UnknownParent && Env::parentEnv(env))
             env = Env::parentEnv(env);
     }
     return AbstractLoad(env, AbstractPirValue::tainted());
-    }
+}
+
+Value* AbstractREnvironment::UnknownParent = (Value*)-1;
+Value* AbstractREnvironment::UninitializedParent = nullptr;
+MkFunCls* AbstractREnvironment::UnknownClosure = (MkFunCls*)-1;
 }
 }

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -2,7 +2,7 @@
 #define PIR_GENERIC_STATIC_ANALYSIS
 
 #include "../pir/bb.h"
-#include "../pir/function.h"
+#include "../pir/closure.h"
 #include "../pir/instruction.h"
 #include "../util/cfg.h"
 #include "../util/visitor.h"

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -23,7 +23,7 @@ class ScopeAnalysis {
     std::unordered_map<Instruction*, AbstractLoad> loads;
     std::unordered_set<Instruction*> observedStores;
     AbstractREnvironmentHierarchy finalState;
-    ScopeAnalysis(Function* fun);
+    ScopeAnalysis(Closure* fun);
 };
 }
 }

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -8,9 +8,9 @@ using namespace rir::pir;
 
 class TheVerifier {
   public:
-    Function* f;
+    Closure* f;
 
-    TheVerifier(Function* f) : f(f) {}
+    TheVerifier(Closure* f) : f(f) {}
 
     bool ok = true;
 
@@ -135,7 +135,7 @@ class TheVerifier {
 namespace rir {
 namespace pir {
 
-bool Verify::apply(Function* f) {
+bool Verify::apply(Closure* f) {
     TheVerifier v(f);
     v();
     return v.ok;

--- a/rir/src/compiler/analysis/verifier.h
+++ b/rir/src/compiler/analysis/verifier.h
@@ -8,7 +8,7 @@ namespace pir {
 
 class Verify {
   public:
-    static bool apply(Function*);
+    static bool apply(Closure*);
 };
 }
 }

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -12,8 +12,8 @@ using namespace rir::pir;
 
 class TheCleanup {
   public:
-    TheCleanup(Function* function) : function(function) {}
-    Function* function;
+    TheCleanup(Closure* function) : function(function) {}
+    Closure* function;
     void operator()() {
         std::unordered_set<size_t> used_p;
         std::unordered_map<BB*, std::unordered_set<Phi*>> used_bb;
@@ -184,7 +184,7 @@ class TheCleanup {
 namespace rir {
 namespace pir {
 
-void Cleanup::apply(Function* function) {
+void Cleanup::apply(Closure* function) {
     TheCleanup s(function);
     s();
 }

--- a/rir/src/compiler/opt/cleanup.h
+++ b/rir/src/compiler/opt/cleanup.h
@@ -4,10 +4,10 @@
 namespace rir {
 namespace pir {
 
-class Function;
+class Closure;
 class Cleanup {
   public:
-    static void apply(Function* function);
+    static void apply(Closure* function);
 };
 }
 }

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -9,7 +9,7 @@
 namespace rir {
 namespace pir {
 
-void DelayEnv::apply(Function* function) {
+void DelayEnv::apply(Closure* function) {
     std::vector<MkEnv*> envs;
 
     Visitor::run(function->entry, [&](BB* bb) {

--- a/rir/src/compiler/opt/delay_env.h
+++ b/rir/src/compiler/opt/delay_env.h
@@ -10,10 +10,10 @@ namespace pir {
  * the goal is to move it out of the others.
  *
  */
-class Function;
+class Closure;
 class DelayEnv {
   public:
-    static void apply(Function*);
+    static void apply(Closure*);
 };
 }
 }

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -6,7 +6,7 @@
 namespace rir {
 namespace pir {
 
-void DelayInstr::apply(Function* function) {
+void DelayInstr::apply(Closure* function) {
     std::vector<MkEnv*> envs;
 
     Visitor::run(function->entry, [&](BB* bb) {

--- a/rir/src/compiler/opt/delay_instr.h
+++ b/rir/src/compiler/opt/delay_instr.h
@@ -8,10 +8,10 @@ namespace pir {
  * DelayInstr tries to schedule instruction right before they are needed.
  *
  */
-class Function;
+class Closure;
 class DelayInstr {
   public:
-    static void apply(Function*);
+    static void apply(Closure*);
 };
 }
 }

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -9,7 +9,7 @@
 namespace rir {
 namespace pir {
 
-void ElideEnv::apply(Function* function) {
+void ElideEnv::apply(Closure* function) {
     std::unordered_set<Value*> envNeeded;
     std::unordered_map<Value*, Value*> envDependency;
 

--- a/rir/src/compiler/opt/elide_env.h
+++ b/rir/src/compiler/opt/elide_env.h
@@ -11,10 +11,10 @@ namespace pir {
  * can be removed.
  *
  */
-class Function;
+class Closure;
 class ElideEnv {
   public:
-    static void apply(Function* function);
+    static void apply(Closure* function);
 };
 }
 }

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -131,7 +131,7 @@ class ForceDominanceAnalysisResult {
 namespace rir {
 namespace pir {
 
-void ForceDominance::apply(Function* function) {
+void ForceDominance::apply(Closure* function) {
     ForceDominanceAnalysisResult analysis(function->entry);
 
     std::unordered_map<Force*, Value*> inlinedPromise;

--- a/rir/src/compiler/opt/force_dominance.h
+++ b/rir/src/compiler/opt/force_dominance.h
@@ -12,10 +12,10 @@ namespace pir {
  * dominating force, and replaces all subsequent forces with it's result.
  *
  */
-class Function;
+class Closure;
 class ForceDominance {
   public:
-    static void apply(Function*);
+    static void apply(Closure*);
 };
 }
 }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -15,8 +15,8 @@ using namespace rir::pir;
 
 class TheInliner {
   public:
-    Function* function;
-    TheInliner(Function* function) : function(function) {}
+    Closure* function;
+    TheInliner(Closure* function) : function(function) {}
 
     void operator()() {
 
@@ -30,7 +30,7 @@ class TheInliner {
                 auto cls = MkFunCls::Cast(call->cls());
                 if (!cls)
                     continue;
-                Function* inlinee = cls->fun;
+                Closure* inlinee = cls->fun;
                 if (inlinee->argNames.size() != call->nCallArgs())
                     continue;
 
@@ -56,7 +56,7 @@ class TheInliner {
                         auto next = ip + 1;
                         auto ld = LdArg::Cast(*ip);
                         Instruction* i = *ip;
-                        if (i->hasEnv() && i->env() == Env::theParent()) {
+                        if (i->hasEnv() && i->env() == Env::notClosed()) {
                             i->env(cls->env());
                         }
                         if (ld) {
@@ -124,7 +124,7 @@ class TheInliner {
 namespace rir {
 namespace pir {
 
-void Inline::apply(Function* function) {
+void Inline::apply(Closure* function) {
     TheInliner s(function);
     s();
 }

--- a/rir/src/compiler/opt/inline.h
+++ b/rir/src/compiler/opt/inline.h
@@ -14,10 +14,10 @@ namespace pir {
  * Later scope resolution and force dominance passes will do the smart parts.
  *
  */
-class Function;
+class Closure;
 class Inline {
   public:
-    static void apply(Function* function);
+    static void apply(Closure* function);
 };
 }
 }

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -14,8 +14,8 @@ namespace {
 using namespace rir::pir;
 class TheScopeResolution {
   public:
-    Function* function;
-    TheScopeResolution(Function* function) : function(function) {}
+    Closure* function;
+    TheScopeResolution(Closure* function) : function(function) {}
     void operator()() {
         ScopeAnalysis analysis(function);
 
@@ -49,7 +49,7 @@ class TheScopeResolution {
                     // exists in the super env.
                     auto e = Env::parentEnv(ss->env());
                     auto aload = analysis.loads.at(ss);
-                    if (e && aload.env != UnknownParent) {
+                    if (e && aload.env != AbstractREnvironment::UnknownParent) {
                         if ((Env::isPirEnv(aload.env) &&
                              !aload.result.isUnknown()) ||
                             Env::isStaticEnv(aload.env)) {
@@ -71,7 +71,8 @@ class TheScopeResolution {
                     auto aload = analysis.loads.at(ld);
                     auto aval = aload.result;
                     bool localVals = true;
-                    if (aval.isUnknown() && aload.env != UnknownParent) {
+                    if (aval.isUnknown() &&
+                        aload.env != AbstractREnvironment::UnknownParent) {
                         // We have no clue what we load, but we know from where
                         ld->env(aload.env);
                     } else {
@@ -128,7 +129,7 @@ class TheScopeResolution {
 namespace rir {
 namespace pir {
 
-void ScopeResolution::apply(Function* function) {
+void ScopeResolution::apply(Closure* function) {
     TheScopeResolution s(function);
     s();
 }

--- a/rir/src/compiler/opt/scope_resolution.h
+++ b/rir/src/compiler/opt/scope_resolution.h
@@ -11,10 +11,10 @@ namespace pir {
  * environment, to pir SSA variables.
  *
  */
-class Function;
+class Closure;
 class ScopeResolution {
   public:
-    static void apply(Function* function);
+    static void apply(Closure* function);
 };
 }
 }

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -1,4 +1,4 @@
-#include "function.h"
+#include "closure.h"
 #include "../transform/bb.h"
 #include "../util/visitor.h"
 #include "pir_impl.h"
@@ -8,8 +8,8 @@
 namespace rir {
 namespace pir {
 
-void Function::print(std::ostream& out) {
-    out << "Function " << this << "\n";
+void Closure::print(std::ostream& out) {
+    out << "Closure " << this << "\n";
     Code::print(out);
     for (auto p : promises) {
         if (p)
@@ -17,13 +17,13 @@ void Function::print(std::ostream& out) {
     }
 }
 
-Promise* Function::createProm() {
+Promise* Closure::createProm() {
     Promise* p = new Promise(this, promises.size());
     promises.push_back(p);
     return p;
 }
 
-Function::~Function() {
+Closure::~Closure() {
     for (auto p : promises)
         if (p)
             delete p;
@@ -31,8 +31,8 @@ Function::~Function() {
         delete p;
 }
 
-Function* Function::clone() {
-    Function* c = new Function(argNames);
+Closure* Closure::clone() {
+    Closure* c = new Closure(argNames);
 
     // clone code
     c->entry = BBTransform::clone(entry, c);

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -9,18 +9,18 @@ namespace rir {
 namespace pir {
 
 /*
- * Function
+ * Closure
  *
  * A function does not have an environment per se, but just a number of named
  * arguments. If an environment is necessary, `MkEnv` can bind arguments
  * (referred to by `LdArg`).
  *
  */
-class Function : public Code {
+class Closure : public Code {
   private:
     friend class Module;
-    Function(std::initializer_list<SEXP> a) : argNames(a) {}
-    Function(const std::vector<SEXP>& a) : argNames(a) {}
+    Closure(std::initializer_list<SEXP> a) : argNames(a) {}
+    Closure(const std::vector<SEXP>& a) : argNames(a) {}
 
   public:
     Env* closureEnv;
@@ -36,14 +36,14 @@ class Function : public Code {
 
     size_t maxBBId = 0;
 
-    friend std::ostream& operator<<(std::ostream& out, const Function& e) {
+    friend std::ostream& operator<<(std::ostream& out, const Closure& e) {
         out << "Func(" << (void*)&e << ")";
         return out;
     }
 
-    Function* clone();
+    Closure* clone();
 
-    ~Function();
+    ~Closure();
 };
 }
 }

--- a/rir/src/compiler/pir/env.cpp
+++ b/rir/src/compiler/pir/env.cpp
@@ -9,8 +9,8 @@ namespace rir {
 namespace pir {
 
 void Env::printRef(std::ostream& out) {
-    if (this == theParent()) {
-        out << "parent?";
+    if (this == notClosed()) {
+        out << "?";
         return;
     }
     if (this == nil()) {
@@ -28,7 +28,7 @@ void Env::printRef(std::ostream& out) {
 }
 
 bool Env::isStaticEnv(Value* v) {
-    return Env::Cast(v) && v != Env::theParent() && v != Env::nil();
+    return Env::Cast(v) && v != Env::notClosed() && v != Env::nil();
 }
 
 bool Env::isPirEnv(Value* v) {

--- a/rir/src/compiler/pir/env.h
+++ b/rir/src/compiler/pir/env.h
@@ -31,7 +31,7 @@ class Env : public Value {
         return &u;
     }
 
-    static Env* theParent() {
+    static Env* notClosed() {
         static Env u(nullptr, nullptr);
         return &u;
     }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -47,7 +47,7 @@ enum class Opcode : uint8_t;
 namespace pir {
 
 class BB;
-class Function;
+class Closure;
 class Phi;
 
 struct InstrArg : public std::pair<Value*, PirType> {
@@ -516,8 +516,8 @@ class FLI(MkCls, 4, Effect::None, EnvAccess::Capture) {
 
 class FLI(MkFunCls, 1, Effect::None, EnvAccess::Capture) {
   public:
-    Function* fun;
-    MkFunCls(Function* fun, Value* parent)
+    Closure* fun;
+    MkFunCls(Closure* fun, Value* parent)
         : FixedLenInstruction(RType::closure, parent), fun(fun) {}
 };
 

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -15,7 +15,7 @@ void Module::printEachVersion(std::ostream& out) {
     for (auto f : functions) {
         out << "\n======= Function ========================\n";
         f.second.current()->print(out);
-        f.second.eachVersion([&](Function* f) {
+        f.second.eachVersion([&](Closure* f) {
             out << "\n     == Version ========================\n";
             f->print(out);
         });
@@ -23,35 +23,35 @@ void Module::printEachVersion(std::ostream& out) {
     }
 }
 
-Function* Module::declare(rir::Function* fun, const std::vector<SEXP>& args) {
-    auto* f = new pir::Function(args);
+Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args) {
+    auto* f = new pir::Closure(args);
     functions.emplace(fun, f);
     return f;
 }
 
-void Module::VersionedFunction::deallocatePirFunctions() {
+void Module::VersionedClosure::deallocatePirFunctions() {
     for (auto f : translations) {
         delete f;
     }
-    delete pirFunction;
+    delete pirClosure;
 }
 
-void Module::eachPirFunction(PirFunctionIterator it) {
+void Module::eachPirFunction(PirClosureIterator it) {
     for (auto& f : functions)
         it(f.second.current());
 }
 
-void Module::eachPirFunction(PirFunctionVersionIterator it) {
+void Module::eachPirFunction(PirClosureVersionIterator it) {
     for (auto& f : functions)
         it(f.second);
 }
 
-void Module::VersionedFunction::eachVersion(PirFunctionIterator it) {
+void Module::VersionedClosure::eachVersion(PirClosureIterator it) {
     for (auto f : translations)
         it(f);
 }
 
-void Module::VersionedFunction::saveVersion() {
+void Module::VersionedClosure::saveVersion() {
     auto f = current()->clone();
     translations.push_back(f);
 }

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -12,53 +12,53 @@
 namespace rir {
 namespace pir {
 
+class Closure;
 class Env;
-class Function;
 
 class Module {
     std::unordered_map<SEXP, Env*> environments;
 
   public:
-    Function* declare(rir::Function*, const std::vector<SEXP>& a);
+    Closure* declare(rir::Function*, const std::vector<SEXP>& a);
     Env* getEnv(SEXP);
 
     void print(std::ostream& out = std::cout);
     void printEachVersion(std::ostream& out = std::cout);
 
-    typedef std::function<void(pir::Function*)> PirFunctionIterator;
-    struct VersionedFunction {
+    typedef std::function<void(pir::Closure*)> PirClosureIterator;
+    struct VersionedClosure {
         SEXP closure = nullptr;
-        pir::Function* pirFunction;
+        pir::Closure* pirClosure;
 
-        VersionedFunction(SEXP closure, pir::Function* pir)
-            : closure(closure), pirFunction(pir) {}
-        VersionedFunction(pir::Function* pir) : pirFunction(pir) {}
+        VersionedClosure(SEXP closure, pir::Closure* pir)
+            : closure(closure), pirClosure(pir) {}
+        VersionedClosure(pir::Closure* pir) : pirClosure(pir) {}
 
-        pir::Function* current() { return pirFunction; }
+        pir::Closure* current() { return pirClosure; }
 
         void saveVersion();
 
-        void eachVersion(PirFunctionIterator it);
+        void eachVersion(PirClosureIterator it);
 
         void deallocatePirFunctions();
 
       private:
-        std::vector<pir::Function*> translations;
+        std::vector<pir::Closure*> translations;
     };
 
-    pir::Function* get(rir::Function* f) {
+    pir::Closure* get(rir::Function* f) {
         assert(functions.count(f));
         return functions.at(f).current();
     }
 
-    typedef std::function<void(VersionedFunction&)> PirFunctionVersionIterator;
-    void eachPirFunction(PirFunctionIterator it);
-    void eachPirFunction(PirFunctionVersionIterator it);
+    typedef std::function<void(VersionedClosure&)> PirClosureVersionIterator;
+    void eachPirFunction(PirClosureIterator it);
+    void eachPirFunction(PirClosureVersionIterator it);
 
     ~Module();
 
   private:
-    std::unordered_map<rir::Function*, VersionedFunction> functions;
+    std::unordered_map<rir::Function*, VersionedClosure> functions;
 };
 
 }

--- a/rir/src/compiler/pir/pir.h
+++ b/rir/src/compiler/pir/pir.h
@@ -8,7 +8,7 @@
 namespace rir {
 namespace pir {
 
-class Function;
+class Closure;
 class BB;
 class Promise;
 class Value;

--- a/rir/src/compiler/pir/pir_impl.h
+++ b/rir/src/compiler/pir/pir_impl.h
@@ -6,8 +6,8 @@
 // contains all the headers from the /pir subdir
 
 #include "bb.h"
+#include "closure.h"
 #include "env.h"
-#include "function.h"
 #include "instruction.h"
 #include "module.h"
 #include "pir.h"

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -9,7 +9,8 @@ namespace pir {
 class Promise : public Code {
   public:
     unsigned id;
-    Function* fun;
+    Closure* fun;
+
     void print(std::ostream& out = std::cout) {
         out << "Prom " << id << ":\n";
         Code::print(out);
@@ -21,8 +22,8 @@ class Promise : public Code {
     }
 
   private:
-    friend class Function;
-    Promise(Function* fun, unsigned id) : id(id), fun(fun) {}
+    friend class Closure;
+    Promise(Closure* fun, unsigned id) : id(id), fun(fun) {}
 };
 }
 }

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -11,7 +11,8 @@
 namespace {
 using namespace rir;
 
-std::pair<pir::Function*, pir::Module*> compile(const std::string& inp, SEXP env = R_GlobalEnv) {
+std::pair<pir::Closure*, pir::Module*> compile(const std::string& inp,
+                                               SEXP env = R_GlobalEnv) {
     Protect p;
     ParseStatus status;
     SEXP arg = p(CONS(R_NilValue, R_NilValue));
@@ -23,14 +24,14 @@ std::pair<pir::Function*, pir::Module*> compile(const std::string& inp, SEXP env
     pir::Module* m = new pir::Module;
     pir::Rir2PirCompiler cmp(m);
     // cmp.setVerbose(true);
-    auto f = cmp.compileFunction(fun);
+    auto f = cmp.compileClosure(fun);
     cmp.optimizeModule();
-    return std::pair<pir::Function*, pir::Module*>(f, m);
+    return std::pair<pir::Closure*, pir::Module*>(f, m);
 }
 
 using namespace rir::pir;
-typedef std::function<bool(void)> TestFunction;
-typedef std::pair<std::string, TestFunction> Test;
+typedef std::function<bool(void)> TestClosure;
+typedef std::pair<std::string, TestClosure> Test;
 
 #define CHECK(___test___)                                                      \
     if (!(___test___)) {                                                       \
@@ -65,8 +66,8 @@ class NullBuffer : public std::ostream {
 
 bool verify(Module* m) {
     bool success = true;
-    m->eachPirFunction([&success](pir::Module::VersionedFunction& f) {
-        f.eachVersion([&success](pir::Function* f) {
+    m->eachPirFunction([&success](pir::Module::VersionedClosure& f) {
+        f.eachVersion([&success](pir::Closure* f) {
             if (!Verify::apply(f))
                 success = false;
         });
@@ -114,14 +115,14 @@ bool testDelayEnv() {
 
 extern "C" SEXP Rf_NewEnvironment(SEXP, SEXP, SEXP);
 bool testSuperAssign() {
-    auto hasAssign = [](pir::Function* f) {
+    auto hasAssign = [](pir::Closure* f) {
         return !Visitor::check(f->entry, [&](Instruction* i) {
             if (StVar::Cast(i))
                 return false;
             return true;
         });
     };
-    auto hasSuperAssign = [](pir::Function* f) {
+    auto hasSuperAssign = [](pir::Closure* f) {
         return !Visitor::check(f->entry, [&](Instruction* i) {
             if (StVarSuper::Cast(i))
                 return false;

--- a/rir/src/compiler/translations/pir_translator.h
+++ b/rir/src/compiler/translations/pir_translator.h
@@ -12,7 +12,7 @@ class PirTranslator {
   public:
     PirTranslator(bool verbose) : verbose(verbose) {}
 
-    pir::Function* compileFunction(SEXP);
+    pir::Closure* compileClosure(SEXP);
 
     bool isVerbose();
     void setVerbose(bool);

--- a/rir/src/compiler/translations/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir.h
@@ -11,8 +11,10 @@ namespace pir {
 class Rir2PirCompiler {
   public:
     Rir2PirCompiler(Module* module) : module(module) {}
-    Function* compileFunction(SEXP);
-    Function* compileFunction(rir::Function*, const std::vector<SEXP>&, Value* closureEnv);
+    Closure* compileClosure(SEXP);
+    Closure* compileClosure(rir::Function*, const std::vector<SEXP>&,
+                            Value* closureEnv);
+    Closure* compileFunction(rir::Function*, const std::vector<SEXP>&);
     void optimizeModule();
     Module* getModule() { return module; }
 

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -6,7 +6,7 @@ namespace pir {
 
 BB* Builder::createBB() { return new BB(code, ++function->maxBBId); }
 
-Builder::Builder(Function* fun, Value* closureEnv)
+Builder::Builder(Closure* fun, Value* closureEnv)
     : function(fun), code(fun), env(nullptr), bb(fun->entry) {
     bb = function->entry = createBB();
     std::vector<Value*> args;
@@ -14,7 +14,7 @@ Builder::Builder(Function* fun, Value* closureEnv)
         args.push_back(this->operator()(new LdArg(i)));
     env = this->operator()(new MkEnv(closureEnv, fun->argNames, args.data()));
 }
-Builder::Builder(Function* fun, Promise* prom)
+Builder::Builder(Closure* fun, Promise* prom)
     : function(fun), code(prom), env(nullptr), bb(prom->entry) {
     bb = prom->entry = createBB();
     env = this->operator()(new LdFunctionEnv());

--- a/rir/src/compiler/util/builder.h
+++ b/rir/src/compiler/util/builder.h
@@ -9,14 +9,14 @@ namespace pir {
 
 class Builder {
   public:
-    Function* function;
+    Closure* function;
     Code* code;
     Value* env;
     BB* bb;
-    Builder(Function* fun, Promise* prom);
-    Builder(Function* fun, Value* closureEnv);
+    Builder(Closure* fun, Promise* prom);
+    Builder(Closure* fun, Value* enclos);
 
-    Value* buildDefaultEnv(Function* fun);
+    Value* buildDefaultEnv(Closure* fun);
 
     template <class T>
     T* operator()(T* i) {


### PR DESCRIPTION
I would like to rename pir::Function to pir::Closure in #97 , but then I realized that this will probably mess with @charig and @JanJecmen 's ongoing work. So I keep the renaming here in a separate PR, such that we can wait with this until you are ready.