### PR TITLE
delay loading of constants

### DIFF
--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -34,6 +34,12 @@ void DelayInstr::apply(Closure* function) {
                     } else {
                         next = bb->moveToBegin(ip, usage->bb());
                     }
+                } else if (usage && usage != *next) {
+                    auto swap = ip;
+                    while (swap + 1 != bb->end() && *(swap + 1) != usage) {
+                        bb->swapWithNext(swap);
+                        ++swap;
+                    }
                 }
             }
 


### PR DESCRIPTION
Instructions with no side-effects should be scheduled as late as
possible. This is a fairly stupid optimization, but it should help
some of the pain points when compiling to rir.