### PR TITLE
fix promise inliner

### DIFF
--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -45,9 +45,14 @@ using namespace rir::pir;
 struct ForcedAt : public std::unordered_map<Value*, Force*> {
     static Force* ambiguous() { return (Force*)0x22; }
 
-    void evalAt(Value* val, Force* force) {
+    void forcedAt(MkArg* val, Force* force) {
         if (!count(val))
             (*this)[val] = force;
+    }
+    void usedAt(MkArg* val, Force* force) {
+        // Used before force, this means we need to keep the promise as is
+        if (!count(val))
+            (*this)[val] = ambiguous();
     }
     bool merge(ForcedAt& other) {
         bool changed = false;
@@ -89,8 +94,17 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedAt> {
 
     void apply(ForcedAt& d, Instruction* i) const override {
         auto f = Force::Cast(i);
-        if (f)
-            d.evalAt(getValue(f), f);
+        if (f) {
+            MkArg* arg = MkArg::Cast(getValue(f));
+            if (arg)
+                d.forcedAt(arg, f);
+        } else if (!CastType::Cast(i)) {
+            i->eachArg([&](Value* v) {
+                MkArg* arg = MkArg::Cast(v);
+                if (arg)
+                    d.usedAt(arg, f);
+            });
+        }
     }
 };
 
@@ -140,6 +154,7 @@ void ForceDominance::apply(Closure* cls) {
     ForceDominanceAnalysisResult analysis(cls);
 
     std::unordered_map<Force*, Value*> inlinedPromise;
+    std::unordered_map<MkArg*, MkArg*> forcedMkArg;
 
     // 1. Inline dominating promises
     Visitor::run(cls->entry, [&](BB* bb) {
@@ -180,10 +195,15 @@ void ForceDominance::apply(Closure* cls) {
                             f = Force::Cast(*split->begin());
                             assert(f);
                             f->replaceUsesWith(promRes);
-                            next = split->remove(split->begin());
-                            bb = split;
+                            split->remove(split->begin());
+
+                            MkArg* fixedMkArg =
+                                new MkArg(mkarg->prom, promRes, mkarg->env());
+                            next = split->insert(split->begin(), fixedMkArg);
+                            forcedMkArg[mkarg] = fixedMkArg;
 
                             inlinedPromise[f] = promRes;
+                            bb = split;
                         }
                     }
                 }
@@ -212,6 +232,10 @@ void ForceDominance::apply(Closure* cls) {
             ip = next;
         }
     });
+
+    // 3. replace remaining uses of the mkarg itself
+    for (auto m : forcedMkArg)
+        m.first->replaceUsesIn(m.second, m.second->bb());
 }
 }
 }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -86,6 +86,7 @@ class TheInliner {
                                 a = cast;
                             }
                             ld->replaceUsesWith(a);
+                            next = bb->remove(ip);
                         }
                         ip = next;
                     }


### PR DESCRIPTION
when we inline a promise, we did not account for the case where the
promise itself is still used. There are two main cases:

1. The promise is used before being forced, e.g.:
```
    prom %1 = mkarg(...)
              call (prom1)
    val %3  = force(%1)
```
here we can't inline.

2. the promise is forced before being used standalone
```
    prom %1 = mkarg(missing, code, env)
    val %2  = force(%1)
              call(%1)
```
here we can create a new promise with the eager value:
```
    # prom %1 = mkarg(missing, code, env)
    val %2  = force(%1)
    prom %3 = mkarg(%2, code, env)
              call(%3)
```