### PR TITLE
add support for statically resolved calls

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -127,9 +127,10 @@ REXPORT SEXP pir_compile(SEXP what) {
         Rf_error("not a compiled closure");
     pir::Module* m = new pir::Module;
     pir::Rir2PirCompiler cmp(m);
-    cmp.setVerbose(true);
+    // cmp.setVerbose(true);
     cmp.compileClosure(what);
     cmp.optimizeModule();
+    m->print(std::cout);
     delete m;
     return R_NilValue;
 }

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -80,7 +80,7 @@ class StaticAnalysis {
             if (POS == PositioningStyle::BeforeInstruction && i == j)
                 return state;
 
-            if (Call::Cast(i))
+            if (CallInstruction::Cast(i))
                 state = mergepoint[bb->id][++segment];
             else
                 apply(state, i);
@@ -106,7 +106,7 @@ class StaticAnalysis {
                 if (POS == PositioningStyle::BeforeInstruction)
                     collect(state, i);
 
-                if (Call::Cast(i))
+                if (CallInstruction::Cast(i))
                     state = mergepoint[bb->id][++segment];
                 else
                     apply(state, i);
@@ -138,7 +138,7 @@ class StaticAnalysis {
                 for (auto i : *bb) {
                     apply(state, i);
 
-                    if (Call::Cast(i)) {
+                    if (CallInstruction::Cast(i)) {
                         segment++;
                         if (mergepoint[id].size() <= segment) {
                             mergepoint[id].resize(segment + 1);

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -15,14 +15,15 @@ class TheScopeAnalysis : public StaticAnalysis<AbstractREnvironmentHierarchy> {
 
     static constexpr size_t maxDepth = 5;
     size_t depth;
-    Call* invocation = nullptr;
+    Value* staticClosureEnv = nullptr;
 
     TheScopeAnalysis(Closure* origin, const std::vector<SEXP>& args, BB* bb)
         : Super(bb), origin(origin), args(args), depth(0) {}
-    TheScopeAnalysis(Closure* origin, const std::vector<SEXP>& args, BB* bb,
-                     const AS& initialState, Call* invocation, size_t depth)
+    TheScopeAnalysis(Closure* origin, const std::vector<SEXP>& args,
+                     Value* staticClosureEnv, BB* bb, const AS& initialState,
+                     size_t depth)
         : Super(bb, initialState), origin(origin), args(args), depth(depth),
-          invocation(invocation) {}
+          staticClosureEnv(staticClosureEnv) {}
 
     void apply(AS& envs, Instruction* i) const override;
 
@@ -69,19 +70,15 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
     StVar* s = StVar::Cast(i);
     StVarSuper* ss = StVarSuper::Cast(i);
     MkEnv* mk = MkEnv::Cast(i);
-    Call* call = Call::Cast(i);
 
     bool handled = false;
 
     if (mk) {
         Value* parentEnv = mk->env();
         // If we know the caller, we can fill in the parent env
-        if (parentEnv == Env::notClosed() && invocation) {
-            Value* cls = invocation->cls();
-            if (envs[invocation->env()].mkClosures.count(cls)) {
-                auto mkCls = envs[invocation->env()].mkClosures.at(cls);
-                parentEnv = mkCls->env();
-            }
+        if (parentEnv == Env::notClosed() &&
+            staticClosureEnv != Env::notClosed()) {
+            parentEnv = staticClosureEnv;
         }
         envs[mk].parentEnv = parentEnv;
         mk->eachLocalVar(
@@ -96,18 +93,33 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
             envs[superEnv].set(ss->varName, ss->val(), ss);
             handled = true;
         }
-    } else if (call && depth < maxDepth) {
-        Value* trg = call->cls();
-        MkFunCls* cls = envs.findClosure(i->env(), trg);
-        if (cls != AbstractREnvironment::UnknownClosure) {
-            if (cls->fun->argNames.size() == call->nCallArgs()) {
-                TheScopeAnalysis nextFun(cls->fun, cls->fun->argNames,
-                                         cls->fun->entry, envs, call,
-                                         depth + 1);
+    } else if (CallInstruction::Cast(i) && depth < maxDepth) {
+        if (Call::Cast(i)) {
+            auto call = Call::Cast(i);
+            Value* trg = call->cls();
+            MkFunCls* cls = envs.findClosure(i->env(), trg);
+            if (cls != AbstractREnvironment::UnknownClosure) {
+                if (cls->fun->argNames.size() == call->nCallArgs()) {
+                    TheScopeAnalysis nextFun(cls->fun, cls->fun->argNames,
+                                             cls->env(), cls->fun->entry, envs,
+                                             depth + 1);
+                    nextFun();
+                    envs.merge(nextFun.result());
+                    handled = true;
+                }
+            }
+        } else if (StaticCall::Cast(i)) {
+            auto call = StaticCall::Cast(i);
+            Closure* trg = call->cls();
+            if (trg->argNames.size() == call->nCallArgs()) {
+                TheScopeAnalysis nextFun(trg, trg->argNames, trg->closureEnv(),
+                                         trg->entry, envs, depth + 1);
                 nextFun();
                 envs.merge(nextFun.result());
                 handled = true;
             }
+        } else {
+            assert(false);
         }
     }
 

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -60,7 +60,7 @@ class TheCleanup {
                             used_bb[bb].insert(phi);
                     }
                 } else if (arg) {
-                    used_p.insert(arg->prom->id);
+                    arg->ifPromise([&](Promise* p) { used_p.insert(p->id); });
                 }
                 ip = next;
             }
@@ -80,12 +80,14 @@ class TheCleanup {
             Visitor::run(p->entry, [&](Instruction* i) {
                 MkArg* mk = MkArg::Cast(i);
                 if (mk) {
-                    size_t id = mk->prom->id;
-                    if (used_p.find(id) == used_p.end()) {
-                        // found a new used promise...
-                        todo.push_back(mk->prom);
-                        used_p.insert(mk->prom->id);
-                    }
+                    mk->ifPromise([&](Promise* prom) {
+                        size_t id = prom->id;
+                        if (used_p.find(id) == used_p.end()) {
+                            // found a new used promise...
+                            todo.push_back(prom);
+                            used_p.insert(prom->id);
+                        }
+                    });
                 }
             });
         }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -24,22 +24,38 @@ class TheInliner {
             // Dangerous iterater usage, works since we do only update it in
             // one place.
             for (auto it = bb->begin(); it != bb->end(); it++) {
-                Call* call = Call::Cast(*it);
+                auto call = CallInstruction::Cast(*it);
                 if (!call)
                     continue;
-                auto cls = MkFunCls::Cast(call->cls());
-                if (!cls)
-                    continue;
-                Closure* inlinee = cls->fun;
-                if (inlinee->argNames.size() != call->nCallArgs())
-                    continue;
+
+                Closure* inlinee = nullptr;
+                Value* staticEnv = nullptr;
+
+                if (Call::Cast(*it)) {
+                    Call* call = Call::Cast(*it);
+                    auto cls = MkFunCls::Cast(call->cls());
+                    if (!cls)
+                        continue;
+                    inlinee = cls->fun;
+                    if (inlinee->argNames.size() != call->nCallArgs())
+                        continue;
+                    assert(cls->fun->closureEnv() == Env::notClosed());
+                    staticEnv = cls->env();
+                } else if (StaticCall::Cast(*it)) {
+                    StaticCall* call = StaticCall::Cast(*it);
+                    inlinee = call->cls();
+                    staticEnv = inlinee->closureEnv();
+                } else {
+                    assert(false);
+                }
 
                 BB* split =
                     BBTransform::split(++function->maxBBId, bb, it, function);
 
-                Call* theCall = Call::Cast(*split->begin());
+                auto theCall = *split->begin();
+                auto theCallInstruction = CallInstruction::Cast(theCall);
                 std::vector<MkArg*> arguments;
-                theCall->eachCallArg([&](Value* v) {
+                theCallInstruction->eachCallArg([&](Value* v) {
                     MkArg* a = MkArg::Cast(v);
                     assert(a);
                     arguments.push_back(a);
@@ -57,7 +73,7 @@ class TheInliner {
                         auto ld = LdArg::Cast(*ip);
                         Instruction* i = *ip;
                         if (i->hasEnv() && i->env() == Env::notClosed()) {
-                            i->env(cls->env());
+                            i->env(staticEnv);
                         }
                         if (ld) {
                             ld->replaceUsesWith(arguments[ld->id]);
@@ -83,23 +99,25 @@ class TheInliner {
                         if (!mk)
                             continue;
 
-                        Promise* prom = mk->prom;
-                        size_t id = prom->id;
-                        if (prom->fun == inlinee) {
-                            if (copiedPromise[id]) {
-                                mk->prom = function->promises[newPromId[id]];
-                            } else {
-                                Promise* clone = function->createProm();
-                                BB* promCopy =
-                                    BBTransform::clone(prom->entry, clone);
-                                clone->id = function->promises.size();
-                                function->promises.push_back(clone);
-                                clone->entry = promCopy;
-                                newPromId[id] = clone->id;
-                                copiedPromise[id] = true;
-                                mk->prom = clone;
+                        mk->ifPromise([&](Promise* prom) {
+                            size_t id = prom->id;
+                            if (prom->fun == inlinee) {
+                                if (copiedPromise[id]) {
+                                    mk->promise(
+                                        function->promises[newPromId[id]]);
+                                } else {
+                                    Promise* clone = function->createProm();
+                                    BB* promCopy =
+                                        BBTransform::clone(prom->entry, clone);
+                                    clone->id = function->promises.size();
+                                    function->promises.push_back(clone);
+                                    clone->entry = promCopy;
+                                    newPromId[id] = clone->id;
+                                    copiedPromise[id] = true;
+                                    mk->promise(clone);
+                                }
                             }
-                        }
+                        });
                     }
                 });
 

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -32,7 +32,7 @@ Closure::~Closure() {
 }
 
 Closure* Closure::clone() {
-    Closure* c = new Closure(argNames);
+    Closure* c = new Closure(argNames, env);
 
     // clone code
     c->entry = BBTransform::clone(entry, c);
@@ -52,13 +52,13 @@ Closure* Closure::clone() {
     Visitor::run(c->entry, [&](Instruction* i) {
         auto a = MkArg::Cast(i);
         if (a)
-            a->prom = promMap[a->prom];
+            a->ifPromise([&](Promise* p) { a->promise(promMap[p]); });
     });
     for (auto p : c->promises)
         Visitor::run(p->entry, [&](Instruction* i) {
             auto a = MkArg::Cast(i);
             if (a)
-                a->prom = promMap[a->prom];
+                a->ifPromise([&](Promise* p) { a->promise(promMap[p]); });
         });
 
     return c;

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -19,11 +19,13 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
-    Closure(std::initializer_list<SEXP> a) : argNames(a) {}
-    Closure(const std::vector<SEXP>& a) : argNames(a) {}
+    Closure(std::initializer_list<SEXP> a, Env* env) : env(env), argNames(a) {}
+    Closure(const std::vector<SEXP>& a, Env* env) : env(env), argNames(a) {}
+
+    Env* env;
 
   public:
-    Env* closureEnv;
+    Env* closureEnv() { return env; }
 
     std::vector<SEXP> argNames;
     std::vector<Promise*> defaultArgs;

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -5,6 +5,7 @@
 #include "R/Funtab.h"
 #include "utils/capture_out.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <sstream>
@@ -136,6 +137,11 @@ void LdConst::printArgs(std::ostream& out) {
     }
     if (val.length() > 0)
         val.pop_back();
+    std::replace(val.begin(), val.end(), '\n', ' ');
+    if (val.length() > 40) {
+        val.resize(47);
+        val.append("...");
+    }
     out << val;
 }
 
@@ -147,7 +153,9 @@ void Branch::printArgs(std::ostream& out) {
 void MkArg::printArgs(std::ostream& out) {
     out << "(";
     arg<0>().val()->printRef(out);
-    out << ", " << *prom << ", ";
+    out << ", ";
+    if (prom)
+        out << *prom << ", ";
     env()->printRef(out);
     out << ") ";
 }
@@ -255,5 +263,24 @@ void Deopt::printArgs(std::ostream& out) {
     out << "], env=";
     env()->printRef(out);
 }
+
+MkFunCls::MkFunCls(Closure* fun, Value* parent)
+    : FixedLenInstruction(RType::closure, parent), fun(fun) {
+    assert(fun->closureEnv() == Env::notClosed());
+}
+
+void StaticCall::printArgs(std::ostream& out) {
+    out << "(" << *cls_ << ", ";
+    if (nargs() > 0) {
+        for (size_t i = 0; i < nargs(); ++i) {
+            arg(i).val()->printRef(out);
+            if (i + 1 < nargs())
+                out << ", ";
+        }
+    }
+    out << ")";
+}
+
+
 }
 }

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -24,6 +24,7 @@
     V(ChkMissing)                                                              \
     V(ChkClosure)                                                              \
     V(Call)                                                                    \
+    V(StaticCall)                                                              \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
     V(MkEnv)                                                                   \

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -23,8 +23,9 @@ void Module::printEachVersion(std::ostream& out) {
     }
 }
 
-Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args) {
-    auto* f = new pir::Closure(args);
+Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args,
+                         Env* env) {
+    auto* f = new pir::Closure(args, env);
     functions.emplace(fun, f);
     return f;
 }

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -19,7 +19,7 @@ class Module {
     std::unordered_map<SEXP, Env*> environments;
 
   public:
-    Closure* declare(rir::Function*, const std::vector<SEXP>& a);
+    Closure* declare(rir::Function*, const std::vector<SEXP>& a, Env* env);
     Env* getEnv(SEXP);
 
     void print(std::ostream& out = std::cout);

--- a/rir/src/compiler/pir/stack_machine.h
+++ b/rir/src/compiler/pir/stack_machine.h
@@ -30,7 +30,7 @@ class StackMachine {
 
       typedef std::pair<BB*, Value*> ReturnSite;
       typedef std::function<void(ReturnSite)> ReturnMaybe;
-      void runCurrentBC(Rir2Pir& cmp, Builder&);
+      void runCurrentBC(Rir2Pir&, Builder&);
 
       void clear();
       bool empty();
@@ -43,6 +43,7 @@ class StackMachine {
       void advancePC();
 
     private:
+      void compileCall(Rir2Pir& cmp, Builder&, BC);
       rir::Function* srcFunction;
       rir::Code* srcCode;
       std::deque<Value*> stack;

--- a/rir/src/compiler/translations/pir_translator.h
+++ b/rir/src/compiler/translations/pir_translator.h
@@ -12,8 +12,6 @@ class PirTranslator {
   public:
     PirTranslator(bool verbose) : verbose(verbose) {}
 
-    pir::Closure* compileClosure(SEXP);
-
     bool isVerbose();
     void setVerbose(bool);
   private:

--- a/rir/src/compiler/translations/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir.h
@@ -13,7 +13,7 @@ class Rir2PirCompiler {
     Rir2PirCompiler(Module* module) : module(module) {}
     Closure* compileClosure(SEXP);
     Closure* compileClosure(rir::Function*, const std::vector<SEXP>&,
-                            Value* closureEnv);
+                            Env* closureEnv);
     Closure* compileFunction(rir::Function*, const std::vector<SEXP>&);
     void optimizeModule();
     Module* getModule() { return module; }


### PR DESCRIPTION
When the call target is statically known, let's use a different call
instruction that allows us to directly link to that known closure.

This commit also fixes a bug in the compiler, where we assumed that
every 'static_call_stack' calls a builting (which is wrong).

Also we add support for speculative static calls for callsites which
have been observed to be monomorphic.