### PR TITLE
bugs

### DIFF
--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -789,7 +789,14 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
             case Tag::ForSeqSize: {
                 // TODO: not tested
                 // make sure that the seq is at TOS? the instr doesn't push it!
+                auto sz = ForSeqSize::Cast(instr);
+                auto seq = sz->arg(0).val();
+                load(it, seq);
                 cs << BC::forSeqSize();
+                // hack to fix for_seq_size_ not popping the sequence...
+                // TODO: find another way
+                if (Instruction::Cast(seq)->hasSingleUse() == sz && alloc.onStack(seq))
+                    cs << BC::swap() << BC::pop();
                 store(it, instr);
                 break;
             }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -259,6 +259,7 @@ Value* Rir2Pir::translate() {
         }
     });
 
+
     InsertCast c(insert.code->entry);
     c();
 


### PR DESCRIPTION
So, I didn't get to running the tests yet, I tried to run some simple for loops and found some bugs instead...

So far:
* in stack machine merge, the phi's were matched in the wrong order (ie. one from the bottom, the other from tos)
* `pick_` was implemented incorrectly (it should shift the elements down the stack)
* `for_seq_size_` looks at the arg on tos, but doesn't pop it... so if the sequence got allocated to the stack and only used in the `for_seq_size_`, it was never popped (eg. `function(x) for (i in 1:x) {}`)

Still, this blows up: `function(x) for (i in 1:x) cat(i, " ")`

For some reason, the increment uses no phi and just increments a constant:

Original RIR:
```
   guard_fun_  for == 0x7fb844009fb8
   guard_fun_  : == 0x7fb84400fc00
   push_  5 # [1] 1
   ldvar_  6 # x
   colon_
   set_shared_
   for_seq_size_
   push_  7 # [1] 0
1:
   inc_
   dup2_
   lt_
   brtrue_  0
   pull_  2
   pull_  1
   extract2_1_
   stvar_  8 # i
   ldfun_  9 # cat
   call_ [ 0 1 ]
        -> cat(i, " ")
           Prof : [ 0, <0> ]

   pop_
   br_  1
0:
   pop_
   pop_
   pop_
   push_  12 # NULL
   invisible_
   ret_
```

PIR:
```
BB0
  val^    %0.0  = LdArg            0
  real$   %0.1  = LdConst          [1] 1
  val     %0.2  = Force            %0.0
  val     %0.3  = Colon            %0.1, %0.2
  int$    %0.4  = ForSeqSize       %0.3
  int$    %0.5  = LdConst          [1] 0
  env     e0.6  = MkEnv            parent=<environment: R_GlobalEnv>, x=%0.0
  goto BB1
BB1
  int$    %1.0  = Inc              %0.5
  lgl     %1.1  = Lt               %0.4, %1.0
  t       %1.2  = AsTest           %1.1
  void            Branch           %1.2 -> BB2 (if true) | BB3 (if false)
BB3
  val$    %3.0  = Extract2_1D      %0.3, %1.0
  void            StVar            i, %3.0, e0.6
  cls     %3.2  = LdFun            cat, e0.6
  prom    %3.3  = MkArg            missing, Prom(0), e0.6
  str$    %3.4  = LdConst          [1] " "
  prom    %3.5  = MkArg            %3.4, Prom(1), e0.6
  val^    %3.6  = Call             e0.6, %3.2, %3.3, %3.5                             ; env leak
  goto BB1
BB2
  nil     %2.0  = LdConst          NULL
  void            Return           %2.0
======= Liveness ========
%0.1 is live : BB0 [1,3]
%0.0 is live : BB0 [0,6]
%0.3 is live : BB0 [3,7]  BB1 [0,4]  BB3 [0,7]
%3.0 is live : BB3 [0,1]
missing is live : BB0 [0,7]  BB1 [0,4]  BB3 [0,7]
%1.2 is live : BB1 [2,3]
%3.4 is live : BB3 [4,5]
%3.2 is live : BB3 [2,6]
e0.6 is live : BB0 [6,7]  BB1 [0,4]  BB3 [0,7]
%0.2 is live : BB0 [2,3]
%3.5 is live : BB3 [5,6]
%1.0 is live : BB1 [0,4]  BB3 [0,0]
<environment: R_GlobalEnv> is live : BB0 [0,6]
%1.1 is live : BB1 [1,2]
%0.4 is live : BB0 [4,7]  BB1 [0,4]  BB3 [0,7]
%3.3 is live : BB3 [3,6]
%0.5 is live : BB0 [5,7]  BB1 [0,4]  BB3 [0,7]
%2.0 is live : BB2 [0,1]
======= End Liveness ========
======= Allocation ========
BB0: e0.6@5   %0.4@3   %0.3@2   %0.0@1   %0.5@4   %0.1@s   %0.2@s
BB1: %1.0@1   %1.1@s   %1.2@s
BB3: %3.3@1   %3.0@6   %3.4@s   %3.2@s   %3.5@6
BB2: %2.0@s
dead: %1.3   %3.1   %3.6   %2.1
slots: 6
======= End Allocation ========
```
