### PR TITLE
add support for statically resolved and eager calls

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -53,7 +53,8 @@ void AbstractPirValue::print(std::ostream& out) {
 AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
     while (env != AbstractREnvironment::UnknownParent) {
         if (this->count(env) == 0)
-            return AbstractLoad(env, AbstractPirValue::tainted());
+            return AbstractLoad(env ? env : AbstractREnvironment::UnknownParent,
+                                AbstractPirValue::tainted());
         auto aenv = this->at(env);
         const AbstractPirValue& res = aenv.get(e);
         if (!res.isUnknown())

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -208,11 +208,13 @@ struct AbstractREnvironment {
  */
 
 struct AbstractLoad {
-    Value* env = nullptr;
+    Value* env;
     AbstractPirValue result;
 
     AbstractLoad(Value* env, const AbstractPirValue& val)
-        : env(env), result(val) {}
+        : env(env), result(val) {
+        assert(env);
+    }
 };
 
 class AbstractREnvironmentHierarchy

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -80,7 +80,7 @@ class StaticAnalysis {
             if (POS == PositioningStyle::BeforeInstruction && i == j)
                 return state;
 
-            if (Call::Cast(i))
+            if (CallInstruction::Cast(i))
                 state = mergepoint[bb->id][++segment];
             else
                 apply(state, i);
@@ -106,7 +106,7 @@ class StaticAnalysis {
                 if (POS == PositioningStyle::BeforeInstruction)
                     collect(state, i);
 
-                if (Call::Cast(i))
+                if (CallInstruction::Cast(i))
                     state = mergepoint[bb->id][++segment];
                 else
                     apply(state, i);
@@ -138,7 +138,7 @@ class StaticAnalysis {
                 for (auto i : *bb) {
                     apply(state, i);
 
-                    if (Call::Cast(i)) {
+                    if (CallInstruction::Cast(i)) {
                         segment++;
                         if (mergepoint[id].size() <= segment) {
                             mergepoint[id].resize(segment + 1);

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -76,15 +76,17 @@ void DelayEnv::apply(Closure* function) {
             if (it != bb->end() && (it + 1) != bb->end()) {
                 auto b = Branch::Cast(*(it + 1));
                 if (e && b) {
-                    auto d = Deopt::Cast(bb->next0->last());
-                    if (d) {
-                        auto newE = e->clone();
-                        it = bb->insert(it, newE);
-                        e->replaceUsesIn(newE, bb->next0);
-                        // Closure wrapper in MkEnv can be circular
-                        Replace::usesOfValue(newE, e, newE);
-                        it = bb->moveToBegin(it, bb->next0);
-                        it = bb->moveToBegin(it, bb->next1);
+                    if (!bb->next0->isEmpty()) {
+                        auto d = Deopt::Cast(bb->next0->last());
+                        if (d) {
+                            auto newE = e->clone();
+                            it = bb->insert(it, newE);
+                            e->replaceUsesIn(newE, bb->next0);
+                            // Closure wrapper in MkEnv can be circular
+                            Replace::usesOfValue(newE, e, newE);
+                            it = bb->moveToBegin(it, bb->next0);
+                            it = bb->moveToBegin(it, bb->next1);
+                        }
                     }
                 }
             }

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -70,12 +70,17 @@ struct ForcedAt : public std::unordered_map<Value*, Force*> {
 };
 
 static Value* getValue(Force* f) {
-    Value* res = nullptr;
-    while (f) {
-        res = f->arg<0>().val();
-        f = Force::Cast(res);
+    Value* cur = f;
+    while (true) {
+        if (Force::Cast(cur)) {
+            cur = Force::Cast(cur)->arg<0>().val();
+        } else if (CastType::Cast(cur)) {
+            cur = CastType::Cast(cur)->arg<0>().val();
+        } else {
+            break;
+        }
     }
-    return res;
+    return cur;
 }
 
 class ForceDominanceAnalysis : public StaticAnalysis<ForcedAt> {

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -24,26 +24,43 @@ class TheInliner {
             // Dangerous iterater usage, works since we do only update it in
             // one place.
             for (auto it = bb->begin(); it != bb->end(); it++) {
-                Call* call = Call::Cast(*it);
+                auto call = CallInstruction::Cast(*it);
                 if (!call)
                     continue;
-                auto cls = MkFunCls::Cast(call->cls());
-                if (!cls)
-                    continue;
-                Closure* inlinee = cls->fun;
-                if (inlinee->argNames.size() != call->nCallArgs())
-                    continue;
+
+                Closure* inlinee = nullptr;
+                Value* staticEnv = nullptr;
+
+                if (Call::Cast(*it)) {
+                    Call* call = Call::Cast(*it);
+                    auto cls = MkFunCls::Cast(call->cls());
+                    if (!cls)
+                        continue;
+                    inlinee = cls->fun;
+                    if (inlinee->argNames.size() != call->nCallArgs())
+                        continue;
+                    assert(cls->fun->closureEnv() == Env::notClosed());
+                    staticEnv = cls->env();
+                } else if (StaticCall::Cast(*it)) {
+                    StaticCall* call = StaticCall::Cast(*it);
+                    inlinee = call->cls();
+                    staticEnv = inlinee->closureEnv();
+                } else if (StaticEagerCall::Cast(*it)) {
+                    StaticEagerCall* call = StaticEagerCall::Cast(*it);
+                    inlinee = call->cls();
+                    staticEnv = inlinee->closureEnv();
+                } else {
+                    assert(false);
+                }
 
                 BB* split =
                     BBTransform::split(++function->maxBBId, bb, it, function);
 
-                Call* theCall = Call::Cast(*split->begin());
-                std::vector<MkArg*> arguments;
-                theCall->eachCallArg([&](Value* v) {
-                    MkArg* a = MkArg::Cast(v);
-                    assert(a);
-                    arguments.push_back(a);
-                });
+                auto theCall = *split->begin();
+                auto theCallInstruction = CallInstruction::Cast(theCall);
+                std::vector<Value*> arguments;
+                theCallInstruction->eachCallArg(
+                    [&](Value* v) { arguments.push_back(v); });
 
                 // Clone the function
                 BB* copy = BBTransform::clone(&function->maxBBId,
@@ -57,12 +74,19 @@ class TheInliner {
                         auto ld = LdArg::Cast(*ip);
                         Instruction* i = *ip;
                         if (i->hasEnv() && i->env() == Env::notClosed()) {
-                            i->env(cls->env());
+                            i->env(staticEnv);
                         }
                         if (ld) {
-                            ld->replaceUsesWith(arguments[ld->id]);
-                            arguments[ld->id]->type = PirType::any();
-                            next = bb->remove(ip);
+                            Value* a = arguments[ld->id];
+                            if (MkArg::Cast(a)) {
+                                // We need to cast from a promise to a lazy
+                                // value
+                                auto cast = new CastType(a, RType::prom,
+                                                         PirType::any());
+                                bb->insert(ip + 1, cast);
+                                a = cast;
+                            }
+                            ld->replaceUsesWith(a);
                         }
                         ip = next;
                     }
@@ -83,15 +107,14 @@ class TheInliner {
                         if (!mk)
                             continue;
 
-                        Promise* prom = mk->prom;
-                        size_t id = prom->id;
-                        if (prom->fun == inlinee) {
+                        size_t id = mk->prom->id;
+                        if (mk->prom->fun == inlinee) {
                             if (copiedPromise[id]) {
                                 mk->prom = function->promises[newPromId[id]];
                             } else {
                                 Promise* clone = function->createProm();
                                 BB* promCopy =
-                                    BBTransform::clone(prom->entry, clone);
+                                    BBTransform::clone(mk->prom->entry, clone);
                                 clone->id = function->promises.size();
                                 function->promises.push_back(clone);
                                 clone->entry = promCopy;

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -63,5 +63,5 @@ Closure* Closure::clone() {
 
     return c;
 }
-}
-}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -32,7 +32,7 @@ Closure::~Closure() {
 }
 
 Closure* Closure::clone() {
-    Closure* c = new Closure(argNames);
+    Closure* c = new Closure(argNames, env);
 
     // clone code
     c->entry = BBTransform::clone(entry, c);
@@ -63,5 +63,5 @@ Closure* Closure::clone() {
 
     return c;
 }
-} // namespace pir
-} // namespace rir
+}
+}

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -47,7 +47,7 @@ class Closure : public Code {
 
     ~Closure();
 };
-}
-}
+} // namespace pir
+} // namespace rir
 
 #endif

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -19,11 +19,13 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
-    Closure(std::initializer_list<SEXP> a) : argNames(a) {}
-    Closure(const std::vector<SEXP>& a) : argNames(a) {}
+    Closure(std::initializer_list<SEXP> a, Env* env) : env(env), argNames(a) {}
+    Closure(const std::vector<SEXP>& a, Env* env) : env(env), argNames(a) {}
+
+    Env* env;
 
   public:
-    Env* closureEnv;
+    Env* closureEnv() { return env; }
 
     std::vector<SEXP> argNames;
     std::vector<Promise*> defaultArgs;
@@ -45,7 +47,7 @@ class Closure : public Code {
 
     ~Closure();
 };
-} // namespace pir
-} // namespace rir
+}
+}
 
 #endif

--- a/rir/src/compiler/pir/code.cpp
+++ b/rir/src/compiler/pir/code.cpp
@@ -17,9 +17,10 @@ Code::~Code() {
     std::stack<BB*> toDel;
     Visitor::run(entry, [&toDel](BB* bb) { toDel.push(bb); });
     while (!toDel.empty()) {
-        assert(toDel.top()->owner == this);
-        delete toDel.top();
+        auto d = toDel.top();
         toDel.pop();
+        assert(d->owner == this);
+        delete d;
     }
 }
 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -5,6 +5,7 @@
 #include "R/Funtab.h"
 #include "utils/capture_out.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <sstream>
@@ -136,6 +137,11 @@ void LdConst::printArgs(std::ostream& out) {
     }
     if (val.length() > 0)
         val.pop_back();
+    std::replace(val.begin(), val.end(), '\n', ' ');
+    if (val.length() > 40) {
+        val.resize(47);
+        val.append("...");
+    }
     out << val;
 }
 
@@ -147,7 +153,9 @@ void Branch::printArgs(std::ostream& out) {
 void MkArg::printArgs(std::ostream& out) {
     out << "(";
     arg<0>().val()->printRef(out);
-    out << ", " << *prom << ", ";
+    out << ", ";
+    if (prom)
+        out << *prom << ", ";
     env()->printRef(out);
     out << ") ";
 }
@@ -254,6 +262,35 @@ void Deopt::printArgs(std::ostream& out) {
     }
     out << "], env=";
     env()->printRef(out);
+}
+
+MkFunCls::MkFunCls(Closure* fun, Value* parent)
+    : FixedLenInstruction(RType::closure, parent), fun(fun) {
+    assert(fun->closureEnv() == Env::notClosed());
+}
+
+void StaticEagerCall::printArgs(std::ostream& out) {
+    out << "(" << *cls_ << ", ";
+    if (nargs() > 0) {
+        for (size_t i = 0; i < nargs(); ++i) {
+            arg(i).val()->printRef(out);
+            if (i + 1 < nargs())
+                out << ", ";
+        }
+    }
+    out << ")";
+}
+
+void StaticCall::printArgs(std::ostream& out) {
+    out << "(" << *cls_ << ", ";
+    if (nargs() > 0) {
+        for (size_t i = 0; i < nargs(); ++i) {
+            arg(i).val()->printRef(out);
+            if (i + 1 < nargs())
+                out << ", ";
+        }
+    }
+    out << ")";
 }
 }
 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -38,7 +38,6 @@ void printPaddedInstructionName(std::ostream& out, const std::string& name) {
 }
 
 void Instruction::printArgs(std::ostream& out) {
-    out << "(";
     if (nargs() > 0) {
         for (size_t i = 0; i < nargs(); ++i) {
             arg(i).val()->printRef(out);
@@ -46,7 +45,6 @@ void Instruction::printArgs(std::ostream& out) {
                 out << ", ";
         }
     }
-    out << ")";
 }
 
 void Instruction::print(std::ostream& out) {
@@ -151,53 +149,44 @@ void Branch::printArgs(std::ostream& out) {
 }
 
 void MkArg::printArgs(std::ostream& out) {
-    out << "(";
     arg<0>().val()->printRef(out);
-    out << ", ";
-    if (prom)
-        out << *prom << ", ";
+    out << ", " << *prom << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
 void LdVar::printArgs(std::ostream& out) {
-    out << "(" << CHAR(PRINTNAME(varName)) << ", ";
+    out << CHAR(PRINTNAME(varName)) << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
 void LdFun::printArgs(std::ostream& out) {
-    out << "(" << CHAR(PRINTNAME(varName)) << ", ";
+    out << CHAR(PRINTNAME(varName)) << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
-void LdArg::printArgs(std::ostream& out) { out << "(" << id << ")"; }
+void LdArg::printArgs(std::ostream& out) { out << id; }
 
 void StVar::printArgs(std::ostream& out) {
-    out << "(" << CHAR(PRINTNAME(varName)) << ", ";
+    out << CHAR(PRINTNAME(varName)) << ", ";
     val()->printRef(out);
     out << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
 void StVarSuper::printArgs(std::ostream& out) {
-    out << "(" << CHAR(PRINTNAME(varName)) << ", ";
+    out << CHAR(PRINTNAME(varName)) << ", ";
     val()->printRef(out);
     out << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
 void LdVarSuper::printArgs(std::ostream& out) {
-    out << "(" << CHAR(PRINTNAME(varName)) << ", ";
+    out << CHAR(PRINTNAME(varName)) << ", ";
     env()->printRef(out);
-    out << ") ";
 }
 
 void MkEnv::printArgs(std::ostream& out) {
-    out << "(parent=";
+    out << "parent=";
     arg(0).val()->printRef(out);
     if (nargs() > 1)
         out << ", ";
@@ -207,7 +196,6 @@ void MkEnv::printArgs(std::ostream& out) {
         if (i != nargs() - 2)
             out << ", ";
     }
-    out << ") ";
 }
 
 void Phi::updateType() {
@@ -216,7 +204,6 @@ void Phi::updateType() {
 }
 
 void Phi::printArgs(std::ostream& out) {
-    out << "(";
     if (nargs() > 0) {
         for (size_t i = 0; i < nargs(); ++i) {
             arg(i).val()->printRef(out);
@@ -225,7 +212,6 @@ void Phi::printArgs(std::ostream& out) {
                 out << ", ";
         }
     }
-    out << ")";
 }
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args)
@@ -244,12 +230,12 @@ CallBuiltin::CallBuiltin(Value* e, SEXP builtin,
 }
 
 void CallBuiltin::printArgs(std::ostream& out) {
-    std::cout << "[" << getBuiltinName(builtinId) << "] ";
+    std::cout << getBuiltinName(builtinId) << ", ";
     Instruction::printArgs(out);
 }
 
 void CallSafeBuiltin::printArgs(std::ostream& out) {
-    std::cout << "[" << getBuiltinName(builtinId) << "] ";
+    std::cout << getBuiltinName(builtinId) << ", ";
     Instruction::printArgs(out);
 }
 
@@ -269,28 +255,24 @@ MkFunCls::MkFunCls(Closure* fun, Value* parent)
     assert(fun->closureEnv() == Env::notClosed());
 }
 
+void MkFunCls::printArgs(std::ostream& out) {
+    out << *fun;
+    out << ", ";
+    Instruction::printArgs(out);
+}
+
 void StaticEagerCall::printArgs(std::ostream& out) {
-    out << "(" << *cls_ << ", ";
-    if (nargs() > 0) {
-        for (size_t i = 0; i < nargs(); ++i) {
-            arg(i).val()->printRef(out);
-            if (i + 1 < nargs())
-                out << ", ";
-        }
-    }
-    out << ")";
+    out << *cls_;
+    if (nargs() > 0)
+        out << ", ";
+    Instruction::printArgs(out);
 }
 
 void StaticCall::printArgs(std::ostream& out) {
-    out << "(" << *cls_ << ", ";
-    if (nargs() > 0) {
-        for (size_t i = 0; i < nargs(); ++i) {
-            arg(i).val()->printRef(out);
-            if (i + 1 < nargs())
-                out << ", ";
-        }
-    }
-    out << ")";
+    out << *cls_;
+    if (nargs() > 0)
+        out << ", ";
+    Instruction::printArgs(out);
 }
 }
 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -525,6 +525,7 @@ class FLI(MkFunCls, 1, Effect::None, EnvAccess::Capture) {
   public:
     Closure* fun;
     MkFunCls(Closure* fun, Value* parent);
+    void printArgs(std::ostream&) override;
 };
 
 class FLI(Force, 1, Effect::Any, EnvAccess::None) {
@@ -703,9 +704,10 @@ class VLI(Call, Effect::Any, EnvAccess::Leak), public CallInstructionI {
 // Call instruction for lazy, but staticatlly resolved calls. Closure is
 // specified as `cls_`, args passed as promises.
 class VLI(StaticCall, Effect::Any, EnvAccess::Leak), public CallInstructionI {
+    Closure* cls_;
+
   public:
     constexpr static size_t callArgOffset = 1;
-    Closure* cls_;
 
     Closure* cls() { return cls_; }
     size_t nCallArgs() override { return nargs() - callArgOffset; }
@@ -729,9 +731,10 @@ class VLI(StaticCall, Effect::Any, EnvAccess::Leak), public CallInstructionI {
 // specified as `cls_`, args passed as values.
 class VLI(StaticEagerCall, Effect::Any, EnvAccess::Leak),
     public CallInstructionI {
+    Closure* cls_;
+
   public:
     constexpr static size_t callArgOffset = 1;
-    Closure* cls_;
 
     Closure* cls() { return cls_; }
     size_t nCallArgs() override { return nargs() - callArgOffset; }

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -24,6 +24,8 @@
     V(ChkMissing)                                                              \
     V(ChkClosure)                                                              \
     V(Call)                                                                    \
+    V(StaticCall)                                                              \
+    V(StaticEagerCall)                                                         \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
     V(MkEnv)                                                                   \
@@ -58,6 +60,7 @@
     V(Subassign2_1D)                                                           \
     V(ForSeqSize)                                                              \
     V(Deopt)                                                                   \
-    V(Force)                                                                   
+    V(Force)                                                                   \
+    V(CastType)
 
 #endif

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -23,8 +23,9 @@ void Module::printEachVersion(std::ostream& out) {
     }
 }
 
-Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args) {
-    auto* f = new pir::Closure(args);
+Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args,
+                         Env* env) {
+    auto* f = new pir::Closure(args, env);
     functions.emplace(fun, f);
     return f;
 }

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -25,6 +25,7 @@ void Module::printEachVersion(std::ostream& out) {
 
 Closure* Module::declare(rir::Function* fun, const std::vector<SEXP>& args,
                          Env* env) {
+    assert(functions.count(fun) == 0);
     auto* f = new pir::Closure(args, env);
     functions.emplace(fun, f);
     return f;

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -19,7 +19,7 @@ class Module {
     std::unordered_map<SEXP, Env*> environments;
 
   public:
-    Closure* declare(rir::Function*, const std::vector<SEXP>& a);
+    Closure* declare(rir::Function*, const std::vector<SEXP>& a, Env* env);
     Env* getEnv(SEXP);
 
     void print(std::ostream& out = std::cout);

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -19,7 +19,6 @@ class Module {
     std::unordered_map<SEXP, Env*> environments;
 
   public:
-    Closure* declare(rir::Function*, const std::vector<SEXP>& a, Env* env);
     Env* getEnv(SEXP);
 
     void print(std::ostream& out = std::cout);
@@ -51,6 +50,16 @@ class Module {
         return functions.at(f).current();
     }
 
+    typedef std::function<void(Closure* f)> Compile;
+    Closure* getOrCreate(rir::Function* f, const std::vector<SEXP>& a, Env* env,
+                         Compile cmp) {
+        if (functions.count(f))
+            return functions.at(f).current();
+        Closure* cls = declare(f, a, env);
+        cmp(cls);
+        return cls;
+    }
+
     typedef std::function<void(VersionedClosure&)> PirClosureVersionIterator;
     void eachPirFunction(PirClosureIterator it);
     void eachPirFunction(PirClosureVersionIterator it);
@@ -58,6 +67,7 @@ class Module {
     ~Module();
 
   private:
+    Closure* declare(rir::Function*, const std::vector<SEXP>& a, Env* env);
     std::unordered_map<rir::Function*, VersionedClosure> functions;
 };
 

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -1,5 +1,6 @@
 #include "pir_tests.h"
 #include "R/Protect.h"
+#include "R/RList.h"
 #include "R_ext/Parse.h"
 #include "analysis/query.h"
 #include "analysis/verifier.h"
@@ -11,22 +12,53 @@
 namespace {
 using namespace rir;
 
-std::pair<pir::Closure*, pir::Module*> compile(const std::string& inp,
-                                               SEXP env = R_GlobalEnv) {
+std::unordered_map<std::string, pir::Closure*>
+compile(const std::string& context, const std::string& expr, pir::Module* m,
+        SEXP super = R_GlobalEnv) {
     Protect p;
-    ParseStatus status;
-    SEXP arg = p(CONS(R_NilValue, R_NilValue));
-    SET_TAG(arg, Rf_install("arg1"));
-    SEXP str = p(Rf_mkString(inp.c_str()));
-    SEXP bdy = p(R_ParseVector(str, -1, &status, R_NilValue));
-    SEXP fun = p(Compiler::compileClosure(CDR(bdy), arg));
-    CLOENV(fun) = env;
-    pir::Module* m = new pir::Module;
+
+    auto eval = [&](const std::string& expr, SEXP env) {
+        ParseStatus status;
+        // Parse expression
+        SEXP str = p(Rf_mkString(("{" + expr + "}").c_str()));
+        SEXP e = p(R_ParseVector(str, -1, &status, R_NilValue));
+
+        // Compile expression to rir
+        SEXP rirexp = p(Compiler::compileClosure(VECTOR_ELT(e, 0), R_NilValue));
+
+        // Evaluate expression under the fresh environment `env`
+        Rf_eval(BODY(rirexp), env);
+    };
+
+    if (context != "") {
+        SEXP contextEnv = p(Rf_allocSExp(ENVSXP));
+        ENCLOS(contextEnv) = super;
+        eval(context, contextEnv);
+        super = contextEnv;
+    }
+
+    SEXP env = p(Rf_allocSExp(ENVSXP));
+    ENCLOS(env) = super;
+    eval(expr, env);
+
     pir::Rir2PirCompiler cmp(m);
+
+    // Compile every function the expression created
+    std::unordered_map<std::string, pir::Closure*> results;
+    auto envlist = RList(FRAME(env));
+    for (auto f = envlist.begin(); f != envlist.end(); ++f) {
+        auto fun = *f;
+        if (TYPEOF(fun) == CLOSXP) {
+            assert(isValidClosureSEXP(fun));
+            // isValidClosureSEXP(fun)->body()->print();
+            results[CHAR(PRINTNAME(f.tag()))] = cmp.compileClosure(fun);
+        }
+    }
+
+    m->print(std::cout);
     // cmp.setVerbose(true);
-    auto f = cmp.compileClosure(fun);
     cmp.optimizeModule();
-    return std::pair<pir::Closure*, pir::Module*>(f, m);
+    return results;
 }
 
 using namespace rir::pir;
@@ -35,16 +67,16 @@ typedef std::pair<std::string, TestClosure> Test;
 
 #define CHECK(___test___)                                                      \
     if (!(___test___)) {                                                       \
-        m->print(std::cerr);                                                   \
+        m.print(std::cerr);                                                    \
         std::cerr << "'" << #___test___ << "' failed\n";                       \
         assert(false);                                                         \
         return false;                                                          \
     }
 
 bool test42(const std::string& input) {
-    auto res = compile(input);
-    auto f = res.first;
-    auto m = res.second;
+    pir::Module m;
+    auto res = compile("", "theFun <- function() " + input, &m);
+    auto f = res["theFun"];
 
     CHECK(Query::noEnv(f));
 
@@ -55,7 +87,6 @@ bool test42(const std::string& input) {
     CHECK(ld);
     CHECK(TYPEOF(ld->c) == INTSXP);
     CHECK(INTEGER(ld->c)[0] == 42);
-    delete m;
     return true;
 };
 
@@ -79,20 +110,22 @@ bool verify(Module* m) {
     return true;
 }
 
-bool compileAndVerify(const std::string& input) {
-    auto m = compile(input).second;
-    bool t = verify(m);
-    delete m;
+bool compileAndVerify(const std::string& context, const std::string& input) {
+    pir::Module m;
+    compile(context, input, &m);
+    bool t = verify(&m);
     return t;
 }
 
+bool compileAndVerify(const std::string& input) {
+    return compileAndVerify("", input);
+}
+
 bool canRemoveEnvironment(const std::string& input) {
-    auto r = compile(input);
-    auto m = r.second;
-    auto f = r.first;
-    bool t = verify(m);
-    t = t && Query::noEnv(f);
-    delete m;
+    pir::Module m;
+    compile("", input, &m);
+    bool t = verify(&m);
+    m.eachPirFunction([&t](pir::Closure* f) { t = t && Query::noEnv(f); });
     return t;
 }
 
@@ -101,15 +134,13 @@ bool testDelayEnv() {
     //       analysis!
     // auto m = compile("{f <- function()1; arg1[[2]]}");
 
-    auto res = compile("{f <- arg1; arg1[[2]]}");
-    auto f = res.first;
-    auto m = res.second;
-    bool t = Visitor::check(f->entry, [&](Instruction* i, BB* bb) {
+    pir::Module m;
+    auto res = compile("", "a <- function(b) {f <- b; b[[2]]}", &m);
+    bool t = Visitor::check(res["a"]->entry, [&](Instruction* i, BB* bb) {
         if (i->hasEnv())
             CHECK(Deopt::Cast(bb->last()));
         return true;
     });
-    delete m;
     return t;
 }
 
@@ -130,31 +161,30 @@ bool testSuperAssign() {
         });
     };
     {
+        pir::Module m;
         // This super assign can be fully resolved, and dead store eliminated
-        auto r = compile("{a <- 1; (function() a <<- 1)()}");
-        auto m = r.second;
-        auto f = r.first;
+        auto res =
+            compile("", "f <- function() {a <- 1; (function() a <<- 1)()}", &m);
+        auto f = res["f"];
         CHECK(!hasSuperAssign(f));
         CHECK(!hasAssign(f));
-        delete m;
     }
     {
+        pir::Module m;
         // This super assign can be converted into a store to the global env
-        auto r = compile("{(function() a <<- 1)()}");
-        auto m = r.second;
-        auto f = r.first;
+        auto res = compile("", "f <- function() {(function() a <<- 1)()}", &m);
+        auto f = res["f"];
         CHECK(!hasSuperAssign(f));
         CHECK(hasAssign(f));
-        delete m;
     }
     {
+        pir::Module m;
         // This super assign cannot be removed, since the super env is not
-        // assigneable.
-        auto r = compile("{f <- (function() a <<- 1)()}", R_NilValue);
-        auto m = r.second;
-        auto f = r.first;
+        // unknown.
+        auto res = compile(
+            "", "f <- function() {f <- (function() {qq(); a <<- 1})()}", &m);
+        auto f = res["f"];
         CHECK(hasSuperAssign(f));
-        delete m;
     }
 
     return true;
@@ -163,8 +193,7 @@ bool testSuperAssign() {
 static Test tests[] = {
     Test("test_42L", []() { return test42("42L"); }),
     Test("test_inline", []() { return test42("{f <- function() 42L; f()}"); }),
-    Test("return_cls", []() { return compileAndVerify("function() 42L"); }),
-    Test("index", []() { return compileAndVerify("arg1[[2]]"); }),
+    Test("test_inline", []() { return test42("{f <- function() 42L; f()}"); }),
     Test("test_inline_arg",
          []() { return test42("{f <- function(x) x; f(42L)}"); }),
     Test("test_assign",
@@ -172,20 +201,30 @@ static Test tests[] = {
     Test(
         "test_super_assign",
         []() { return test42("{x <- 0; f <- function() x <<- 42L; f(); x}"); }),
-    Test("return_cls", []() { return compileAndVerify("function() 42L"); }),
-    Test("index", []() { return compileAndVerify("arg1[[2]]"); }),
+
+    Test("return_cls",
+         []() { return compileAndVerify("f <- function() 42L"); }),
+    Test("index", []() { return compileAndVerify("f <- function(x) x[[2]]"); }),
+    Test("return_cls",
+         []() { return compileAndVerify("f <- function() {function() 42L}"); }),
     Test("deopt_in_prom",
          []() {
              return compileAndVerify(
-                 "{function(a) {f <- function(x) x; f(a[[1]])}}");
+                 "fun <- function(a) {f <- function(x) x; f(a[[1]])}");
          }),
     Test("delay_env", &testDelayEnv),
-    Test("context_load", []() { return canRemoveEnvironment("a"); }),
+    Test("context_load",
+         []() { return canRemoveEnvironment("f <- function() a"); }),
     Test("super_assign", &testSuperAssign),
     Test("loop",
          []() {
              return compileAndVerify(
-                 "{function(x) {while (x < 10) if (x) x <- x + 1}}");
+                 "f <- function(x) {while (x < 10) if (x) x <- x + 1}");
+         }),
+    Test("static_call",
+         []() {
+             return compileAndVerify("f <- function(x) x",
+                                     "g <- function() f(1); g()");
          }),
 };
 }

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -194,6 +194,11 @@ static Test tests[] = {
     Test("test_42L", []() { return test42("42L"); }),
     Test("test_inline", []() { return test42("{f <- function() 42L; f()}"); }),
     Test("test_inline", []() { return test42("{f <- function() 42L; f()}"); }),
+    Test("test_inline_two",
+         []() {
+             return test42(
+                 "{f <- function(val, fun) fun(val); f(42L, function(x)x)}");
+         }),
     Test("test_inline_arg",
          []() { return test42("{f <- function(x) x; f(42L)}"); }),
     Test("test_assign",

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -21,9 +21,11 @@ Rir2PirCompiler::Rir2PirCompiler(Module* module) : RirCompiler(module) {
     translations.push_back(new ForceDominance());
     translations.push_back(new ScopeResolution());
     translations.push_back(new Cleanup());
+    translations.push_back(new Cleanup());
     translations.push_back(new DelayInstr());
     translations.push_back(new ElideEnv());
     translations.push_back(new DelayEnv());
+    translations.push_back(new Cleanup());
 }
 
 Closure* Rir2PirCompiler::compileClosure(SEXP closure) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -46,8 +46,8 @@ Closure* Rir2PirCompiler::compileFunction(rir::Function* srcFunction,
 
 Closure* Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                                          const std::vector<SEXP>& args,
-                                         Value* closureEnv) {
-    Closure* pirFunction = module->declare(srcFunction, args);
+                                         Env* closureEnv) {
+    Closure* pirFunction = module->declare(srcFunction, args, closureEnv);
 
     Builder builder(pirFunction, closureEnv);
 
@@ -102,7 +102,7 @@ void Rir2PirCompiler::printAfterPass(const std::string& pass,
 void Rir2PirCompiler::applyOptimizations(Closure* f,
                                          const std::string& category) {
     size_t passnr = 0;
-    for (auto translation : this->translations) {
+    for (auto& translation : this->translations) {
         translation->apply(f);
         if (isVerbose())
             printAfterPass(translation->getName(), category, f, passnr++);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -47,23 +47,25 @@ Closure* Rir2PirCompiler::compileFunction(rir::Function* srcFunction,
 Closure* Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                                          const std::vector<SEXP>& args,
                                          Env* closureEnv) {
-    Closure* pirFunction = module->declare(srcFunction, args, closureEnv);
+    return module->getOrCreate(
+        srcFunction, args, closureEnv, [&](Closure* pirFunction) {
 
-    Builder builder(pirFunction, closureEnv);
+            Builder builder(pirFunction, closureEnv);
 
-    {
-        Rir2Pir rir2pir(*this, builder, srcFunction, srcFunction->body());
-        rir2pir.translate();
-        if (isVerbose()) {
-            std::cout << " ========== Done compiling " << srcFunction << "\n";
-            builder.function->print(std::cout);
-            std::cout << " ==========\n";
-        }
-    }
+            {
+                Rir2Pir rir2pir(*this, builder, srcFunction,
+                                srcFunction->body());
+                rir2pir.translate();
+                if (isVerbose()) {
+                    std::cout << " ========== Done compiling " << srcFunction
+                              << "\n";
+                    builder.function->print(std::cout);
+                    std::cout << " ==========\n";
+                }
+            }
 
-    assert(Verify::apply(pirFunction));
-
-    return pirFunction;
+            assert(Verify::apply(pirFunction));
+        });
 }
 
 void Rir2PirCompiler::optimizeModule() {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -15,16 +15,9 @@ class Rir2PirCompiler : public RirCompiler {
     void optimizeModule();
     void printAfterPass(const std::string&, const std::string&, Closure*,
                         size_t);
-
-    ~Rir2PirCompiler() {
-        for (auto translation : translations) {
-            delete translation;
-        }
-    }
-
   private:
     Closure* compileClosure(rir::Function*, const std::vector<SEXP>&,
-                            Value* closureEnv);
+                            Env* closureEnv);
     void applyOptimizations(Closure*, const std::string&);
 };
 } // namespace pir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -15,6 +15,13 @@ class Rir2PirCompiler : public RirCompiler {
     void optimizeModule();
     void printAfterPass(const std::string&, const std::string&, Closure*,
                         size_t);
+
+    ~Rir2PirCompiler() {
+        for (auto translation : translations) {
+            delete translation;
+        }
+    }
+
   private:
     Closure* compileClosure(rir::Function*, const std::vector<SEXP>&,
                             Env* closureEnv);

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -41,7 +41,7 @@ void StackMachine::set(size_t index, Value* value) {
     stack[stack_size() - index - 1] = value;
 }
 
-void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
+void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     assert(pc >= srcCode->code() && pc < srcCode->endCode());
 
     Value* env = insert.env;
@@ -71,7 +71,7 @@ void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
         insert(new StVarSuper(bc.immediateConst(), v, env));
         break;
     case Opcode::ret_:
-        pir2rir.addReturn(ReturnSite(bb, pop()));
+        rir2pir.addReturn(ReturnSite(bb, pop()));
         assert(empty());
         break;
     case Opcode::asbool_:
@@ -123,6 +123,14 @@ void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
         unsigned n = bc.immediate.call_args.nargs;
         rir::CallSite* cs = bc.callSite(srcFunction->body());
 
+        SEXP monomorphic = nullptr;
+        if (cs->hasProfile) {
+            auto prof = cs->profile();
+            if (prof->numTargets == 1) {
+                monomorphic = prof->targets[0];
+            }
+        }
+
         std::vector<Value*> args;
         for (size_t i = 0; i < n; ++i) {
             unsigned argi = cs->args()[i];
@@ -135,19 +143,44 @@ void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
             Promise* prom = insert.function->createProm();
             {
                 Builder promiseBuilder(insert.function, prom);
-                Rir2Pir compiler(pir2rir.compiler(), promiseBuilder,
+                Rir2Pir compiler(rir2pir.compiler(), promiseBuilder,
                                  srcFunction, promiseCode);
                 compiler.translate();
             }
             Value* val = Missing::instance();
             if (Query::pure(prom)) {
-                RirInlinedPromise2Rir compiler(pir2rir, promiseCode);
+                RirInlinedPromise2Rir compiler(rir2pir, promiseCode);
                 val = compiler.translate();
             }
             args.push_back(insert(new MkArg(prom, val, env)));
         }
 
-        push(insert(new Call(env, pop(), args)));
+        if (monomorphic && isValidClosureSEXP(monomorphic)) {
+            auto& cmp = rir2pir.compiler();
+            Closure* f = cmp.compileClosure(monomorphic);
+            Value* expected = insert(new LdConst(monomorphic));
+            Value* t = insert(new Eq(top(), expected));
+            insert(new Branch(t));
+            BB* curBB = insert.bb;
+
+            BB* asExpected = insert.createBB();
+            insert.bb = asExpected;
+            curBB->next0 = asExpected;
+            Value* r1 = insert(new StaticCall(insert.env, f, args));
+
+            BB* fallback = insert.createBB();
+            insert.bb = fallback;
+            curBB->next1 = fallback;
+            Value* r2 = insert(new Call(insert.env, pop(), args));
+
+            BB* cont = insert.createBB();
+            asExpected->next0 = cont;
+            fallback->next0 = cont;
+            insert.bb = cont;
+            push(insert(new Phi({r1, r2}, {asExpected, fallback})));
+        } else {
+            push(insert(new Call(insert.env, pop(), args)));
+        }
         break;
     }
     case Opcode::promise_: {
@@ -157,13 +190,13 @@ void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
         {
             // What should I do with this?
             Builder promiseBuilder(insert.function, prom);
-            Rir2Pir compiler(pir2rir.compiler(), promiseBuilder, srcFunction,
+            Rir2Pir compiler(rir2pir.compiler(), promiseBuilder, srcFunction,
                              promiseCode);
             compiler.translate();
         }
         Value* val = Missing::instance();
         if (Query::pure(prom)) {
-            RirInlinedPromise2Rir compiler(pir2rir, promiseCode);
+            RirInlinedPromise2Rir compiler(rir2pir, promiseCode);
             val = compiler.translate();
         }
         // TODO: Remove comment and check how to deal with
@@ -179,13 +212,18 @@ void StackMachine::runCurrentBC(Rir2Pir& pir2rir, Builder& insert) {
         for (size_t i = 0; i < n; ++i)
             args[n - i - 1] = pop();
 
-        // TODO: compile a list of safe builtins
-        static int vector = findBuiltin("vector");
+        if (TYPEOF(target) == BUILTINSXP) {
+            // TODO: compile a list of safe builtins
+            static int vector = findBuiltin("vector");
 
-        if (getBuiltinNr(target) == vector)
-            push(insert(new CallSafeBuiltin(target, args)));
-        else
-            push(insert(new CallBuiltin(env, target, args)));
+            if (getBuiltinNr(target) == vector)
+                push(insert(new CallSafeBuiltin(target, args)));
+            else
+                push(insert(new CallBuiltin(env, target, args)));
+        } else {
+            Closure* f = rir2pir.compiler().compileClosure(target);
+            push(insert(new StaticEagerCall(env, f, args)));
+        }
         break;
     }
     case Opcode::seq_: {

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -14,6 +14,9 @@ namespace pir {
 class RirCompiler {
   public:
     RirCompiler(Module* module) : module(module) {}
+    RirCompiler(const RirCompiler&) = delete;
+    void operator=(const RirCompiler&) = delete;
+
     virtual Closure* compileClosure(SEXP) = 0;
     
     bool isVerbose() { return verbose; }


### PR DESCRIPTION
This commit adds support for eager calls

When the call target is statically known, let's use a different call
instruction that allows us to directly link to that known closure.

This commit also fixes a bug in the compiler, where we assumed that
every 'static_call_stack' calls a builting (which is wrong).

Also we add support for speculative static calls for callsites which
have been observed to be monomorphic.


@charig: this is mostly the same PR as #101 , but I added a new `StaticEagerCall`.

The previous PR did this to "simulate" eager arguments:

```
a = mkArg(noExpression, aValue)
StaticCall(cls, a)
```

(Ie. create a mkArg, with no promise expression). Leading to stupid code, since now all the mkArg might actually be "fake"-mkArgs (ie. promise expression == nullptr), and therefore all those `ifPromise` lambdas. That was just stupid.

This PR instead adds a new call, that expects a value instead of a promise:

```
StaticEagerCall(cls, aValue)
```

This blows up the code a bit, but makes it much easier to understand.


Additionally, this PR also fixes the following bug in the inliner. We used to mark the fact that we inlined a MkArg, by changing it's type. For example:

```
f:
   prom a0 = MkArg(...)
   Call(g, a0)

g:
   val^ a1 = LdArg(0)
   val a2 = force a
```

As you can see, the `LdArg` converts the promise from type `prom` (a promise as a value) to type `val^` (a promise that should be evaluated). When we inline, we just changed the type of `MkArg` from `prom` to `val^`. This breaks if the `MkArg` flows into two calls:

```
f:
   prom a0 = MkArg(...)
   Call(g, a0)
   Call(x, a0)   

g:
   val^ a1 = LdArg(0)
   val a2 = force a
```

If we inline and change the type of `a0` then the second call `Call(x, a0)` breaks. Therefore we now insert an explicit cast:

```
f:
   prom a0 = MkArg(...)
   val^ a1 = CastType(a0)
   val a2 = force(a1)          // inlined g
   Call(x, a0)
```