### PR TITLE
Fix segv

### DIFF
--- a/rir/src/R/Sexp.h
+++ b/rir/src/R/Sexp.h
@@ -62,21 +62,20 @@ class MatchStatement {
 
 #define Case2(__M__type, __M__car_name)                                        \
     case (__M__type): {                                                        \
-        SEXP(__M__car_name) = CAR(__M__match_statement__.subject);
+        SEXP __M__car_name = CAR(__M__match_statement__.subject);
 
 #define Case3(__M__type, __M__car_name, __M__cdr_name)                         \
     case (__M__type): {                                                        \
-        SEXP(__M__car_name)                                                    \
-        __attribute__((unused)) = CAR(__M__match_statement__.subject);         \
-        SEXP(__M__cdr_name) = CDR(__M__match_statement__.subject);
+        SEXP __M__car_name __attribute__((unused)) =                           \
+            CAR(__M__match_statement__.subject);                               \
+        SEXP __M__cdr_name = CDR(__M__match_statement__.subject);
 
 #define Case4(__M__type, __M__car_name, __M__cdr_name, __M__tag_name)          \
     case (__M__type): {                                                        \
-        SEXP(__M__car_name)                                                    \
-        __attribute__((unused)) = CAR(__M__match_statement__.subject);         \
-        SEXP(__M__cdr_name)                                                    \
-        __attribute__((unused)) = CDR(__M__match_statement__.subject);         \
-        SEXP(__M__tag_name) = TAG(__M__match_statement__.subject);
-
+        SEXP __M__car_name __attribute__((unused)) =                           \
+            CAR(__M__match_statement__.subject);                               \
+        SEXP __M__cdr_name __attribute__((unused)) =                           \
+            CDR(__M__match_statement__.subject);                               \
+        SEXP __M__tag_name = TAG(__M__match_statement__.subject);
 
 #endif

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -236,7 +236,7 @@ bool checkPir2Rir(SEXP expected, SEXP result) {
 }
 
 extern "C" SEXP rir_eval(SEXP, SEXP);
-extern "C" SEXP pir_compile(SEXP);
+extern "C" SEXP pir_compile(SEXP, SEXP);
 
 bool testPir2Rir(std::string name, std::string fun, std::string args,
                  bool useSame = false, bool verbose = false) {
@@ -281,7 +281,7 @@ bool testPir2Rir(std::string name, std::string fun, std::string args,
         rCall = createRWrapperCall(wrapper);
     }
 
-    pir_compile(rirFun);
+    pir_compile(rirFun, R_FalseValue);
 
     auto after = p(Rf_eval(rCall, execEnv));
     if (verbose) {


### PR DESCRIPTION
new compiler, new problems.

this fixes some issues encountered with gcc 8.1.1.

kind of surprising that we didn't see them before...

(The change in Sexp.h is just to avoid some warnings)