### PR TITLE
Global value numbering

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -43,7 +43,7 @@ namespace pir {
 /*
  * Captures an abstract PIR value.
  *
- * Vals is the set of potential candidates. If we don't can't tell what the
+ * Vals is the set of potential candidates. If we can't tell what the
  * possible values are, then we set "unknown" (ie. we taint the value). This is
  * the top element of our lattice.
  *
@@ -210,13 +210,6 @@ struct AbstractREnvironment {
         return changed;
     }
 };
-
-/*
- * AbstractEnvironmentSet is an abstract domain that deals with multiple
- * environments at the same time. This is necessary for inter-procedural
- * analysis, or analyzing a function with multiple environments.
- *
- */
 
 struct AbstractLoad {
     Value* env;

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -40,6 +40,16 @@ struct hash<rir::pir::ValOrig> {
 namespace rir {
 namespace pir {
 
+class AbstractValue {
+    virtual bool merge(const AbstractValue& otherValue) = 0;            
+};
+
+template <class AbsValue>
+class AbstractState : public std::unordered_map<Value*, AbsValue> {
+    virtual bool merge(const AbstractState& otherState) = 0;            
+};         
+
+
 /*
  * Captures an abstract PIR value.
  *

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -45,16 +45,6 @@ enum class PositioningStyle { BeforeInstruction, AfterInstruction };
  * provided by the subclass that specializes StaticAnalysis.
  */
 
-class AbstractValue {
-    virtual bool merge(const AbstractValue& otherValue) = 0;            
-};
-
-template <class AbsValue>
-class AbstractState : public std::unordered_map<Value*, AbsValue> {
-    virtual bool merge(const AbstractState& otherState) = 0;            
-};         
-
-
 template <class State>
 class StaticAnalysis {
   private:

--- a/rir/src/compiler/analysis/global_redundancies.cpp
+++ b/rir/src/compiler/analysis/global_redundancies.cpp
@@ -1,0 +1,122 @@
+#include "global_redundancies.h"
+
+namespace rir {
+namespace pir {
+  
+void GlobalRedundanciesAnalysis::apply(GRPartition& partition, Instruction* instruction) const {
+    // No operator
+    LdArg* loadArg = LdArg::Cast(instruction);
+    LdFun* loadFun = LdFun::Cast(instruction);
+    Instruction* loadVar = LdVar::Cast(instruction);
+    LdVarSuper* superLoadVar = LdVarSuper::Cast(instruction);
+    LdConst* loadConst = LdConst::Cast(instruction);
+
+    // Operator and 1 operand
+    Inc* inc = Inc::Cast(instruction);
+    IsObject* isObject = IsObject::Cast(instruction);
+
+    // Operator and 2 operands
+    Add* add = Add::Cast(instruction);
+    Gte* gte = Gte::Cast(instruction);
+    Lte* lte = Lte::Cast(instruction);
+    Mul* mul = Mul::Cast(instruction);
+    Div* division = Div::Cast(instruction);
+    IDiv* idiv = IDiv::Cast(instruction);
+    Mod* mod = Mod::Cast(instruction);
+    Colon* colon = Colon::Cast(instruction);
+    Pow* power = Pow::Cast(instruction);
+    Sub* sub = Sub::Cast(instruction);
+    Gt* gt = Gt::Cast(instruction);
+    Lt* lt = Lt::Cast(instruction);
+    Neq* neq = Neq::Cast(instruction);
+    Eq* eq = Eq::Cast(instruction);
+    LAnd* land = LAnd::Cast(instruction);
+    LOr* lor = LOr::Cast(instruction);
+
+    Phi* phi = Phi::Cast(instruction);
+    if (phi) {
+        /* It is a phi node. Create a phi eq-class if it is the first time
+         * Note that the original algorithm does not process phis but creates
+         * the phi equivalance classes at join points. For that it requires to
+         * be in CSSA. We workaround this by creating the phi equivalaence here.
+         * Check if we mantain semantics. 
+        */
+        if (!partition.count(instruction)) {
+            GREquivalenceClass klass;
+            klass.phis = new ValuePhiFunction(phi->arg(0).val(), phi->arg(1).val());
+            partition.insert({instruction, klass});
+        }
+        return;
+    }
+
+    partition.removeVariableFromClasses(instruction);
+
+    PIRAssignment assignment;
+    if (loadConst) {
+        assignment.setConstant(&loadConst->c);
+    } else if (loadArg) {
+        assignment.setIndex(loadArg->id);
+    } else {
+        ValueExpression::Expression expression;
+        if (loadFun || loadVar || superLoadVar) {
+            expression.operand1 = instruction->arg(0).first;
+        } else if (inc || isObject) {
+            expression.operand1 = instruction->arg(0).first;
+            expression.operation = &instruction->tag;
+        } else if (add || gte || lte || mul || division || idiv || mod || colon || 
+                power || sub || gt || lt || neq || eq || land || lor) {
+            expression.operand1 = instruction->arg(0).first;
+            expression.operand2 = instruction->arg(1).first;
+            expression.operation = &instruction->tag;            
+        }
+        assignment.setExpression(&expression);
+    }
+    Value* eqClass = partition.detectClassContaining(assignment);
+    if (eqClass) {
+        // There is already a value for that expression
+        // so add this new pir variable to that class
+        partition.at(eqClass).variables.push_back(instruction);
+    } else {
+        // No existing value class for the expression. 
+        ValuePhiFunction* valuePhiFunc = this->createValuePhiFunction(partition, assignment);
+        Value* eqClass = partition.detectClassContaining(*valuePhiFunc);
+        if (eqClass) {
+            // There is already a value for the expression's phi equivalence class 
+            partition.at(eqClass).variables.push_back(instruction);
+            partition.at(eqClass).expressions.push_back(assignment);
+        } else {
+            auto it = partition.find(instruction);
+            if (it != partition.end()){
+                GREquivalenceClass& klass = it->second;
+                klass.expressions.push_back(assignment);
+                klass.phis = valuePhiFunc;
+            } else {
+                GREquivalenceClass klass;
+                klass.expressions.push_back(assignment);
+                klass.phis = valuePhiFunc;
+                partition.insert({instruction, klass});
+            }
+        }
+    
+        /*if (add || gte || lte || mul || division || idiv || mod || colon || 
+                power || sub || gt || lt || neq || eq || land || lor)*/
+    }
+}
+
+std::vector<Instruction*> GlobalRedundanciesAnalysis::redundantInstructions() {
+    std::vector<Instruction*> redundant;
+    this->foreach<PositioningStyle::AfterInstruction>(
+    [&](const GRPartition& partition, Instruction* i) {
+        if (!partition.at(i).variables.empty() || partition.at(i).phis)
+            redundant.push_back(i);
+    });
+    return redundant;
+}
+
+ValuePhiFunction* GlobalRedundanciesAnalysis::createValuePhiFunction(GRPartition&, PIRAssignment&) const {
+    // This is the only remaining function to implement
+    return nullptr;
+}
+
+}
+}

--- a/rir/src/compiler/analysis/global_redundancies.h
+++ b/rir/src/compiler/analysis/global_redundancies.h
@@ -3,6 +3,7 @@
 
 #include "../pir/pir.h"
 #include "generic_static_analysis.h"
+#include <algorithm>
 
 namespace rir {
 namespace pir {
@@ -105,7 +106,7 @@ struct PIRAssignment {
         if (type != anotherPA.type) return false;
         if (this->isConstant()) return *argument.constant == *anotherPA.argument.constant;
         else if (this->isArgIndex()) return argument.argIndex == anotherPA.argument.argIndex;
-        else return argument.expression = anotherPA.argument.expression;
+        else return argument.expression == anotherPA.argument.expression;
     }
 };
 
@@ -123,13 +124,13 @@ class GREquivalenceClass {
         bool changed = false;
         assert(number == otherClass.number);
         for (auto var : otherClass.variables){
-            int size = variables.size();
+            size_t size = variables.size();
             variables.push_back(var);
             changed = changed || (variables.size() > size);
         }
         for (auto exp : otherClass.expressions){
             // TODO: Verify after merge that there are no more that one argument and constants
-            int size = expressions.size();
+            size_t size = expressions.size();
             expressions.push_back(exp);
             changed = changed || (expressions.size() > size);
         }

--- a/rir/src/compiler/analysis/global_redundancies.h
+++ b/rir/src/compiler/analysis/global_redundancies.h
@@ -1,0 +1,213 @@
+#ifndef COMPILER_PIR_GR_H
+#define COMPILER_PIR_GR_H
+
+#include "../pir/pir.h"
+#include "generic_static_analysis.h"
+
+namespace rir {
+namespace pir {
+
+/*
+ * Polynomial Time Global Value Numbering analysis based on:
+ * https://www.sciencedirect.com/science/article/pii/S1477842415300622
+ */
+
+/*
+struct GBNValue {
+    Value* value;
+    SEXP* constant;
+    GBNValue() : value(nullptr), constant(nullptr) {};
+    GBNValue(Value* aValue) : value(aValue), constant(nullptr) {};
+    GBNValue(SEXP* aConstant) : constant(aConstant), value(nullptr) {};
+    
+    bool isValid() const { return value != nullptr || constant != nullptr; } 
+    bool operator==(const GBNValue& anotherGV) {
+        if (value!=nullptr && anotherGV.value!=nullptr) 
+            return value == anotherGV.value;
+        if (constant!=nullptr && anotherGV.constant!=nullptr)
+            return *constant == *anotherGV.constant; 
+        return false;
+    }
+    
+};*/
+
+/*
+ * An abstraction of a set of equivalent expressions.
+ * For more information see page 170. 
+*/
+struct ValueExpression {
+    typedef ValueExpression Expression;
+    ValueExpression() : operand1(), operand2(), operation(nullptr) {};
+    ValueExpression(Value* value) : operand1(value), operand2(), operation(nullptr) {};
+    ValueExpression(Value* value, Value* anotherValue, Tag* operation) : 
+        operand1(value), operand2(anotherValue), operation(operation) {};
+    Value* operand1;
+    Value* operand2;
+    Tag* operation;
+
+    bool contains(Expression& expression) {
+        return (operand1 == expression.operand1) &&
+                (operand2 == expression.operand2) &&
+                (operation == expression.operation); 
+    }
+};
+
+/*
+ * An abstraction of a set of equivalent phi-functions.
+ * For more information see page 170. 
+*/
+struct ValuePhiFunction {
+    ValuePhiFunction(Value* left, Value* right) : leftPath(left), rightPath(right) {};
+    Value* leftPath;
+    Value* rightPath;
+    //BB* joinPoint;
+    bool operator==(const ValuePhiFunction& anotherPF) {
+        return leftPath == anotherPF.leftPath &&
+                rightPath == anotherPF.rightPath;
+    }        
+};
+
+union GRPIRAssignment {
+    SEXP* constant;
+    size_t argIndex;
+    ValueExpression::Expression* expression;
+};
+
+struct PIRAssignment {
+    GRPIRAssignment argument;
+    unsigned char type;
+    
+    void setConstant(SEXP* constant) {
+        argument.constant = constant;
+        type = 1;        
+    }
+
+    void setIndex(size_t index) {
+        argument.argIndex = index;
+        type = 2;        
+    }
+
+    void setExpression(ValueExpression::Expression* expession) {
+        argument.expression = expession;
+        type = 3;        
+    }
+
+    ValueExpression::Expression* getExpression() {
+        assert(type == 3);
+        return argument.expression;
+    }
+
+    bool isConstant() { return type == 1; }
+    bool isArgIndex() { return type == 2; }
+    bool isExp() { return type == 3; }
+
+    bool operator==(const PIRAssignment& anotherPA) {
+        if (type != anotherPA.type) return false;
+        if (this->isConstant()) return *argument.constant == *anotherPA.argument.constant;
+        else if (this->isArgIndex()) return argument.argIndex == anotherPA.argument.argIndex;
+        else return argument.expression = anotherPA.argument.expression;
+    }
+};
+
+// This is the abstract domain.
+class GREquivalenceClass {
+  public:
+    //GBNEquivalenceClass();
+    
+    Value* number;
+    std::vector<Value*> variables;
+    std::vector<PIRAssignment> expressions;
+    ValuePhiFunction* phis;
+
+    bool merge(const GREquivalenceClass& otherClass){
+        bool changed = false;
+        assert(number == otherClass.number);
+        for (auto var : otherClass.variables){
+            int size = variables.size();
+            variables.push_back(var);
+            changed = changed || (variables.size() > size);
+        }
+        for (auto exp : otherClass.expressions){
+            // TODO: Verify after merge that there are no more that one argument and constants
+            int size = expressions.size();
+            expressions.push_back(exp);
+            changed = changed || (expressions.size() > size);
+        }
+        // Is it possible to have more than one phi eq class
+        if (phis == nullptr && otherClass.phis!=nullptr){
+            this->phis = otherClass.phis;
+            changed = true;
+        }
+        return changed;
+    };
+};
+
+/*
+ * A partition at a point in the program represents equivalences 
+ * that hold at that point along with available expressions. 
+ * A partition is a set of equivalence classes. 
+*/
+class GRPartition : public std::unordered_map<Value*, GREquivalenceClass> {
+  public:
+    Value* detectClassContaining(PIRAssignment& assignment){
+        for (auto it : *this) {
+            for (PIRAssignment otherAssigment : it.second.expressions) {
+                if (assignment == otherAssigment) return it.first;
+            }
+        } 
+        return nullptr;
+    }
+
+    Value* detectClassContaining(ValuePhiFunction& phi){
+        /*for (auto it : *this) {
+            if (*it.second.phis == phi) return it.first;
+        }*/
+        return nullptr;             
+    }
+
+    bool merge(const GRPartition& otherState) {
+        bool changed;
+        for (auto it : otherState) {
+            if (this->count(it.first)) {
+                changed = changed || (this->at(it.first).merge(it.second));
+            } else {
+                this->insert({it.first, it.second});
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    void removeVariableFromClasses(Value* variable) {
+        for (auto it : *this) {
+            std::vector<Value*> variables = it.second.variables;
+            variables.erase(std::remove_if(variables.begin(), variables.end(), 
+                [&](const Value* var) { return var == variable; }), 
+                variables.end());
+        }
+    }    
+
+    Value* variableDefiningEquivalentExpression(Value* variable) const{
+        for (auto it : *this) {
+            for (Value* var : it.second.variables) {
+                if (var == variable) return var;
+            }
+        }    
+        return nullptr;
+    }
+};         
+
+class GlobalRedundanciesAnalysis : public StaticAnalysis<GRPartition> {
+  public:
+    typedef StaticAnalysis<GRPartition> Super;
+    GlobalRedundanciesAnalysis(Closure* closure) : Super(closure) {}
+    
+    void apply(GRPartition&, Instruction*) const override;
+    std::vector<Instruction*> redundantInstructions();
+  private:
+    ValuePhiFunction* createValuePhiFunction(GRPartition&, PIRAssignment&) const;
+};
+}
+}
+
+#endif

--- a/rir/src/compiler/opt/global_value_numbering.cpp
+++ b/rir/src/compiler/opt/global_value_numbering.cpp
@@ -1,0 +1,37 @@
+#include "global_value_numbering.h"
+#include "../analysis/global_redundancies.h"
+#include <map>
+
+namespace rir {
+namespace pir {
+
+void GlobalValueNumbering::apply(Closure* cls) {
+    GlobalRedundanciesAnalysis analysis(cls);
+    analysis();
+    std::map<Instruction*, Value*> redundancies;
+    analysis.foreach<PositioningStyle::AfterInstruction>(
+        [&](const GRPartition& partition, Instruction* i) {
+            Value* variable = partition.variableDefiningEquivalentExpression(i);
+            if (variable != nullptr){
+                redundancies.insert({i, variable});
+            } else if (partition.at(i).phis != nullptr){
+                // Todo: Support redundancies based on phi functions
+            }
+        }
+    );
+
+    Visitor::run(cls->entry, [&redundancies](BB* bb) {
+        auto instruction = bb->begin();
+        while (instruction != bb->end()) {
+            auto redundancy = redundancies.find(*instruction);
+            auto next = instruction + 1;
+            if (redundancy != redundancies.end()){
+                (*instruction)->replaceUsesWith(redundancy->second);
+                next = bb->remove(instruction);
+            }
+            instruction = next;
+        }
+    });
+}
+}
+}

--- a/rir/src/compiler/opt/global_value_numbering.h
+++ b/rir/src/compiler/opt/global_value_numbering.h
@@ -1,0 +1,27 @@
+#ifndef PIR_GVN_H
+#define PIR_GVN_H
+
+#include "../translations/pir_translator.h"
+
+namespace rir {
+namespace pir {
+
+/*
+ * This pass searches for dominating force instructions.
+ *
+ * If we identify such an instruction, and we statically know which promise is
+ * being forced, then it inlines the promise code at the place of the
+ * dominating force, and replaces all subsequent forces with it's result.
+ *
+ */
+class Closure;
+class GlobalValueNumbering : public PirTranslator {
+  public:
+    GlobalValueNumbering() : PirTranslator("global value numbering"){};
+
+    void apply(Closure* function) override;
+};
+}
+}
+
+#endif

--- a/rir/src/compiler/opt/global_value_numbering.h
+++ b/rir/src/compiler/opt/global_value_numbering.h
@@ -7,12 +7,8 @@ namespace rir {
 namespace pir {
 
 /*
- * This pass searches for dominating force instructions.
- *
- * If we identify such an instruction, and we statically know which promise is
- * being forced, then it inlines the promise code at the place of the
- * dominating force, and replaces all subsequent forces with it's result.
- *
+ * This pass searches for global redundancies in a piece of code.
+ * If we identify redundancies we can remove those operations.
  */
 class Closure;
 class GlobalValueNumbering : public PirTranslator {

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -21,9 +21,9 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
+    friend bool hasRedundantCopy(std::function <void (Closure*)>&);
     Closure(std::initializer_list<SEXP> a, Env* env) : env(env), argNames(a) {}
     Closure(const std::vector<SEXP>& a, Env* env) : env(env), argNames(a) {}
-
     Env* env;
 
   public:
@@ -60,7 +60,6 @@ class Closure : public Code {
             if (p)
                 it(p);
     }
-
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -21,7 +21,9 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
-    friend bool hasRedundantCopy(std::function <void (Closure*)>&);
+    friend bool hasRedundantCopy(std::function <void (Closure*)>& addPirCodeToTest,
+                      std::function <BB* (Closure*)>& basicBlockToCheck,
+                      std::function <bool (BB*)>& predicate);
     Closure(std::initializer_list<SEXP> a, Env* env) : env(env), argNames(a) {}
     Closure(const std::vector<SEXP>& a, Env* env) : env(env), argNames(a) {}
     Env* env;

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -21,9 +21,10 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
-    friend bool hasRedundantCopy(std::function <void (Closure*)>& addPirCodeToTest,
-                      std::function <BB* (Closure*)>& basicBlockToCheck,
-                      std::function <bool (BB*)>& predicate);
+    friend bool
+    hasRedundantCopy(std::function<void(Closure*)>& addPirCodeToTest,
+                     std::function<BB*(Closure*)>& basicBlockToCheck,
+                     std::function<bool(BB*)>& predicate);
     Closure(std::initializer_list<SEXP> a, Env* env) : env(env), argNames(a) {}
     Closure(const std::vector<SEXP>& a, Env* env) : env(env), argNames(a) {}
     Env* env;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -21,7 +21,7 @@
  *
  * Instructions are either FixedLength or VariableLength.
  *
- * Every instruction is also a Value, and can therefore be used as an argument
+ * Every instruction also has a Value, and can therefore be used as an argument
  * for other instructions.
  *
  * Instructions have an InstructionDescription, which gives us basic

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -11,8 +11,6 @@ namespace pir {
 
 enum class Tag : uint8_t;
 
-class BB;
-
 /*
  * A typed PIR value.
  *

--- a/rir/src/compiler/pir_ad_hoc_test_closures.cpp
+++ b/rir/src/compiler/pir_ad_hoc_test_closures.cpp
@@ -1,6 +1,6 @@
+#include "R/Protect.h"
 #include "pir/pir_impl.h"
 #include "util/builder.h"
-#include "R/Protect.h"
 #include "util/visitor.h"
 
 namespace rir {
@@ -14,14 +14,14 @@ void sameBBSimpleRedundancy(pir::Closure* function) {
     builder(new LdConst(value));
 }
 
-void sameBBComplexRedundancy(pir::Closure* function) {
+/*void sameBBComplexRedundancy(pir::Closure* function) {
     Protect p;
     Builder builder(function, Env::notClosed());
     SEXP value = p(Rf_ScalarInteger(1));
-    SEXP value = p(Rf_ScalarInteger(2));
+    SEXP value2 = p(Rf_ScalarInteger(2));
     builder(new LdConst(value));
-    builder(new LdConst(value));
-}
+    builder(new LdConst(value2));
+}*/
 
 void controlFlowRedundancy(pir::Closure* function) {
     Protect p;
@@ -48,41 +48,36 @@ void controlFlowRedundancy(pir::Closure* function) {
     builder(new LdConst(value));
 }
 
-bool hasOneConstantLoad(BB* bb){
+bool hasOneConstantLoad(BB* bb) {
     std::vector<SEXP> values;
-    return !Visitor::check (
-        bb, [&](Instruction* i) { 
-            if (LdConst::Cast(i)) {
-                if(std::find(values.begin(), values.end(), LdConst::Cast(i)->c) != values.end())
-                    return false;
-                else
-                    values.push_back(LdConst::Cast(i)->c);
-            }
-            return true;
-        });
+    return !Visitor::check(bb, [&](Instruction* i) {
+        if (LdConst::Cast(i)) {
+            if (std::find(values.begin(), values.end(), LdConst::Cast(i)->c) !=
+                values.end())
+                return false;
+            else
+                values.push_back(LdConst::Cast(i)->c);
+        }
+        return true;
+    });
 }
 
-bool hasTwoConstantLoads(BB* bb){
+bool hasTwoConstantLoads(BB* bb) {
     std::vector<SEXP> values;
-    return !Visitor::check (
-        bb, [&](Instruction* i) { 
-            if (LdConst::Cast(i)) {
-                if(std::find(values.begin(), values.end(), LdConst::Cast(i)->c) != values.end())
-                    return false;
-                else
-                    values.push_back(LdConst::Cast(i)->c);
-            }
-            return true;
-        });
+    return !Visitor::check(bb, [&](Instruction* i) {
+        if (LdConst::Cast(i)) {
+            if (std::find(values.begin(), values.end(), LdConst::Cast(i)->c) !=
+                values.end())
+                return false;
+            else
+                values.push_back(LdConst::Cast(i)->c);
+        }
+        return true;
+    });
 }
 
-BB* firstBB(pir::Closure* closure) {
-    return closure->entry;
-}
+BB* firstBB(pir::Closure* closure) { return closure->entry; }
 
-BB* mergeBB(pir::Closure* closure) {
-    return closure->entry->next0->next0;
-}
-
+BB* mergeBB(pir::Closure* closure) { return closure->entry->next0->next0; }
 }
 }

--- a/rir/src/compiler/pir_ad_hoc_test_closures.cpp
+++ b/rir/src/compiler/pir_ad_hoc_test_closures.cpp
@@ -1,16 +1,87 @@
 #include "pir/pir_impl.h"
 #include "util/builder.h"
 #include "R/Protect.h"
+#include "util/visitor.h"
 
 namespace rir {
 namespace pir {
 
-void sameBBredundnacy(pir::Closure* function) {
+void sameBBSimpleRedundancy(pir::Closure* function) {
     Protect p;
     Builder builder(function, Env::notClosed());
     SEXP value = p(Rf_ScalarInteger(1));
     builder(new LdConst(value));
     builder(new LdConst(value));
+}
+
+void sameBBComplexRedundancy(pir::Closure* function) {
+    Protect p;
+    Builder builder(function, Env::notClosed());
+    SEXP value = p(Rf_ScalarInteger(1));
+    SEXP value = p(Rf_ScalarInteger(2));
+    builder(new LdConst(value));
+    builder(new LdConst(value));
+}
+
+void controlFlowRedundancy(pir::Closure* function) {
+    Protect p;
+    Builder builder(function, Env::notClosed());
+    SEXP value = p(Rf_ScalarInteger(1));
+    BB* bbIfTrue = builder.createBB();
+    builder.bb->next0 = bbIfTrue;
+    BB* bbIfFalse = builder.createBB();
+    builder.bb->next1 = bbIfFalse;
+    builder.bb = bbIfTrue;
+    Instruction* varIfTrue = new LdConst(value);
+    builder(varIfTrue);
+    builder.bb = bbIfFalse;
+    Instruction* varIfFalse = new LdConst(value);
+    builder(varIfFalse);
+    BB* join = builder.createBB();
+    bbIfTrue->next0 = join;
+    bbIfFalse->next0 = join;
+    builder.bb = join;
+    Phi* phi = new Phi();
+    phi->addInput(bbIfTrue, varIfTrue);
+    phi->addInput(bbIfFalse, varIfFalse);
+    builder(phi);
+    builder(new LdConst(value));
+}
+
+bool hasOneConstantLoad(BB* bb){
+    std::vector<SEXP> values;
+    return !Visitor::check (
+        bb, [&](Instruction* i) { 
+            if (LdConst::Cast(i)) {
+                if(std::find(values.begin(), values.end(), LdConst::Cast(i)->c) != values.end())
+                    return false;
+                else
+                    values.push_back(LdConst::Cast(i)->c);
+            }
+            return true;
+        });
+}
+
+bool hasTwoConstantLoads(BB* bb){
+    std::vector<SEXP> values;
+    return !Visitor::check (
+        bb, [&](Instruction* i) { 
+            if (LdConst::Cast(i)) {
+                if(std::find(values.begin(), values.end(), LdConst::Cast(i)->c) != values.end())
+                    return false;
+                else
+                    values.push_back(LdConst::Cast(i)->c);
+            }
+            return true;
+        });
+}
+
+BB* firstBB(pir::Closure* closure) {
+    return closure->entry;
+}
+
+BB* mergeBB(pir::Closure* closure) {
+    return closure->entry->next0->next0;
 }
 
 }

--- a/rir/src/compiler/pir_ad_hoc_test_closures.cpp
+++ b/rir/src/compiler/pir_ad_hoc_test_closures.cpp
@@ -1,0 +1,17 @@
+#include "pir/pir_impl.h"
+#include "util/builder.h"
+#include "R/Protect.h"
+
+namespace rir {
+namespace pir {
+
+void sameBBredundnacy(pir::Closure* function) {
+    Protect p;
+    Builder builder(function, Env::notClosed());
+    SEXP value = p(Rf_ScalarInteger(1));
+    builder(new LdConst(value));
+    builder(new LdConst(value));
+}
+
+}
+}

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -18,9 +18,9 @@ namespace rir {
 namespace pir {
 /* I define this function within the same namespace as Closure so that 
    the friendshipness works for Closure's private constructors */
-bool hasRedundantCopy(std::function <void (Closure*)>& addPirCodeToTest,
-                      std::function <BB* (Closure*)>& basicBlockToCheck,
-                      std::function <bool (BB*)>& predicate) {
+bool hasRedundantCopy(std::function<void(Closure*)>& addPirCodeToTest,
+                      std::function<BB*(Closure*)>& basicBlockToCheck,
+                      std::function<bool(BB*)>& predicate) {
     pir::Module module;
     std::vector<SEXP> args;
     auto* f = new Closure(args, Env::notClosed());
@@ -39,7 +39,6 @@ bool hasOneConstantLoad(BB* bb);
 bool hasTwoConstantLoads(BB* bb);
 BB* firstBB(pir::Closure*);
 BB* mergeBB(pir::Closure* closure);
-
 }
 }
 
@@ -374,40 +373,56 @@ static Test tests[] = {
          }),
     Test("sameBBredundnacy",
          []() {
-             std::function<void(Closure* pirFunction)> test = [](Closure* pirFunction){
-                 rir::pir::sameBBSimpleRedundancy(pirFunction);};
-             std::function<BB*(Closure*)> bbSelector = [](Closure* pirFunction) -> BB* {
-                 return rir::pir::firstBB(pirFunction);};
+             std::function<void(Closure * pirFunction)> test =
+                 [](Closure* pirFunction) {
+                     rir::pir::sameBBSimpleRedundancy(pirFunction);
+                 };
+             std::function<BB*(Closure*)> bbSelector =
+                 [](Closure* pirFunction) -> BB* {
+                 return rir::pir::firstBB(pirFunction);
+             };
              std::function<bool(BB*)> redundancyPredicate = [](BB* bb) -> bool {
-                 return rir::pir::hasTwoConstantLoads(bb);};
-                 
+                 return rir::pir::hasTwoConstantLoads(bb);
+             };
+
              return !hasRedundantCopy(test, bbSelector, redundancyPredicate);
          }),
-    Test("sameBBOperationRedundancy",
+    /*Test("sameBBOperationRedundancy",
          []() {
-             std::function<void(Closure* pirFunction)> test = [](Closure* pirFunction){
-                 rir::pir::sameBBComplexRedundancy(pirFunction);};
-             std::function<BB*(Closure*)> bbSelector = [](Closure* pirFunction) -> BB* {
-                 return rir::pir::firstBB(pirFunction);};
+             std::function<void(Closure * pirFunction)> test =
+                 [](Closure* pirFunction) {
+                     rir::pir::sameBBComplexRedundancy(pirFunction);
+                 };
+             std::function<BB*(Closure*)> bbSelector =
+                 [](Closure* pirFunction) -> BB* {
+                 return rir::pir::firstBB(pirFunction);
+             };
              std::function<bool(BB*)> redundancyPredicate = [](BB* bb) -> bool {
-                 return rir::pir::hasTwoAdditions(bb);};
-                 
+                 return rir::pir::hasTwoAdditions(bb);
+             };
+
              return !hasRedundantCopy(test, bbSelector, redundancyPredicate);
-         }),     
+         }),*/
     Test("controlFlowDependentSimpleRedundancy",
          []() {
-             std::function<void(Closure* pirFunction)> test = [](Closure* pirFunction){
-                 rir::pir::controlFlowRedundancy(pirFunction);};
-             std::function<BB*(Closure*)> bbSelector = [](Closure* pirFunction) -> BB* {
-                 return rir::pir::mergeBB(pirFunction);};
+             std::function<void(Closure * pirFunction)> test =
+                 [](Closure* pirFunction) {
+                     rir::pir::controlFlowRedundancy(pirFunction);
+                 };
+             std::function<BB*(Closure*)> bbSelector =
+                 [](Closure* pirFunction) -> BB* {
+                 return rir::pir::mergeBB(pirFunction);
+             };
              std::function<bool(BB*)> redundancyPredicate = [](BB* bb) -> bool {
-                 return rir::pir::hasOneConstantLoad(bb);};
-                 
+                 return rir::pir::hasOneConstantLoad(bb);
+             };
+
              return !hasRedundantCopy(test, bbSelector, redundancyPredicate);
          }),
     /*Test("controlFlowDependentComplexRedundancy",
          []() {
-             std::function<void(Closure* pirFunction)> lambda = [](Closure* pirFunction){rir::pir::controlFlowComplexRedundnacy(pirFunction);};
+             std::function<void(Closure* pirFunction)> lambda = [](Closure*
+       pirFunction){rir::pir::controlFlowComplexRedundnacy(pirFunction);};
              return !hasRedundantCopy(lambda);
          }),*/
     Test("PIR to RIR: basic",

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -14,15 +14,13 @@
 #include "../../opt/scope_resolution.h"
 #include "ir/BC.h"
 
-#include <iostream>
-
 #include "interpreter/runtime.h"
 
 namespace rir {
 namespace pir {
 
 Rir2PirCompiler::Rir2PirCompiler(Module* module) : RirCompiler(module) {
-    for (auto optimization : pirConfigurations()->pirOptimizations()) {
+    for (auto optimization: pirConfigurations()->pirOptimizations()) {
         translations.push_back(optimization->translator);
     }
 }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -15,6 +15,7 @@ class Rir2PirCompiler : public RirCompiler {
     void optimizeModule();
     void printAfterPass(const std::string&, const std::string&, Closure*,
                         size_t);
+
   private:
     Closure* compileClosure(rir::Function*, const std::vector<SEXP>&,
                             Env* closureEnv);

--- a/rir/src/interpreter/runtime.cpp
+++ b/rir/src/interpreter/runtime.cpp
@@ -84,4 +84,4 @@ void initializeRuntime(CompilerCallback compiler, OptimizerCallback optimizer) {
 }
 
 Context* globalContext() { return globalContext_; }
-rir::Configurations* pirConfigurations() { return configurations; }
+rir::Configurations* pirConfigurations(){ return configurations; }

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -1,6 +1,7 @@
 #ifndef RIR_INTERPRETER_RUNTIME_H
 #define RIR_INTERPRETER_RUNTIME_H
 
+#include "utils/configurations.h"
 #include "../config.h"
 #include "interp_context.h"
 #include "interp_data.h"


### PR DESCRIPTION
The implementation is based on [Rekha Pai's paper](https://dl.acm.org/citation.cfm?id=3034351) which presents a polynomial time algorithm for detecting global redundancies.

The main difficulty of the problem is to find redundancies among join point. For instance:
```
bb1:                                           bb2:
 x1 = ...                                        x2 = ...
 y1= x1 + 1                                  y2 = x2 + 1

                  bb3:
                   x3 = phi(x1,x2)
                   w3 = x3 + 1
```

In this case w3 is redundant but its redundancy depends on both previous bbs.

Anyway, this first wip commit still does not implement the most important case of the transfer function to support this kind of redundancies. Till now it only detects and removes redundancies at the same bb level.