### PR TITLE
Fix popping of eager arguments and simplify passing of callsite info in interpreter

### DIFF
--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -12,10 +12,10 @@
 extern "C" {
 #endif
 
-struct DispatchContext;
+struct CallContext;
 SEXP evalRirCodeExtCaller(Code* c, Context* ctx, SEXP* env);
 SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
-                 const DispatchContext* callContext);
+                 const CallContext* callContext);
 
 SEXP rirExpr(SEXP f);
 


### PR DESCRIPTION
The previous solution was massively overengineered and also broken.
In general, if we want to support `ldarg_` for eager arguments
(passed on the stack), we need to pop eager arguments *after*
`doCall`. Everything else is just broken.