### PR TITLE
A new Register allocator

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -54,6 +54,24 @@ void AbstractPirValue::print(std::ostream& out) {
     out << ") : " << type;
 }
 
+MkFunCls* AbstractREnvironmentHierarchy::findClosure(Value* env, Value* fun) {
+    for (;;) {
+        if (Force::Cast(fun)) {
+            fun = Force::Cast(fun)->arg<0>().val();
+        } else if (ChkClosure::Cast(fun)) {
+            fun = ChkClosure::Cast(fun)->arg<0>().val();
+        } else {
+            break;
+        }
+    }
+    while (env && env != AbstractREnvironment::UnknownParent) {
+        if ((*this)[env].mkClosures.count(fun))
+            return (*this)[env].mkClosures.at(fun);
+        env = (*this)[env].parentEnv;
+    }
+    return AbstractREnvironment::UnknownClosure;
+}
+
 AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
     while (env != AbstractREnvironment::UnknownParent) {
         if (this->count(env) == 0)

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -82,6 +82,7 @@ struct AbstractPirValue {
 
     typedef std::function<void(Value*)> ValMaybe;
     typedef std::function<void(ValOrig&)> ValOrigMaybe;
+    typedef std::function<bool(ValOrig&)> ValOrigMaybePredicate;
 
     void ifSingleValue(ValMaybe known) {
         if (!unknown && vals.size() == 1)
@@ -91,6 +92,13 @@ struct AbstractPirValue {
     void eachSource(ValOrigMaybe apply) {
         for (auto v : vals)
             apply(v);
+    }
+
+    bool checkEachSource(ValOrigMaybePredicate apply) {
+        for (auto v : vals)
+            if (!apply(v))
+                return false;
+        return true;
     }
 
     bool merge(const AbstractPirValue& other);

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -244,14 +244,7 @@ class AbstractREnvironmentHierarchy
         return changed;
     }
 
-    MkFunCls* findClosure(Value* env, Value* fun) {
-        while (env && env != AbstractREnvironment::UnknownParent) {
-            if ((*this)[env].mkClosures.count(fun))
-                return (*this)[env].mkClosures.at(fun);
-            env = (*this)[env].parentEnv;
-        }
-        return AbstractREnvironment::UnknownClosure;
-    }
+    MkFunCls* findClosure(Value* env, Value* fun);
 
     AbstractLoad get(Value* env, SEXP e) const;
 };

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -9,8 +9,9 @@ using namespace rir::pir;
 class TheVerifier {
   public:
     Closure* f;
+    CFG cfg;
 
-    TheVerifier(Closure* f) : f(f) {}
+    TheVerifier(Closure* f) : f(f), cfg(f->entry) {}
 
     bool ok = true;
 
@@ -26,7 +27,8 @@ class TheVerifier {
         }
 
         for (auto p : f->promises) {
-            verify(p);
+            if (p)
+                verify(p);
             if (!ok) {
                 std::cerr << "Verification of promise failed\n";
                 p->print(std::cerr);
@@ -34,7 +36,8 @@ class TheVerifier {
             }
         }
         for (auto p : f->defaultArgs) {
-            verify(p);
+            if (p)
+                verify(p);
             if (!ok) {
                 std::cerr << "Verification of argument failed\n";
                 p->print(std::cerr);
@@ -50,6 +53,16 @@ class TheVerifier {
             if (!bb->next0 && !bb->next1) {
                 std::cerr << "bb" << bb->id << " has no successor\n";
                 ok = false;
+            }
+            if (cfg.predecessors[bb->id].size() > 1) {
+                for (auto in : cfg.predecessors[bb->id]) {
+                    if (in->next1) {
+                        std::cerr << "BB " << in->id << " merges into "
+                                  << bb->id << " and branches into "
+                                  << in->next1->id << " at the same time.\n";
+                        ok = false;
+                    }
+                }
             }
         } else {
             Instruction* last = bb->last();
@@ -94,7 +107,15 @@ class TheVerifier {
             Instruction* iv = Instruction::Cast(v);
             if (iv) {
                 if (phi) {
-                    // TODO: what is a good condition for phi inputs?
+                    if (!cfg.transitivePredecessors[i->bb()->id].count(
+                            iv->bb())) {
+                        std::cerr << "Error at instruction '";
+                        i->print(std::cerr);
+                        std::cerr << "': input '";
+                        iv->printRef(std::cerr);
+                        std::cerr << "' does not come from a predecessor.\n";
+                        ok = false;
+                    }
                 } else if ((iv->bb() == i->bb() &&
                             bb->indexOf(iv) > bb->indexOf(i)) ||
                            (iv->bb() != i->bb() &&

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -54,6 +54,27 @@ class TheVerifier {
                 std::cerr << "bb" << bb->id << " has no successor\n";
                 ok = false;
             }
+            // This check verifies that our graph is in edge-split format.
+            // Currently we do not rely on this property, however we should
+            // make it a conscious decision if we want to violate it.
+            // This basically rules out graphs of the following form:
+            //
+            //   A       B
+            //     \   /   \
+            //       C       D
+            //
+            // or
+            //     _
+            //  | / \
+            //  A __/
+            //  |
+            //
+            // The nice property about edge-split graphs is, that merge-points
+            // are always dominated by *both* inputs, therefore local code
+            // motion can push instructions to both input blocks.
+            //
+            // In the above example, we can't push an instruction from C to A
+            // and B, without worrying about D.
             if (cfg.predecessors[bb->id].size() > 1) {
                 for (auto in : cfg.predecessors[bb->id]) {
                     if (in->next1) {

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -54,27 +54,28 @@ class TheVerifier {
                 std::cerr << "bb" << bb->id << " has no successor\n";
                 ok = false;
             }
-            // This check verifies that our graph is in edge-split format.
-            // Currently we do not rely on this property, however we should
-            // make it a conscious decision if we want to violate it.
-            // This basically rules out graphs of the following form:
-            //
-            //   A       B
-            //     \   /   \
-            //       C       D
-            //
-            // or
-            //     _
-            //  | / \
-            //  A __/
-            //  |
-            //
-            // The nice property about edge-split graphs is, that merge-points
-            // are always dominated by *both* inputs, therefore local code
-            // motion can push instructions to both input blocks.
-            //
-            // In the above example, we can't push an instruction from C to A
-            // and B, without worrying about D.
+            /* This check verifies that our graph is in edge-split format.
+               Currently we do not rely on this property, however we should
+               make it a conscious decision if we want to violate it.
+               This basically rules out graphs of the following form:
+
+                 A       B
+                   \   /   \
+                     C       D
+
+               or
+                   _
+                | / \
+                A __/
+                |
+
+               The nice property about edge-split graphs is, that merge-points
+               are always dominated by *both* inputs, therefore local code
+               motion can push instructions to both input blocks.
+
+               In the above example, we can't push an instruction from C to A
+               and B, without worrying about D.
+            */
             if (cfg.predecessors[bb->id].size() > 1) {
                 for (auto in : cfg.predecessors[bb->id]) {
                     if (in->next1) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -26,7 +26,6 @@ class TheCleanup {
                 Force* force = Force::Cast(i);
                 ChkClosure* chkcls = ChkClosure::Cast(i);
                 ChkMissing* missing = ChkMissing::Cast(i);
-                ChkClosure* closure = ChkClosure::Cast(i);
                 Phi* phi = Phi::Cast(i);
                 MkArg* arg = MkArg::Cast(i);
                 if (!i->mightIO() && !i->changesEnv() && i->unused()) {
@@ -39,7 +38,7 @@ class TheCleanup {
                     }
                 } else if (chkcls) {
                     Value* arg = chkcls->arg<0>().val();
-                    if (PirType(RType::closure).isSuper(arg->type)) {
+                    if (arg->type.isA(RType::closure)) {
                         chkcls->replaceUsesWith(arg);
                         next = bb->remove(ip);
                     }
@@ -47,12 +46,6 @@ class TheCleanup {
                     Value* arg = missing->arg<0>().val();
                     if (PirType::val().isSuper(arg->type)) {
                         missing->replaceUsesWith(arg);
-                        next = bb->remove(ip);
-                    }
-                } else if (closure) {
-                    Value* arg = closure->arg<0>().val();
-                    if (PirType::val().isSuper(arg->type)) {
-                        closure->replaceUsesWith(arg);
                         next = bb->remove(ip);
                     }
                 } else if (phi) {

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -15,7 +15,8 @@ void DelayInstr::apply(Closure* function) {
             auto i = *ip;
             auto next = ip + 1;
 
-            if (i->accessesEnv() == false && i->mightIO() == false) {
+            if (i->accessesEnv() == false && i->mightIO() == false &&
+                !Phi::Cast(i)) {
                 Instruction* usage = i->hasSingleUse();
                 if (usage && usage->bb() != bb) {
                     auto phi = Phi::Cast(usage);

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -111,14 +111,11 @@ class TheScopeResolution {
                         // handled here)
                         if (!aval.isSingleValue() && !aval.isUnknown() &&
                             !ldfun) {
-                            auto hasAllInputs = [&](BB* load) {
-                                bool success = true;
-                                aval.eachSource([&](ValOrig& src) {
-                                    if (!cfg.transitivePredecessors[load->id]
-                                             .count(src.origin->bb()))
-                                        success = false;
+                            auto hasAllInputs = [&](BB* load) -> bool {
+                                return aval.checkEachSource([&](ValOrig& src) {
+                                    return cfg.transitivePredecessors[load->id]
+                                        .count(src.origin->bb());
                                 });
-                                return success;
                             };
                             BB* phiBlock = bb;
                             // Shift phi up until we see at least two inputs

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -36,8 +36,6 @@ class Closure : public Code {
 
     Promise* createProm();
 
-    size_t maxBBId = 0;
-
     friend std::ostream& operator<<(std::ostream& out, const Closure& e) {
         out << "Func(" << (void*)&e << ")";
         return out;

--- a/rir/src/compiler/pir/code.h
+++ b/rir/src/compiler/pir/code.h
@@ -16,6 +16,8 @@ class Code {
   public:
     BB* entry;
 
+    size_t maxBBId = 0;
+
     Code();
     void print(std::ostream&);
     ~Code();

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -231,7 +231,7 @@ void MkEnv::printArgs(std::ostream& out) {
 
 void Phi::updateType() {
     type = arg(0).val()->type;
-    eachArg([&](Value* v) -> void { type = type | v->type; });
+    eachArg([&](BB*, Value* v) -> void { type = type | v->type; });
 }
 
 void Phi::printArgs(std::ostream& out) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -130,12 +130,21 @@ class Instruction : public Value {
     virtual const InstrArg& arg(size_t pos) const = 0;
 
     typedef std::function<void(Value*)> ArgumentValueIterator;
+    typedef std::function<void(Instruction*)> ArgumentInstructionIterator;
     typedef std::function<void(const InstrArg&)> ArgumentIterator;
     typedef std::function<void(InstrArg&)> MutableArgumentIterator;
 
     void eachArg(Instruction::ArgumentValueIterator it) const {
         for (size_t i = 0; i < nargs(); ++i)
             it(arg(i).val());
+    }
+
+    void eachInstructionArg(Instruction::ArgumentInstructionIterator it) const {
+        for (size_t i = 0; i < nargs(); ++i) {
+            auto in = Instruction::Cast(arg(i).val());
+            if (in)
+                it(in);
+        }
     }
 
     void eachArg(Instruction::ArgumentIterator it) const {
@@ -889,6 +898,22 @@ class VLI(Phi, Effect::None, EnvAccess::None) {
     void addInput(BB* in, Value* arg) {
         input.push_back(in);
         VarLenInstruction::pushArg(arg);
+    }
+    typedef std::function<void(BB* bb, Value*)> PhiArgumentIterator;
+    typedef std::function<void(BB* bb, Instruction*)>
+        PhiArgumentInstructionIterator;
+
+    void eachArg(PhiArgumentIterator it) const {
+        for (size_t i = 0; i < nargs(); ++i)
+            it(input[i], arg(i).val());
+    }
+
+    void eachInstructionArg(PhiArgumentInstructionIterator it) const {
+        for (size_t i = 0; i < nargs(); ++i) {
+            auto in = Instruction::Cast(arg(i).val());
+            if (in)
+                it(input[i], in);
+        }
     }
 };
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -145,6 +145,7 @@ struct PirType {
         //    .orObj();
     }
     static PirType vecs() { return num() | RType::str | RType::vec; }
+    static PirType closure() { return RType::closure; }
 
     static PirType valOrMissing() { return val().orMissing(); }
     static PirType valOrLazy() { return val().orLazy(); }
@@ -222,6 +223,8 @@ struct PirType {
         return flags_ == o.flags_ &&
                (isRType() ? t_.r == o.t_.r : t_.n == o.t_.n);
     }
+
+    bool isA(const PirType& o) const { return o.isSuper(*this); }
 
     bool isSuper(const PirType& o) const {
         if (isRType() != o.isRType()) {

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -73,7 +73,7 @@ class SSAAllocator {
     }
 
     // Run backwards analysis to compute livenessintervals
-    void computeLiveness(bool verbose = true) {
+    void computeLiveness(bool verbose = false) {
         // temp list of live out sets for every BB
         std::unordered_map<BB*, std::set<Value*>> liveAtEnd(bbsSize);
 

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -91,8 +91,8 @@ class SSAAllocator {
 
             // Mark all (backwards) incoming live variables
             for (auto v : liveAtEnd[bb]) {
-                auto& liveRange = livenessInterval[v][bb->id];
                 assert(livenessInterval.count(v));
+                auto& liveRange = livenessInterval.at(v)[bb->id];
                 if (!liveRange.live || liveRange.end < bb->size()) {
                     liveRange.live = true;
                     liveRange.end = bb->size();
@@ -219,8 +219,10 @@ class SSAAllocator {
     void computeStackAllocation() {
         Visitor::run(code->entry, [&](BB* bb) {
             {
-                // Phi at the beginning of BB, all inputs at the end of
-                // immediate predecessors -> put on stack
+                // If a phi is at the beginning of a BB, and all inputs are at
+                // the end of the immediate predecessors BB, we can allocate it
+                // on the stack, since the stack is otherwise empty at the BB
+                // boundaries.
                 size_t pos = 1;
                 for (auto i : *bb) {
                     Phi* phi = Phi::Cast(i);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -109,6 +109,7 @@ void Rir2PirCompiler::applyOptimizations(Closure* f,
         translation->apply(f);
         if (isVerbose())
             printAfterPass(translation->getName(), category, f, passnr++);
+        assert(Verify::apply(f));
     }
 }
 

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -46,7 +46,6 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     assert(pc >= srcCode->code() && pc < srcCode->endCode());
 
     Value* env = insert.env;
-    BB* bb = insert.bb;
 
     Value* v;
     Value* x;
@@ -72,7 +71,7 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
         insert(new StVarSuper(bc.immediateConst(), v, env));
         break;
     case Opcode::ret_:
-        rir2pir.addReturn(ReturnSite(bb, pop()));
+        rir2pir.addReturn(ReturnSite(insert.bb, pop()));
         assert(empty());
         break;
     case Opcode::asbool_:

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -4,14 +4,14 @@
 namespace rir {
 namespace pir {
 
-BB* Builder::createBB() { return new BB(code, ++function->maxBBId); }
+BB* Builder::createBB() { return new BB(code, ++code->maxBBId); }
 
 Builder::Builder(Closure* fun, Value* closureEnv)
     : function(fun), code(fun), env(nullptr), bb(fun->entry) {
     bb = function->entry = createBB();
-    std::vector<Value*> args;
-    for (size_t i = 0; i < fun->argNames.size(); ++i)
-        args.push_back(this->operator()(new LdArg(i)));
+    std::vector<Value*> args(fun->argNames.size());
+    for (long i = fun->argNames.size() - 1; i >= 0; --i)
+        args[i] = this->operator()(new LdArg(i));
     env = this->operator()(new MkEnv(closureEnv, fun->argNames, args.data()));
 }
 Builder::Builder(Closure* fun, Promise* prom)

--- a/rir/src/compiler/util/cfg.h
+++ b/rir/src/compiler/util/cfg.h
@@ -9,10 +9,11 @@ namespace rir {
 namespace pir {
 
 class CFG {
-    typedef std::vector<BB*> BBList;
+    typedef std::unordered_set<BB*> BBList;
 
   public:
     std::vector<BBList> predecessors;
+    std::vector<BBList> transitivePredecessors;
     BBList exits;
 
     CFG(BB*);

--- a/rir/src/compiler/util/visitor.h
+++ b/rir/src/compiler/util/visitor.h
@@ -251,7 +251,6 @@ class DominatorTreeVisitor {
 
             action(cur);
         }
-        assert(todo.empty());
     }
 };
 }

--- a/rir/src/compiler/util/visitor.h
+++ b/rir/src/compiler/util/visitor.h
@@ -2,11 +2,14 @@
 #define COMPILER_VISITOR_H
 
 #include "../pir/bb.h"
+#include "../pir/code.h"
 #include "../pir/pir.h"
+#include "../util/cfg.h"
 
 #include <deque>
 #include <functional>
 #include <random>
+#include <stack>
 #include <unordered_set>
 
 namespace rir {
@@ -66,7 +69,10 @@ struct PointerMarker {
 };
 };
 
-template <bool STABLE, class Marker>
+enum class Order { Depth, Breadth, Random };
+enum class Direction { Forward, Backward };
+
+template <Order ORDER, class Marker>
 class VisitorImplementation {
   public:
     typedef std::function<bool(Instruction*)> InstrActionPredicate;
@@ -187,7 +193,7 @@ class VisitorImplementation {
 
     static void enqueue(std::deque<BB*>& todo, BB* bb) {
         // For analysis random search is faster
-        if (STABLE || coinFlip())
+        if (ORDER == Order::Breadth || (ORDER == Order::Random && coinFlip()))
             todo.push_back(bb);
         else
             todo.push_front(bb);
@@ -195,11 +201,59 @@ class VisitorImplementation {
 };
 
 class Visitor
-    : public VisitorImplementation<false, VisitorHelpers::IDMarker> {};
+    : public VisitorImplementation<Order::Random, VisitorHelpers::IDMarker> {};
 class BreadthFirstVisitor
-    : public VisitorImplementation<true, VisitorHelpers::IDMarker> {};
-class UnstableIDsVisitor
-    : public VisitorImplementation<true, VisitorHelpers::PointerMarker> {};
+    : public VisitorImplementation<Order::Breadth, VisitorHelpers::IDMarker> {};
+class DepthFirstVisitor
+    : public VisitorImplementation<Order::Depth, VisitorHelpers::IDMarker> {};
+
+template <class Marker = VisitorHelpers::IDMarker>
+class DominatorTreeVisitor {
+    using BBAction = VisitorHelpers::BBAction;
+
+    const DominanceGraph& dom;
+
+  public:
+    DominatorTreeVisitor(const DominanceGraph& dom) : dom(dom) {}
+
+    void run(Code* code, BBAction action) {
+        Marker done;
+
+        std::stack<BB*> todo;
+        std::stack<BB*> delayedTodo;
+
+        todo.push(code->entry);
+        done.set(code->entry);
+
+        BB* cur;
+        while (!todo.empty() || !delayedTodo.empty()) {
+            if (!todo.empty()) {
+                cur = todo.top();
+                todo.pop();
+            } else {
+                cur = delayedTodo.top();
+                delayedTodo.pop();
+            }
+
+            auto apply = [&](BB* next) {
+                if (!next || done.check(next))
+                    return;
+                if (dom.dominates(cur, next)) {
+                    todo.push(next);
+                } else {
+                    delayedTodo.push(next);
+                }
+                done.set(next);
+            };
+
+            apply(cur->next0);
+            apply(cur->next1);
+
+            action(cur);
+        }
+        assert(todo.empty());
+    }
+};
 }
 }
 


### PR DESCRIPTION
This patch adds a new liveness interval algorithm, a naive algo for
sinking ssa variables to stack slots and a coloring register alloc
for the remaining variables.

Liveranges are stored in the following form:

    Instruction -> BB -> {live : bool, start : pos, end : pos}

Two variables do not interfere if: for all BB: either they are not
both live, or their start-end intervals do not overlap.

Stack slots are assigned for variables which are produced and
consumed exactly once in the same BB. Additionally trivial phis,
which are produced at the end of all input BBs and the consumed
by a phi at the beginning of the successor block are sunk to stack
slots.

The approach is fairly naive and should be improved.

The remaining registers are allocated in a linear pass on the
dominator tree. According to Hack and Goos, this should be optimal.

UPDATE: we have established offline, that our `removePhi` transformation is in fact moving to CSSA. I leave the below comment of reference. The reason why it works is that `x1` from below will be split into `x1'` which goes into the phi and the old `x1` which goes into `y = x1+x2`.

> Caveat: we precolor all phi, such that phi and all inputs are
> coalesced into the same input. Also as of yet, we do not convert
> to CSSA. I conjecture that there should be a program that breaks
> this approach. Something like:
> 
>     x1       x2         x3
> 
>       \      /         /
>          y = x1+x2
>             \        /
>            x4 = phi(x1,x2,x3)
> 
> But so far I haven't been able to construct it, or understand
> why it couldn't happen. More investigation is necessary and
> probably another reading of Boissinot etal.
> 

Unfortunately some other things got lumped into this PR:

* The verifier was not run after every optimization
* Delay instruction did delay phis (which is never a good idea)
* Scope resolution was broken for `LdFun`. This instruction
  performs an implicit `ChkClosure` test. If we replace a `LdFun`
  with something that is not of static type `closure`, we need
  to add that runtime check.
* Scope resolution stupidly places phis. Changed it to move
  phi's up the cfg to the point where the inputs actually come
  from different predecessors.