### PR TITLE
Cleanup

### DIFF
--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -283,16 +283,7 @@ size_t Pir2Rir::compile(Context& ctx, Code* code) {
                 while (next1->isEmpty())
                     next1 = next1->next0;
 
-                bool useBrFalse = true;
-                if (next0->id == bb->id + 1)
-                    useBrFalse = false;
-
-                if (useBrFalse)
-                    cs << BC::brfalse(bbLabels[next0])
-                       << BC::br(bbLabels[next1]);
-                else
-                    cs << BC::brtrue(bbLabels[next1])
-                       << BC::br(bbLabels[next0]);
+                cs << BC::brfalse(bbLabels[next0]) << BC::br(bbLabels[next1]);
 
                 // this is the end of this BB
                 return;

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -46,7 +46,6 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     assert(pc >= srcCode->code() && pc < srcCode->endCode());
 
     Value* env = insert.env;
-    BB* bb = insert.bb;
 
     Value* v;
     Value* x;
@@ -70,10 +69,6 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::stvar_super_:
         v = pop();
         insert(new StVarSuper(bc.immediateConst(), v, env));
-        break;
-    case Opcode::ret_:
-        rir2pir.addReturn(ReturnSite(bb, pop()));
-        assert(empty());
         break;
     case Opcode::asbool_:
     case Opcode::aslogical_:
@@ -365,6 +360,8 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::brtrue_:
     case Opcode::brfalse_:
     case Opcode::br_:
+    case Opcode::ret_:
+    case Opcode::return_:
         assert(false);
 
     // Opcodes that only come from PIR
@@ -387,7 +384,6 @@ void StackMachine::runCurrentBC(Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::dispatch_:
     case Opcode::guard_env_:
     case Opcode::call_stack_:
-    case Opcode::return_:
     case Opcode::beginloop_:
     case Opcode::endcontext_:
     case Opcode::ldddvar_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -268,7 +268,7 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
             cptr += cur.size();
             if (cptr == start + c->codeSize) {
                 assert(cptr == start + c->codeSize);
-                assert(cur.isJmp() || cur.bc == Opcode::ret_);
+                assert(cur.isJmp() || cur.isReturn());
                 break;
             }
         }

--- a/rir/src/ir/cleanup.h
+++ b/rir/src/ir/cleanup.h
@@ -177,6 +177,8 @@ class BCCleanup : public InstructionDispatcher::Receiver {
     void return_(CodeEditor::Iterator ins) override { removeDead(ins + 1); }
 
     void run() {
+        // Go over all instructions. Since some might get marked for deletion
+        // before they are dispatched and the change commited, skip those here
         for (auto i = code_.begin(); i != code_.end(); ++i) {
             if (!i.deleted())
                 dispatcher.dispatch(i);


### PR DESCRIPTION
This adds dead code removal from RIR cleanup pass - anything after `br_`, `ret_` and `return_` is dead until the next label or the end of the codestream.

Also fixes the pass to not dispatch on instructions that are marked to be deleted.

Returns are propagated now back if they are the target of a `br_`.

To make this work, handling of `ret_` in pir2rir needed to be changed.

Lastly, changed how we translate branches back to RIR: instead of guessing, now always use `brfalse_` and possibly change to `brtrue_` in RIR cleanup:
```
   ...			   ...
   brfalse_ 0		   brtrue_ 1
   br_ 1		   ->	   
0:			0:
   ...			   ...
```