### PR TITLE
Expose Verbosity to R api

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -20,8 +20,8 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what) {
-    invisible(.Call("pir_compile", what))
+pir.compile <- function(what, verbose = FALSE) {
+    .Call("pir_compile", what, verbose)
 }
 
 pir.tests <- function() {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -86,7 +86,7 @@ REXPORT SEXP rir_body(SEXP cls) {
 #include "compiler/translations/pir_2_rir.h"
 #include "compiler/translations/rir_2_pir/rir_2_pir.h"
 
-REXPORT SEXP pir_compile(SEXP what) {
+REXPORT SEXP pir_compile(SEXP what, bool debug = false) {
     if (!isValidClosureSEXP(what))
         Rf_error("not a compiled closure");
     assert(DispatchTable::unpack(BODY(what))->capacity() == 2 &&
@@ -94,7 +94,6 @@ REXPORT SEXP pir_compile(SEXP what) {
     if (DispatchTable::unpack(BODY(what))->slot(1) != nullptr)
         Rf_error("closure already compiled to pir");
 
-    bool debug = true;
     Protect p(what);
 
     // compile to pir

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -239,14 +239,16 @@ extern "C" SEXP rir_eval(SEXP, SEXP);
 extern "C" SEXP pir_compile(SEXP);
 
 bool testPir2Rir(std::string name, std::string fun, std::string args,
-                 bool useSame = false) {
+                 bool useSame = false, bool verbose = false) {
     Protect p;
 
     std::string wrapper =
         "rir.compile( function() " + name + "(" + args + ") )()";
 
-    Rprintf("   > %s <- %s\n", name.c_str(), fun.c_str());
-    Rprintf("   > %s\n\n", wrapper.c_str());
+    if (verbose) {
+        Rprintf("   > %s <- %s\n", name.c_str(), fun.c_str());
+        Rprintf("   > %s\n\n", wrapper.c_str());
+    }
 
     auto execEnv = p(Rf_NewEnvironment(R_NilValue, R_NilValue, R_GlobalEnv));
     auto rirFun = p(parseCompileToRir(fun));
@@ -262,8 +264,10 @@ bool testPir2Rir(std::string name, std::string fun, std::string args,
     auto rCall = createRWrapperCall(wrapper);
 
     auto orig = p(Rf_eval(rCall, execEnv));
-    Rprintf(" orig = %p\n", orig);
-    Rf_PrintValue(orig);
+    if (verbose) {
+        Rprintf(" orig = %p\n", orig);
+        Rf_PrintValue(orig);
+    }
 
     if (!useSame) {
         // redo everything
@@ -280,8 +284,10 @@ bool testPir2Rir(std::string name, std::string fun, std::string args,
     pir_compile(rirFun);
 
     auto after = p(Rf_eval(rCall, execEnv));
-    Rprintf("after = %p\n", after);
-    Rf_PrintValue(after);
+    if (verbose) {
+        Rprintf("after = %p\n", after);
+        Rf_PrintValue(after);
+    }
 
     return checkPir2Rir(orig, after);
 }

--- a/rir/src/ir/CodeEditor.cpp
+++ b/rir/src/ir/CodeEditor.cpp
@@ -44,6 +44,13 @@ CodeEditor::CodeEditor(SEXP in) {
     loadCode(f, ch, true);
 }
 
+CodeEditor::CodeEditor(Function* f) {
+    Code* ch = f->body();
+    ast = src_pool_at(globalContext(), ch->src);
+    localsCnt = ch->localsCount;
+    loadCode(f, ch, true);
+}
+
 CodeEditor::CodeEditor(Code* code) {
     ast = src_pool_at(globalContext(), code->src);
     localsCnt = code->localsCount;

--- a/rir/src/ir/CodeEditor.h
+++ b/rir/src/ir/CodeEditor.h
@@ -428,6 +428,7 @@ class CodeEditor {
     bool isLabel(Iterator ins) const { return (*ins).isLabel(); }
 
     explicit CodeEditor(SEXP closure);
+    explicit CodeEditor(Function* function);
     explicit CodeEditor(Code* code);
     CodeEditor(Code* code, SEXP formals);
 

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -46,6 +46,7 @@ struct DispatchTable {
     }
 
     void put(size_t i, Function* f) {
+        assert(i < capacity());
         EXTERNALSXP_SET_ENTRY(container(), i, f->container());
     }
 


### PR DESCRIPTION
let the user choose verbosity from `pir.compile` and print all dispatch table slots on `rir.disassemble`