### PR TITLE
towards enabling pir2rir

### DIFF
--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -79,7 +79,7 @@ class StaticAnalysis {
             if (POS == PositioningStyle::BeforeInstruction && i == j)
                 return state;
 
-            if (CallInstructionI::CastCall(i))
+            if (CallInstruction::CastCall(i))
                 state = mergepoint[bb->id][++segment];
             else
                 apply(state, i);
@@ -105,7 +105,7 @@ class StaticAnalysis {
                 if (POS == PositioningStyle::BeforeInstruction)
                     collect(state, i);
 
-                if (CallInstructionI::CastCall(i))
+                if (CallInstruction::CastCall(i))
                     state = mergepoint[bb->id][++segment];
                 else
                     apply(state, i);
@@ -137,7 +137,7 @@ class StaticAnalysis {
                 for (auto i : *bb) {
                     apply(state, i);
 
-                    if (CallInstructionI::CastCall(i)) {
+                    if (CallInstruction::CastCall(i)) {
                         segment++;
                         if (mergepoint[id].size() <= segment) {
                             mergepoint[id].resize(segment + 1);

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -79,7 +79,7 @@ class StaticAnalysis {
             if (POS == PositioningStyle::BeforeInstruction && i == j)
                 return state;
 
-            if (CallInstruction::Cast(i))
+            if (CallInstructionI::CastCall(i))
                 state = mergepoint[bb->id][++segment];
             else
                 apply(state, i);
@@ -105,7 +105,7 @@ class StaticAnalysis {
                 if (POS == PositioningStyle::BeforeInstruction)
                     collect(state, i);
 
-                if (CallInstruction::Cast(i))
+                if (CallInstructionI::CastCall(i))
                     state = mergepoint[bb->id][++segment];
                 else
                     apply(state, i);
@@ -137,7 +137,7 @@ class StaticAnalysis {
                 for (auto i : *bb) {
                     apply(state, i);
 
-                    if (CallInstruction::Cast(i)) {
+                    if (CallInstructionI::CastCall(i)) {
                         segment++;
                         if (mergepoint[id].size() <= segment) {
                             mergepoint[id].resize(segment + 1);

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -77,8 +77,8 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
             envs[superEnv].set(ss->varName, ss->val(), ss);
             handled = true;
         }
-    } else if (CallInstruction::Cast(i) && depth < maxDepth) {
-        auto calli = CallInstruction::Cast(i);
+    } else if (CallInstructionI::CastCall(i) && depth < maxDepth) {
+        auto calli = CallInstructionI::CastCall(i);
         if (Call::Cast(i)) {
             auto call = Call::Cast(i);
             Value* trg = call->cls();
@@ -100,8 +100,7 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
             } else if (StaticEagerCall::Cast(i)) {
                 trg = StaticEagerCall::Cast(i)->cls();
             }
-            assert(trg);
-            if (trg->argNames.size() == calli->nCallArgs()) {
+            if (trg && trg->argNames.size() == calli->nCallArgs()) {
                 TheScopeAnalysis nextFun(trg, trg->argNames, trg->closureEnv(),
                                          trg->entry, envs, depth + 1);
                 nextFun();

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -77,8 +77,8 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
             envs[superEnv].set(ss->varName, ss->val(), ss);
             handled = true;
         }
-    } else if (CallInstructionI::CastCall(i) && depth < maxDepth) {
-        auto calli = CallInstructionI::CastCall(i);
+    } else if (CallInstruction::CastCall(i) && depth < maxDepth) {
+        auto calli = CallInstruction::CastCall(i);
         if (Call::Cast(i) || EagerCall::Cast(i)) {
             Value* trg = nullptr;
             if (Call::Cast(i))

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -23,6 +23,60 @@ class TheCleanup {
             while (ip != bb->end()) {
                 Instruction* i = *ip;
                 auto next = ip + 1;
+
+                // Convert lazy calls to eager calls, if all args are eager.
+                {
+                    auto call = Call::Cast(i);
+                    if (call) {
+                        bool allEager = true;
+                        std::vector<Value*> args;
+                        call->eachCallArg([&](Value* v) {
+                            auto arg = MkArg::Cast(v);
+                            if (arg && arg->eagerArg() == Missing::instance())
+                                allEager = false;
+                            if (allEager)
+                                args.push_back(arg->eagerArg());
+                        });
+                        if (allEager) {
+                            auto eagerCall = new EagerCall(
+                                call->env(), call->cls(), args, call->srcIdx);
+                            call->replaceUsesWith(eagerCall);
+                            bb->replace(ip, eagerCall);
+                        }
+                    }
+                }
+
+                {
+                    auto call = StaticCall::Cast(i);
+                    if (call) {
+                        bool allEager = true;
+                        std::vector<Value*> args;
+                        call->eachCallArg([&](Value* v) {
+                            auto arg = MkArg::Cast(v);
+                            if (arg && arg->eagerArg() == Missing::instance())
+                                allEager = false;
+                            if (allEager)
+                                args.push_back(arg->eagerArg());
+                        });
+                        if (allEager) {
+                            auto eagerCall = new StaticEagerCall(
+                                call->env(), call->cls(), args, call->srcIdx,
+                                call->origin());
+                            call->replaceUsesWith(eagerCall);
+                            bb->replace(ip, eagerCall);
+                        }
+                    }
+                }
+
+                ip = next;
+            }
+        });
+
+        Visitor::run(function->entry, [&](BB* bb) {
+            auto ip = bb->begin();
+            while (ip != bb->end()) {
+                Instruction* i = *ip;
+                auto next = ip + 1;
                 Force* force = Force::Cast(i);
                 ChkClosure* chkcls = ChkClosure::Cast(i);
                 ChkMissing* missing = ChkMissing::Cast(i);

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -166,7 +166,7 @@ void ForceDominance::apply(Closure* cls) {
                 auto mkarg = MkArg::Cast(getValue(f));
                 if (mkarg) {
                     if (analysis.isDominating(f)) {
-                        Value* strict = mkarg->arg<0>().val();
+                        Value* strict = mkarg->eagerArg();
                         if (strict != Missing::instance()) {
                             f->replaceUsesWith(strict);
                             next = bb->remove(ip);

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -45,9 +45,14 @@ using namespace rir::pir;
 struct ForcedAt : public std::unordered_map<Value*, Force*> {
     static Force* ambiguous() { return (Force*)0x22; }
 
-    void evalAt(Value* val, Force* force) {
+    void forcedAt(MkArg* val, Force* force) {
         if (!count(val))
             (*this)[val] = force;
+    }
+    void usedAt(MkArg* val, Force* force) {
+        // Used before force, this means we need to keep the promise as is
+        if (!count(val))
+            (*this)[val] = ambiguous();
     }
     bool merge(ForcedAt& other) {
         bool changed = false;
@@ -89,8 +94,17 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedAt> {
 
     void apply(ForcedAt& d, Instruction* i) const override {
         auto f = Force::Cast(i);
-        if (f)
-            d.evalAt(getValue(f), f);
+        if (f) {
+            MkArg* arg = MkArg::Cast(getValue(f));
+            if (arg)
+                d.forcedAt(arg, f);
+        } else if (!CastType::Cast(i)) {
+            i->eachArg([&](Value* v) {
+                MkArg* arg = MkArg::Cast(v);
+                if (arg)
+                    d.usedAt(arg, f);
+            });
+        }
     }
 };
 
@@ -140,6 +154,7 @@ void ForceDominance::apply(Closure* cls) {
     ForceDominanceAnalysisResult analysis(cls);
 
     std::unordered_map<Force*, Value*> inlinedPromise;
+    std::unordered_map<MkArg*, MkArg*> forcedMkArg;
 
     // 1. Inline dominating promises
     Visitor::run(cls->entry, [&](BB* bb) {
@@ -180,10 +195,15 @@ void ForceDominance::apply(Closure* cls) {
                             f = Force::Cast(*split->begin());
                             assert(f);
                             f->replaceUsesWith(promRes);
-                            next = split->remove(split->begin());
-                            bb = split;
+                            split->remove(split->begin());
+
+                            MkArg* fixedMkArg =
+                                new MkArg(mkarg->prom, promRes, mkarg->env());
+                            next = split->insert(split->begin(), fixedMkArg);
+                            forcedMkArg[mkarg] = fixedMkArg;
 
                             inlinedPromise[f] = promRes;
+                            bb = split;
                         }
                     }
                 }
@@ -212,6 +232,10 @@ void ForceDominance::apply(Closure* cls) {
             ip = next;
         }
     });
+
+    // 3. replace remaining uses of the mkarg itself
+    for (auto m : forcedMkArg)
+        m.first->replaceUsesIn(m.second, m.second->bb());
 }
 }
 }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -41,6 +41,16 @@ class TheInliner {
                         continue;
                     assert(cls->fun->closureEnv() == Env::notClosed());
                     staticEnv = cls->env();
+                } else if (EagerCall::Cast(*it)) {
+                    EagerCall* call = EagerCall::Cast(*it);
+                    auto cls = MkFunCls::Cast(call->cls());
+                    if (!cls)
+                        continue;
+                    inlinee = cls->fun;
+                    if (inlinee->argNames.size() != call->nCallArgs())
+                        continue;
+                    assert(cls->fun->closureEnv() == Env::notClosed());
+                    staticEnv = cls->env();
                 } else if (StaticCall::Cast(*it)) {
                     StaticCall* call = StaticCall::Cast(*it);
                     inlinee = call->cls();

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -24,15 +24,14 @@ class TheInliner {
             // Dangerous iterater usage, works since we do only update it in
             // one place.
             for (auto it = bb->begin(); it != bb->end(); it++) {
-                auto call = CallInstructionI::CastCall(*it);
+                auto call = CallInstruction::CastCall(*it);
                 if (!call)
                     continue;
 
                 Closure* inlinee = nullptr;
                 Value* staticEnv = nullptr;
 
-                if (Call::Cast(*it)) {
-                    Call* call = Call::Cast(*it);
+                if (auto call = Call::Cast(*it)) {
                     auto cls = MkFunCls::Cast(call->cls());
                     if (!cls)
                         continue;
@@ -41,8 +40,7 @@ class TheInliner {
                         continue;
                     assert(cls->fun->closureEnv() == Env::notClosed());
                     staticEnv = cls->env();
-                } else if (EagerCall::Cast(*it)) {
-                    EagerCall* call = EagerCall::Cast(*it);
+                } else if (auto call = EagerCall::Cast(*it)) {
                     auto cls = MkFunCls::Cast(call->cls());
                     if (!cls)
                         continue;
@@ -51,12 +49,10 @@ class TheInliner {
                         continue;
                     assert(cls->fun->closureEnv() == Env::notClosed());
                     staticEnv = cls->env();
-                } else if (StaticCall::Cast(*it)) {
-                    StaticCall* call = StaticCall::Cast(*it);
+                } else if (auto call = StaticCall::Cast(*it)) {
                     inlinee = call->cls();
                     staticEnv = inlinee->closureEnv();
-                } else if (StaticEagerCall::Cast(*it)) {
-                    StaticEagerCall* call = StaticEagerCall::Cast(*it);
+                } else if (auto call = StaticEagerCall::Cast(*it)) {
                     inlinee = call->cls();
                     staticEnv = inlinee->closureEnv();
                 } else {
@@ -67,7 +63,7 @@ class TheInliner {
                     BBTransform::split(function->nextBBId++, bb, it, function);
 
                 auto theCall = *split->begin();
-                auto theCallInstruction = CallInstructionI::CastCall(theCall);
+                auto theCallInstruction = CallInstruction::CastCall(theCall);
                 std::vector<Value*> arguments;
                 theCallInstruction->eachCallArg(
                     [&](Value* v) { arguments.push_back(v); });

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -86,6 +86,7 @@ class TheInliner {
                                 a = cast;
                             }
                             ld->replaceUsesWith(a);
+                            next = bb->remove(ip);
                         }
                         ip = next;
                     }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -24,7 +24,7 @@ class TheInliner {
             // Dangerous iterater usage, works since we do only update it in
             // one place.
             for (auto it = bb->begin(); it != bb->end(); it++) {
-                auto call = CallInstruction::Cast(*it);
+                auto call = CallInstructionI::CastCall(*it);
                 if (!call)
                     continue;
 
@@ -50,14 +50,14 @@ class TheInliner {
                     inlinee = call->cls();
                     staticEnv = inlinee->closureEnv();
                 } else {
-                    assert(false);
+                    continue;
                 }
 
                 BB* split =
                     BBTransform::split(function->nextBBId++, bb, it, function);
 
                 auto theCall = *split->begin();
-                auto theCallInstruction = CallInstruction::Cast(theCall);
+                auto theCallInstruction = CallInstructionI::CastCall(theCall);
                 std::vector<Value*> arguments;
                 theCallInstruction->eachCallArg(
                     [&](Value* v) { arguments.push_back(v); });

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -53,8 +53,8 @@ class TheScopeResolution {
                     auto aload = analysis.loads.at(ss);
                     if (e && aload.env != AbstractREnvironment::UnknownParent) {
                         if (!aload.result.isUnknown()) {
-                            auto r = new StVar(ss->varName, ss->arg<0>().val(),
-                                               aload.env);
+                            auto r =
+                                new StVar(ss->varName, ss->val(), aload.env);
                             bb->replace(ip, r);
                             ss->replaceUsesWith(r);
                         }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -300,7 +300,7 @@ void StaticCall::printArgs(std::ostream& out) {
     Instruction::printArgs(out);
 }
 
-CallInstructionI* CallInstructionI::CastCall(Value* v) {
+CallInstruction* CallInstruction::CastCall(Value* v) {
     switch (v->tag) {
     case Tag::Call:
         return Call::Cast(v);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -28,34 +28,11 @@ static size_t getMaxInstructionNameLength() {
 }
 static size_t maxInstructionNameLength = getMaxInstructionNameLength();
 
-const static Instruction::Description instructionDescriptionTable[] = {
-#define V(Instruction) Instruction::getDescription(),
-    COMPILER_INSTRUCTIONS(V)
-#undef V
-};
-
 static_assert(static_cast<unsigned>(Tag::_UNUSED_) == 0, "");
-static size_t tagIdx(Tag tag) { return static_cast<size_t>(tag) - 1; }
 } // namespace
 
 namespace rir {
 namespace pir {
-
-bool Instruction::mightIO() const {
-    return instructionDescriptionTable[tagIdx(tag)].mightIO;
-}
-bool Instruction::changesEnv() const {
-    return instructionDescriptionTable[tagIdx(tag)].changesEnv;
-}
-bool Instruction::leaksEnv() const {
-    return instructionDescriptionTable[tagIdx(tag)].leaksEnv;
-}
-bool Instruction::hasEnv() const {
-    return instructionDescriptionTable[tagIdx(tag)].hasEnv;
-}
-bool Instruction::accessesEnv() const {
-    return instructionDescriptionTable[tagIdx(tag)].accessEnv;
-}
 
 extern std::ostream& operator<<(std::ostream& out,
                                 Instruction::InstructionUID id) {
@@ -175,7 +152,7 @@ void Branch::printArgs(std::ostream& out) {
 }
 
 void MkArg::printArgs(std::ostream& out) {
-    arg<0>().val()->printRef(out);
+    eagerArg()->printRef(out);
     out << ", " << *prom << ", ";
     env()->printRef(out);
 }
@@ -212,16 +189,13 @@ void LdVarSuper::printArgs(std::ostream& out) {
 }
 
 void MkEnv::printArgs(std::ostream& out) {
-    out << "parent=";
-    arg(0).val()->printRef(out);
-    if (nargs() > 1)
+    eachLocalVar([&](SEXP name, Value* v) {
+        out << CHAR(PRINTNAME(name)) << "=";
+        v->printRef(out);
         out << ", ";
-    for (unsigned i = 0; i < nargs() - 1; ++i) {
-        out << CHAR(PRINTNAME(this->varName[i])) << "=";
-        this->arg(i + 1).val()->printRef(out);
-        if (i != nargs() - 2)
-            out << ", ";
-    }
+    });
+    out << "parent=";
+    parent()->printRef(out);
 }
 
 void Is::printArgs(std::ostream& out) {
@@ -263,7 +237,7 @@ void PirCopy::print(std::ostream& out) {
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
                                  unsigned src)
-    : VarLenInstruction(PirType::valOrLazy()), blt(builtin),
+    : CallInstructionImplementation(PirType::valOrLazy()), blt(builtin),
       builtin(getBuiltin(builtin)), builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
         this->pushArg(args[i], PirType::val());
@@ -272,7 +246,7 @@ CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
 
 CallBuiltin::CallBuiltin(Value* e, SEXP builtin,
                          const std::vector<Value*>& args, unsigned src)
-    : VarLenInstruction(PirType::valOrLazy(), e), blt(builtin),
+    : CallInstructionImplementation(PirType::valOrLazy(), e), blt(builtin),
       builtin(getBuiltin(builtin)), builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
         this->pushArg(args[i], PirType::val());
@@ -324,6 +298,23 @@ void StaticCall::printArgs(std::ostream& out) {
     if (nargs() > 0)
         out << ", ";
     Instruction::printArgs(out);
+}
+
+CallInstructionI* CallInstructionI::CastCall(Value* v) {
+    switch (v->tag) {
+    case Tag::Call:
+        return Call::Cast(v);
+    case Tag::StaticCall:
+        return StaticCall::Cast(v);
+    case Tag::StaticEagerCall:
+        return StaticEagerCall::Cast(v);
+    case Tag::CallBuiltin:
+        return CallBuiltin::Cast(v);
+    case Tag::CallSafeBuiltin:
+        return CallSafeBuiltin::Cast(v);
+    default: {}
+    }
+    return nullptr;
 }
 
 } // namespace pir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -306,6 +306,8 @@ CallInstructionI* CallInstructionI::CastCall(Value* v) {
         return Call::Cast(v);
     case Tag::StaticCall:
         return StaticCall::Cast(v);
+    case Tag::EagerCall:
+        return EagerCall::Cast(v);
     case Tag::StaticEagerCall:
         return StaticEagerCall::Cast(v);
     case Tag::CallBuiltin:

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -26,6 +26,7 @@
     V(Call)                                                                    \
     V(StaticCall)                                                              \
     V(StaticEagerCall)                                                         \
+    V(EagerCall)                                                               \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
     V(MkEnv)                                                                   \

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -51,6 +51,7 @@
     V(Gt)                                                                      \
     V(Neq)                                                                     \
     V(Eq)                                                                      \
+    V(Identical)                                                               \
     V(Length)                                                                  \
     V(Extract1_1D)                                                             \
     V(Extract1_2D)                                                             \

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -283,7 +283,7 @@ class SSAAllocator {
                 size_t newStackSize = stack.size();
                 bool foundAll = true;
                 auto check = stack.rbegin();
-                StackArgVisitor::run(i, [&](Value* arg) {
+                i->eachArgRev([&](Value* arg) {
                     while (check != stack.rend() && *check != arg) {
                         ++check;
                         --newStackSize;
@@ -307,8 +307,7 @@ class SSAAllocator {
                 // A, C to be in a stack slot, discard B (it will become
                 // a local variable later) and resize the stack to [xxx]
                 stack.resize(newStackSize);
-                StackArgVisitor::run(
-                    i, [&](Value* arg) { allocation[arg] = stackSlot; });
+                i->eachArgRev([&](Value* arg) { allocation[arg] = stackSlot; });
             };
 
             for (auto i : *bb) {
@@ -468,7 +467,10 @@ class SSAAllocator {
                         stack.pop_back();
                 } else {
                     // Make sure all our args are live
-                    StackArgVisitor::run(i, [&](Value* a) {
+                    i->eachArgRev([&](Value* a) {
+                        auto i = Instruction::Cast(a);
+                        if (!i)
+                            return;
                         if (!allocation.count(a)) {
                             std::cerr << "REG alloc fail: ";
                             i->printRef(std::cerr);
@@ -573,74 +575,6 @@ class SSAAllocator {
         assert(i);
         return allocation.count(i) == 0;
     }
-
-  private:
-    struct StackArgVisitor {
-        typedef std::function<void(Value*)> ValueAction;
-        static void run(Instruction* i, ValueAction action) {
-            auto runReverseArgs = [&](CallInstructionI* call) {
-                std::vector<Value*> args(call->nCallArgs());
-                call->eachCallArg([&](Value* a) { args.push_back(a); });
-                while (!args.empty()) {
-                    action(args.back());
-                    args.pop_back();
-                }
-            };
-            switch (i->tag) {
-            case Tag::MkArg: {
-                // just the eager value, if it's not missing
-                MkArg::Cast(i)->ifEager([&](Value* arg) { action(arg); });
-                break;
-            }
-            case Tag::Call: {
-                auto call = Call::Cast(i);
-                if (call->allArgsEager())
-                    runReverseArgs(call);
-                action(Call::Cast(i)->cls());
-                break;
-            }
-            case Tag::StaticCall: {
-                auto call = StaticCall::Cast(i);
-                if (call->allArgsEager())
-                    runReverseArgs(call);
-                break;
-            }
-            case Tag::Phi: {
-                // do nothing - stack-allocated phi's are handled elsewhere
-                break;
-            }
-            case Tag::MkEnv: {
-                // expects the parent on stack; only allocate if non-static
-                auto parent = MkEnv::Cast(i)->parent();
-                if (!Env::isStaticEnv(parent))
-                    action(parent);
-                // then fall through to the default and do all locals in reverse
-            }
-            // default is ok for these
-            case Tag::StaticEagerCall:
-            case Tag::CallBuiltin:
-            case Tag::CallSafeBuiltin:
-            default: {
-                // skip env if they have it and go over the rest in reverse
-                i->eachArgRev([&](Value* arg) {
-                    if (i->hasEnv() && i->env() == arg)
-                        return;
-                    action(arg);
-                });
-                break;
-            }
-            case Tag::MkCls:
-            case Tag::Deopt:
-                assert(false && "what to do with these??");
-            // values, not instructions
-            case Tag::Missing:
-            case Tag::Env:
-            case Tag::Nil:
-            case Tag::_UNUSED_:
-                assert(false && "not an instruction");
-            }
-        }
-    };
 };
 
 class Context {
@@ -683,6 +617,7 @@ class Pir2Rir {
   public:
     Pir2Rir(Pir2RirCompiler& cmp, Closure* cls) : compiler(cmp), cls(cls) {}
     size_t compileCode(Context& ctx, Code* code);
+    size_t getPromiseIdx(Context& ctx, Promise* code);
     void toCSSA(Code* code);
     rir::Function* finalize();
 
@@ -720,133 +655,138 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
         CodeStream& cs = ctx.cs();
         cs << bbLabels[bb];
 
-        /*
-            this attempts to eliminate redundant store-load pairs, ie.
-            if there is an instruction that has only one use, and the use is the
-            next instruction, and it is its only input, and PirCopy is not
-            involved
-            TODO: is it always the case that the store and load use the same
-            local slot?
-        */
-        auto store = [&](BB::Instrs::iterator it, Value* what) {
-            if (alloc.dead(what)) {
-                cs << BC::pop();
-                return;
-            }
-            if (alloc.onStack(what))
-                return;
-            cs << BC::stloc(alloc[what]);
-        };
-        auto load = [&](BB::Instrs::iterator it, Value* what) {
-            if (alloc.onStack(what))
-                return;
-            cs << BC::ldloc(alloc[what]);
-        };
-
         Value* currentEnv = nullptr;
-        auto loadEnv = [&](BB::Instrs::iterator it, Value* val) {
-            assert(Env::isAnyEnv(val));
-            if (Env::isStaticEnv(val))
-                cs << BC::push(Env::Cast(val)->rho);
-            else
-                load(it, val);
-        };
-        auto setEnv = [&](BB::Instrs::iterator it, Value* val) {
-            assert(Env::isAnyEnv(val));
-            if (val != currentEnv) {
-                currentEnv = val;
-                loadEnv(it, val);
-                cs << BC::setEnv();
-            } else if (alloc.allocation[val] == SSAAllocator::stackSlot) {
-                cs << BC::pop();
-            }
-        };
 
         for (auto it = bb->begin(); it != bb->end(); ++it) {
             auto instr = *it;
+
+            bool hasResult =
+                instr->type != PirType::voyd() && !Phi::Cast(instr);
+
+            auto explicitEnvValue = [](Instruction* instr) {
+                return MkEnv::Cast(instr) || Deopt::Cast(instr);
+            };
+
+            // Load Arguments to the stack
+            {
+                auto loadEnv = [&](BB::Instrs::iterator it, Value* what) {
+                    if (Env::isStaticEnv(what)) {
+                        cs << BC::push(Env::Cast(what)->rho);
+                    } else if (what == Env::notClosed()) {
+                        cs << BC::callerEnv();
+                    } else if (!alloc.onStack(what)) {
+                        cs << BC::ldloc(alloc[what]);
+                    }
+                };
+
+                auto loadArg = [&](BB::Instrs::iterator it, Instruction* instr,
+                                   Value* what) {
+                    if (what == Missing::instance()) {
+                        assert(MkArg::Cast(instr) &&
+                               "only mkarg supports missing");
+                    } else if (!alloc.onStack(what)) {
+                        cs << BC::ldloc(alloc[what]);
+                    }
+                };
+
+                // Step one: load and set env
+                if (!Phi::Cast(instr)) {
+                    if (instr->hasEnv() && !explicitEnvValue(instr)) {
+                            // If the env is passed on the stack, it needs
+                            // to be TOS here. To relax this condition some
+                            // stack shuffling would be needed.
+                            assert(instr->envSlot() == instr->nargs() - 1);
+                            auto env = instr->env();
+                            if (currentEnv != env) {
+                                loadEnv(it, env);
+                                cs << BC::setEnv();
+                                currentEnv = env;
+                        } else {
+                            if (alloc.onStack(env))
+                                cs << BC::pop();
+                        }
+                    }
+                }
+
+                // Step two: load the rest
+                auto c = Call::Cast(instr);
+                auto sc = StaticCall::Cast(instr);
+                if ((c && !c->allArgsEager()) || (sc && !sc->allArgsEager())) {
+                    // For lazy calls the args are not loaded, eager call args
+                    // are removed from the stack.
+                    CallInstructionI::CastCall(instr)->eachCallArg(
+                        [&](Value* arg) {
+                            if (alloc.onStack(arg)) {
+                                MkArg::Cast(arg)->ifEager(
+                                    [&](Value*) { cs << BC::pop(); });
+                            }
+                        });
+                    if (c)
+                        loadArg(it, instr, c->cls());
+                } else if (!Phi::Cast(instr)) {
+                    instr->eachArg([&](Value* what) {
+                        if (instr->hasEnv() && instr->env() == what) {
+                            if (explicitEnvValue(instr))
+                                loadEnv(it, what);
+                        } else {
+                            loadArg(it, instr, what);
+                        }
+                    });
+                }
+            }
+
             switch (instr->tag) {
             case Tag::LdConst: {
                 cs << BC::push(LdConst::Cast(instr)->c);
-                store(it, instr);
                 break;
             }
             case Tag::LdFun: {
                 auto ldfun = LdFun::Cast(instr);
-                setEnv(it, ldfun->env());
                 cs << BC::ldfun(ldfun->varName);
-                store(it, ldfun);
                 break;
             }
             case Tag::LdVar: {
                 auto ldvar = LdVar::Cast(instr);
-                setEnv(it, ldvar->env());
                 cs << BC::ldvarNoForce(ldvar->varName);
-                store(it, ldvar);
                 break;
             }
             case Tag::ForSeqSize: {
-                // TODO: not tested
-                // make sure that the seq is at TOS? the instr doesn't push it!
-                auto sz = ForSeqSize::Cast(instr);
-                auto seq = sz->arg(0).val();
-                load(it, seq);
                 cs << BC::forSeqSize();
                 // TODO: currently we always pop the sequence, since we cannot
                 // deal with instructions that do not pop the value after use.
                 // If it is used in a later instruction, it will be loaded
                 // from a local variable again.
                 cs << BC::swap() << BC::pop();
-                store(it, instr);
                 break;
             }
             case Tag::LdArg: {
                 cs << BC::ldarg(LdArg::Cast(instr)->id);
-                store(it, instr);
                 break;
             }
             case Tag::ChkMissing: {
-                // TODO: not tested
-                auto check = ChkMissing::Cast(instr);
-                load(it, check->arg<0>().val());
                 cs << BC::checkMissing();
-                store(it, check);
                 break;
             }
             case Tag::ChkClosure: {
-                // TODO: not tested
-                auto check = ChkClosure::Cast(instr);
-                load(it, check->arg<0>().val());
                 cs << BC::isfun();
-                store(it, check);
                 break;
             }
             case Tag::StVarSuper: {
-                // TODO: not tested
                 auto stvar = StVarSuper::Cast(instr);
-                setEnv(it, stvar->env());
-                load(it, stvar->val());
                 cs << BC::stvarSuper(stvar->varName);
                 break;
             }
             case Tag::LdVarSuper: {
-                // TODO: not tested
                 auto ldvar = LdVarSuper::Cast(instr);
-                setEnv(it, ldvar->env());
                 cs << BC::ldvarNoForceSuper(ldvar->varName);
-                store(it, ldvar);
                 break;
             }
             case Tag::StVar: {
                 auto stvar = StVar::Cast(instr);
-                setEnv(it, stvar->env());
-                load(it, stvar->val());
                 cs << BC::stvar(stvar->varName);
                 break;
             }
             case Tag::Branch: {
-                auto br = Branch::Cast(instr);
-                load(it, br->arg<0>().val());
-
                 // jump through empty blocks
                 auto next0 = bb->next0;
                 while (next0->isEmpty())
@@ -861,37 +801,28 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 return;
             }
             case Tag::Return: {
-                Return* ret = Return::Cast(instr);
-                load(it, ret->arg<0>().val());
                 cs << BC::ret();
 
                 // this is the end of this BB
                 return;
             }
             case Tag::MkArg: {
+                // MkArg just passes on the eager value
+                if (MkArg::Cast(instr)->eagerArg() == Missing::instance())
+                    hasResult = false;
+#ifdef SLOWASSERT
                 BreadthFirstVisitor::run(bb, [&](Instruction* i) {
                     i->eachArg([&](Value* arg) {
                         if (arg == i)
-                            assert(CallInstruction::Cast(i) &&
+                            assert(CallInstructionI::CastCall(i) &&
                                    "MkArg used in a non-call instruction");
                     });
                 });
-                // TODO: handle eager values; for now, if eager, just throw it
-                // away
-                MkArg::Cast(instr)->ifEager([&](Value* arg) {
-                    if (alloc.onStack(arg))
-                        cs << BC::pop();
-                });
+#endif
                 break;
             }
             case Tag::Seq: {
-                // TODO: not tested
-                auto seq = Seq::Cast(instr);
-                load(it, seq->arg<0>().val());
-                load(it, seq->arg<1>().val());
-                load(it, seq->arg<2>().val());
                 cs << BC::seq();
-                store(it, seq);
                 break;
             }
             case Tag::MkCls: {
@@ -904,121 +835,71 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
                 auto mkfuncls = MkFunCls::Cast(instr);
 
-                Pir2Rir pir2rir(compiler, mkfuncls->fun);
-                auto rirFun = pir2rir.finalize();
                 auto dt = DispatchTable::unpack(mkfuncls->code);
-                assert(dt->capacity() == 2 && dt->at(1) == nullptr &&
-                       "invalid dispatch table");
-                dt->put(1, rirFun);
 
-                setEnv(it, mkfuncls->env());
+                if (dt->capacity() > 1 && !dt->available(1)) {
+                    Pir2Rir pir2rir(compiler, mkfuncls->fun);
+                    auto rirFun = pir2rir.finalize();
+                    if (!compiler.dryRun)
+                        dt->put(1, rirFun);
+                }
                 cs << BC::push(mkfuncls->fml) << BC::push(mkfuncls->code)
                    << BC::push(mkfuncls->src) << BC::close();
-                store(it, mkfuncls);
                 break;
             }
             case Tag::CastType: {
-                auto cast = CastType::Cast(instr);
-                load(it, cast->arg<0>().val());
-                store(it, cast);
                 break;
             }
             case Tag::Subassign1_1D: {
-                // TODO: not tested
-                auto res = Subassign1_1D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
-                load(it, res->arg<2>().val());
                 cs << BC::subassign1();
-                store(it, res);
                 break;
             }
             case Tag::Subassign2_1D: {
-                // TODO: not tested
                 auto res = Subassign2_1D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
-                load(it, res->arg<2>().val());
                 cs << BC::subassign2(res->sym);
-                store(it, res);
                 break;
             }
             case Tag::Extract1_1D: {
-                // TODO: not tested
-                auto res = Extract1_1D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
                 cs << BC::extract1_1();
-                store(it, res);
                 break;
             }
             case Tag::Extract2_1D: {
-                // TODO: not tested
-                auto res = Extract2_1D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
                 cs << BC::extract2_1();
-                store(it, res);
                 break;
             }
             case Tag::Extract1_2D: {
-                // TODO: not tested
-                auto res = Extract1_2D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
-                load(it, res->arg<2>().val());
                 cs << BC::extract1_2();
-                store(it, res);
                 break;
             }
             case Tag::Extract2_2D: {
-                // TODO: not tested
-                auto res = Extract2_2D::Cast(instr);
-                load(it, res->arg<0>().val());
-                load(it, res->arg<1>().val());
-                load(it, res->arg<2>().val());
                 cs << BC::extract2_2();
-                store(it, res);
                 break;
             }
             case Tag::IsObject: {
-                auto is = IsObject::Cast(instr);
-                load(it, is->arg<0>().val());
                 cs << BC::isObj();
-                store(it, is);
                 break;
             }
             case Tag::LdFunctionEnv: {
                 // TODO: what should happen? For now get the current env (should
                 // be the promise environment that the evaluator was called
                 // with) and store it into local and leave it set as current
-                if (!alloc.dead(instr)) {
-                    cs << BC::getEnv();
-                    store(it, instr);
-                }
+                cs << BC::getEnv();
                 break;
             }
             case Tag::PirCopy: {
-                auto cpy = PirCopy::Cast(instr);
-                load(it, cpy->arg<0>().val());
-                store(it, cpy);
                 break;
             }
             case Tag::Is: {
                 auto is = Is::Cast(instr);
-                load(it, is->arg<0>().val());
                 cs << BC::is(is->sexpTag);
-                store(it, is);
                 break;
             }
 
 #define SIMPLE_INSTR(Name, Factory)                                            \
     case Tag::Name: {                                                          \
         auto simple = Name::Cast(instr);                                       \
-        load(it, simple->arg<0>().val());                                      \
         cs << BC::Factory();                                                   \
         cs.addSrcIdx(simple->srcIdx);                                          \
-        store(it, simple);                                                     \
         break;                                                                 \
     }
                 SIMPLE_INSTR(Inc, inc);
@@ -1036,13 +917,8 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 #define BINOP(Name, Factory)                                                   \
     case Tag::Name: {                                                          \
         auto binop = Name::Cast(instr);                                        \
-        auto lhs = binop->arg<0>().val();                                      \
-        auto rhs = binop->arg<1>().val();                                      \
-        load(it, lhs);                                                         \
-        load(it, rhs);                                                         \
         cs << BC::Factory();                                                   \
         cs.addSrcIdx(binop->srcIdx);                                           \
-        store(it, binop);                                                      \
         break;                                                                 \
     }
                 BINOP(Add, add);
@@ -1057,6 +933,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 BINOP(Lte, ge);
                 BINOP(Gte, le);
                 BINOP(Eq, eq);
+                BINOP(Identical, identical);
                 BINOP(Neq, ne);
                 BINOP(LOr, lglOr);
                 BINOP(LAnd, lglAnd);
@@ -1065,49 +942,43 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
             case Tag::Call: {
                 auto call = Call::Cast(instr);
-                setEnv(it, call->env());
-                load(it, call->cls());
-
                 if (call->allArgsEager()) {
-                    call->eachCallArg([&](Value* arg) { load(it, arg); });
                     cs.insertStackCall(Opcode::call_stack_, call->nCallArgs(),
                                        {}, Pool::get(call->srcIdx));
                 } else {
                     std::vector<FunIdxT> callArgs;
                     call->eachCallArg([&](Value* arg) {
-                        // TODO: for now, ignore the eager value in MkArg
                         auto mkarg = MkArg::Cast(arg);
-                        callArgs.push_back(promises[mkarg->prom]);
+                        assert(mkarg);
+                        callArgs.push_back(getPromiseIdx(ctx, mkarg->prom));
                     });
+
                     cs.insertCall(Opcode::call_, callArgs, {},
                                   Pool::get(call->srcIdx));
                 }
-                store(it, call);
                 break;
             }
             case Tag::StaticCall: {
                 auto call = StaticCall::Cast(instr);
-                setEnv(it, call->env());
 
                 compiler.compile(call->cls(), call->origin());
                 // push callee - this stores it into constant pool
                 cs << BC::push(call->origin());
 
                 if (call->allArgsEager()) {
-                    call->eachCallArg([&](Value* arg) { load(it, arg); });
                     cs.insertStackCall(Opcode::call_stack_, call->nCallArgs(),
                                        {}, Pool::get(call->srcIdx));
                 } else {
                     std::vector<FunIdxT> callArgs;
                     call->eachCallArg([&](Value* arg) {
-                        // TODO: for now, ignore the eager value in MkArg
                         auto mkarg = MkArg::Cast(arg);
-                        callArgs.push_back(promises[mkarg->prom]);
+                        assert(mkarg);
+                        callArgs.push_back(getPromiseIdx(ctx, mkarg->prom));
                     });
+
                     cs.insertCall(Opcode::call_, callArgs, {},
                                   Pool::get(call->srcIdx));
                 }
-                store(it, call);
                 break;
             }
             case Tag::StaticEagerCall: {
@@ -1115,45 +986,37 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
                 compiler.compile(call->cls(), call->origin());
 
-                setEnv(it, call->env());
-                call->eachCallArg([&](Value* arg) { load(it, arg); });
                 cs.insertStackCall(Opcode::static_call_stack_,
                                    call->nCallArgs(), {},
                                    Pool::get(call->srcIdx), call->origin());
-                store(it, call);
                 break;
             }
             case Tag::CallBuiltin: {
                 auto blt = CallBuiltin::Cast(instr);
-                setEnv(it, blt->env());
-                blt->eachCallArg([&](Value* arg) { load(it, arg); });
                 cs.insertStackCall(Opcode::static_call_stack_, blt->nCallArgs(),
                                    {}, Pool::get(blt->srcIdx), blt->blt);
-                store(it, blt);
                 break;
             }
             case Tag::CallSafeBuiltin: {
                 auto blt = CallSafeBuiltin::Cast(instr);
-                // no environment
-                blt->eachArg([&](Value* arg) { load(it, arg); });
                 cs.insertStackCall(Opcode::static_call_stack_, blt->nargs(), {},
                                    Pool::get(blt->srcIdx), blt->blt);
-                store(it, blt);
                 break;
             }
             case Tag::MkEnv: {
                 auto mkenv = MkEnv::Cast(instr);
-                loadEnv(it, mkenv->parent());
-                cs << BC::makeEnv();
-                store(it, mkenv);
 
-                // bind all args
-                // TODO: maybe later have a separate instruction for this?
-                setEnv(it, mkenv);
-                mkenv->eachLocalVar([&](SEXP name, Value* val) {
-                    load(it, val);
-                    cs << BC::stvar(name);
-                });
+                cs << BC::makeEnv();
+
+                if (mkenv->nLocals() > 0) {
+                    cs << BC::setEnv();
+                    currentEnv = instr;
+
+                    mkenv->eachLocalVarRev(
+                        [&](SEXP name, Value* val) { cs << BC::stvar(name); });
+
+                    cs << BC::getEnv();
+                }
                 break;
             }
             case Tag::Phi: {
@@ -1169,8 +1032,10 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 break;
             }
             case Tag::Deopt: {
-                assert(false && "not yet implemented.");
-                break;
+                Deopt::Cast(instr)->eachArg([&](Value*) { cs << BC::pop(); });
+                // TODO
+                cs << BC::int3();
+                return;
             }
             // values, not instructions
             case Tag::Missing:
@@ -1181,10 +1046,19 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
             case Tag::_UNUSED_:
                 break;
             }
+
+            // Store the result
+            if (hasResult) {
+                if (alloc.dead(instr))
+                    cs << BC::pop();
+                else if (!alloc.onStack(instr))
+                    cs << BC::stloc(alloc[instr]);
+            };
         }
 
         // this BB has exactly one successor, next0
         // jump through empty blocks
+        assert(bb->next0);
         auto next = bb->next0;
         while (next->isEmpty())
             next = next->next0;
@@ -1226,6 +1100,15 @@ void Pir2Rir::toCSSA(Code* code) {
     });
 }
 
+size_t Pir2Rir::getPromiseIdx(Context& ctx, Promise* p) {
+    if (!promises.count(p)) {
+        ctx.pushPromise(R_NilValue);
+        size_t localsCnt = compileCode(ctx, p);
+        promises[p] = ctx.finalizeCode(localsCnt);
+    }
+    return promises.at(p);
+}
+
 rir::Function* Pir2Rir::finalize() {
     // TODO: asts are NIL for now, how to deal with that? after inlining
     // functions and asts don't correspond anymore
@@ -1237,17 +1120,8 @@ rir::Function* Pir2Rir::finalize() {
     for (auto arg : cls->defaultArgs) {
         if (!arg)
             continue;
-        ctx.pushDefaultArg(R_NilValue);
-        size_t localsCnt = compileCode(ctx, arg);
-        promises[arg] = ctx.finalizeCode(localsCnt);
+        promises[arg] = getPromiseIdx(ctx, arg);
         argNames[arg] = cls->argNames[i++];
-    }
-    for (auto prom : cls->promises) {
-        if (!prom)
-            continue;
-        ctx.pushPromise(R_NilValue);
-        size_t localsCnt = compileCode(ctx, prom);
-        promises[prom] = ctx.finalizeCode(localsCnt);
     }
     ctx.pushBody(R_NilValue);
     size_t localsCnt = compileCode(ctx, cls);
@@ -1272,11 +1146,15 @@ rir::Function* Pir2Rir::finalize() {
 
 rir::Function* Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
     auto table = DispatchTable::unpack(BODY(origin));
-    if (table->slot(1))
+    if (table->available(1))
         return table->at(1);
 
     Pir2Rir pir2rir(*this, cls);
     auto fun = pir2rir.finalize();
+
+    if (dryRun)
+        return fun;
+
     Protect p(fun->container());
 
     auto oldFun = table->first();

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -9,6 +9,7 @@ namespace pir {
 class Pir2RirCompiler {
   public:
     bool verbose = false;
+    bool dryRun = false;
 
     rir::Function* compile(Closure* cls, SEXP origin);
 };

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -32,7 +32,7 @@ void Rir2PirCompiler::compileClosure(SEXP closure, MaybeCls success,
     assert(isValidClosureSEXP(closure));
     DispatchTable* tbl = DispatchTable::unpack(BODY(closure));
 
-    if (!tbl->slot(1)) {
+    if (tbl->available(1)) {
         if (isVerbose())
             std::cerr << "Closure already compiled to PIR\n";
     }

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -210,7 +210,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
         break;
     }
 
-    case Opcode::static_call_stack_: {
+    case Opcode::static_call_stack_eager_: {
         unsigned n = bc.immediate.call_args.nargs;
         rir::CallSite* cs = bc.callSite(srcCode);
         SEXP target = rir::Pool::get(*cs->target());
@@ -422,18 +422,18 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::movloc_:
     case Opcode::isobj_:
     case Opcode::check_missing_:
-    case Opcode::static_call_stack_lazy_:
-    case Opcode::call_stack_lazy_:
+    case Opcode::static_call_stack_promised_:
+    case Opcode::call_stack_promised_:
         assert(false && "Recompiling PIR not supported for now.");
 
     // Unsupported opcodes:
     case Opcode::ldlval_:
     case Opcode::asast_:
     case Opcode::missing_:
-    case Opcode::dispatch_stack_:
+    case Opcode::dispatch_stack_eager_:
     case Opcode::dispatch_:
     case Opcode::guard_env_:
-    case Opcode::call_stack_:
+    case Opcode::call_stack_eager_:
     case Opcode::beginloop_:
     case Opcode::endcontext_:
     case Opcode::ldddvar_:

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -167,8 +167,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
                 monomorphic,
                 [&](Closure* f) {
                     Value* expected = insert(new LdConst(monomorphic));
-                    Value* t = insert(new Eq(
-                        top(), expected, 0)); // here we don't have src ast...
+                    Value* t = insert(new Identical(top(), expected));
                     insert(new Branch(t));
                     BB* curBB = insert.bb;
 
@@ -340,6 +339,13 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
         BINOP(Neq, ne_);
 #undef BINOP
 
+    case Opcode::identical_: {
+        auto rhs = pop();
+        auto lhs = pop();
+        push(insert(new Identical(lhs, rhs)));
+        break;
+    }
+
 #define UNOP(Name, Op)                                                         \
     case Opcode::Op: {                                                         \
         v = pop();                                                             \
@@ -412,6 +418,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     // Opcodes that only come from PIR
     case Opcode::make_env_:
     case Opcode::get_env_:
+    case Opcode::caller_env_:
     case Opcode::set_env_:
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_noforce_super_:

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -199,19 +199,13 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::promise_: {
         unsigned promi = bc.immediate.i;
         rir::Code* promiseCode = srcFunction->codeAt(promi);
+        Value* val = pop();
         Promise* prom = insert.function->createProm();
         {
-            // What should I do with this?
             Builder promiseBuilder(insert.function, prom);
             if (!Rir2Pir(rir2pir).tryCompile(promiseCode, promiseBuilder))
                 return false;
         }
-        Value* val = Missing::instance();
-        if (Query::pure(prom)) {
-            rir2pir.translate(promiseCode, insert,
-                              [&](Value* success) { val = success; });
-        }
-        // TODO: Remove comment and check how to deal with
         push(insert(new MkArg(prom, val, env)));
         break;
     }
@@ -428,6 +422,8 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::movloc_:
     case Opcode::isobj_:
     case Opcode::check_missing_:
+    case Opcode::static_call_stack_lazy_:
+    case Opcode::call_stack_lazy_:
         assert(false && "Recompiling PIR not supported for now.");
 
     // Unsupported opcodes:

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -614,7 +614,7 @@ SEXP closureArgumentAdaptor(const CallContext& call, SEXP arglist,
 
 unsigned dispatch(const CallContext& call, DispatchTable* vt) {
     assert(vt->capacity() > 0);
-    if (vt->capacity() == 1 || !vt->slot(1))
+    if (vt->capacity() == 1 || !vt->available(1))
         return 0;
 
     // Try to dispatch to slot 1
@@ -1297,6 +1297,11 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
+        INSTRUCTION(caller_env_) {
+            ostack_push(ctx, callCtxt->callerEnv);
+            NEXT();
+        }
+
         INSTRUCTION(get_env_) {
             assert(env);
             ostack_push(ctx, getenv());
@@ -1965,6 +1970,13 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             DO_RELOP(==);
             ostack_popn(ctx, 2);
             ostack_push(ctx, res);
+            NEXT();
+        }
+
+        INSTRUCTION(identical_) {
+            SEXP rhs = ostack_pop(ctx);
+            SEXP lhs = ostack_pop(ctx);
+            ostack_push(ctx, rhs == lhs ? R_TrueValue : R_FalseValue);
             NEXT();
         }
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1558,7 +1558,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
-        INSTRUCTION(call_stack_) {
+        INSTRUCTION(call_stack_eager_) {
             auto lll = ostack_length(ctx);
             int ttt = R_PPStackTop;
 
@@ -1578,7 +1578,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
-        INSTRUCTION(static_call_stack_) {
+        INSTRUCTION(static_call_stack_eager_) {
             auto lll = ostack_length(ctx);
             int ttt = R_PPStackTop;
 
@@ -1599,7 +1599,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
-        INSTRUCTION(call_stack_lazy_) {
+        INSTRUCTION(call_stack_promised_) {
             auto lll = ostack_length(ctx);
             int ttt = R_PPStackTop;
 
@@ -1619,7 +1619,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
-        INSTRUCTION(static_call_stack_lazy_) {
+        INSTRUCTION(static_call_stack_promised_) {
             auto lll = ostack_length(ctx);
             int ttt = R_PPStackTop;
 
@@ -1660,7 +1660,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             NEXT();
         }
 
-        INSTRUCTION(dispatch_stack_) {
+        INSTRUCTION(dispatch_stack_eager_) {
             auto lll = ostack_length(ctx);
             int ttt = R_PPStackTop;
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -81,6 +81,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::nop_:
     case Opcode::make_env_:
     case Opcode::get_env_:
+    case Opcode::caller_env_:
     case Opcode::set_env_:
     case Opcode::extract1_1_:
     case Opcode::extract1_2_:
@@ -121,6 +122,7 @@ bool BC::operator==(const BC& other) const {
     case Opcode::le_:
     case Opcode::ge_:
     case Opcode::eq_:
+    case Opcode::identical_:
     case Opcode::ne_:
     case Opcode::seq_:
     case Opcode::colon_:
@@ -215,6 +217,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::nop_:
     case Opcode::make_env_:
     case Opcode::get_env_:
+    case Opcode::caller_env_:
     case Opcode::set_env_:
     case Opcode::extract1_1_:
     case Opcode::extract1_2_:
@@ -255,6 +258,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::le_:
     case Opcode::ge_:
     case Opcode::eq_:
+    case Opcode::identical_:
     case Opcode::ne_:
     case Opcode::seq_:
     case Opcode::colon_:
@@ -443,6 +447,7 @@ void BC::print(CallSite* cs) {
     case Opcode::nop_:
     case Opcode::make_env_:
     case Opcode::get_env_:
+    case Opcode::caller_env_:
     case Opcode::set_env_:
     case Opcode::force_:
     case Opcode::pop_:
@@ -474,6 +479,7 @@ void BC::print(CallSite* cs) {
     case Opcode::le_:
     case Opcode::ge_:
     case Opcode::eq_:
+    case Opcode::identical_:
     case Opcode::ne_:
     case Opcode::return_:
     case Opcode::isfun_:

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -34,11 +34,11 @@ bool BC::operator==(const BC& other) const {
 
     case Opcode::dispatch_:
     case Opcode::call_:
-    case Opcode::call_stack_:
-    case Opcode::call_stack_lazy_:
-    case Opcode::static_call_stack_:
-    case Opcode::static_call_stack_lazy_:
-    case Opcode::dispatch_stack_:
+    case Opcode::call_stack_eager_:
+    case Opcode::call_stack_promised_:
+    case Opcode::static_call_stack_eager_:
+    case Opcode::static_call_stack_promised_:
+    case Opcode::dispatch_stack_eager_:
         return immediate.call_args.call_id == other.immediate.call_args.call_id;
 
     case Opcode::guard_env_:
@@ -176,11 +176,11 @@ void BC::write(CodeStream& cs) const {
     // They have to be inserted by CodeStream::insertCall
     case Opcode::call_:
     case Opcode::dispatch_:
-    case Opcode::call_stack_:
-    case Opcode::call_stack_lazy_:
-    case Opcode::static_call_stack_:
-    case Opcode::static_call_stack_lazy_:
-    case Opcode::dispatch_stack_:
+    case Opcode::call_stack_eager_:
+    case Opcode::call_stack_promised_:
+    case Opcode::static_call_stack_eager_:
+    case Opcode::static_call_stack_promised_:
+    case Opcode::dispatch_stack_eager_:
         assert(false);
         break;
 
@@ -367,8 +367,8 @@ void BC::print(CallSite* cs) {
         }
         break;
     }
-    case Opcode::call_stack_:
-    case Opcode::call_stack_lazy_: {
+    case Opcode::call_stack_eager_:
+    case Opcode::call_stack_promised_: {
         NumArgsT nargs = immediate.call_args.nargs;
         Rprintf(" %d ", nargs);
         if (cs) {
@@ -379,8 +379,8 @@ void BC::print(CallSite* cs) {
         }
         break;
     }
-    case Opcode::static_call_stack_lazy_:
-    case Opcode::static_call_stack_: {
+    case Opcode::static_call_stack_promised_:
+    case Opcode::static_call_stack_eager_: {
         NumArgsT nargs = immediate.call_args.nargs;
         Rprintf(" %d : ", nargs);
         if (cs) {
@@ -392,7 +392,7 @@ void BC::print(CallSite* cs) {
         }
         break;
     }
-    case Opcode::dispatch_stack_: {
+    case Opcode::dispatch_stack_eager_: {
         if (cs) {
             Rprintf(" `%s` ", CHAR(PRINTNAME(Pool::get(*cs->selector()))));
             Rprintf(" %d ", cs->nargs);

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -35,7 +35,9 @@ bool BC::operator==(const BC& other) const {
     case Opcode::dispatch_:
     case Opcode::call_:
     case Opcode::call_stack_:
+    case Opcode::call_stack_lazy_:
     case Opcode::static_call_stack_:
+    case Opcode::static_call_stack_lazy_:
     case Opcode::dispatch_stack_:
         return immediate.call_args.call_id == other.immediate.call_args.call_id;
 
@@ -175,7 +177,9 @@ void BC::write(CodeStream& cs) const {
     case Opcode::call_:
     case Opcode::dispatch_:
     case Opcode::call_stack_:
+    case Opcode::call_stack_lazy_:
     case Opcode::static_call_stack_:
+    case Opcode::static_call_stack_lazy_:
     case Opcode::dispatch_stack_:
         assert(false);
         break;
@@ -363,7 +367,8 @@ void BC::print(CallSite* cs) {
         }
         break;
     }
-    case Opcode::call_stack_: {
+    case Opcode::call_stack_:
+    case Opcode::call_stack_lazy_: {
         NumArgsT nargs = immediate.call_args.nargs;
         Rprintf(" %d ", nargs);
         if (cs) {
@@ -374,6 +379,7 @@ void BC::print(CallSite* cs) {
         }
         break;
     }
+    case Opcode::static_call_stack_lazy_:
     case Opcode::static_call_stack_: {
         NumArgsT nargs = immediate.call_args.nargs;
         Rprintf(" %d : ", nargs);
@@ -399,7 +405,10 @@ void BC::print(CallSite* cs) {
     }
     case Opcode::push_:
         Rprintf(" %u # ", immediate.pool);
-        Rf_PrintValue(immediateConst());
+        if (immediateConst() == R_UnboundValue)
+            Rprintf(" -\n");
+        else
+            Rf_PrintValue(immediateConst());
         return;
     case Opcode::ldfun_:
     case Opcode::ldvar_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -20,6 +20,7 @@ class CodeStream;
 
 BC BC::nop() { return BC(Opcode::nop_); }
 BC BC::makeEnv() { return BC(Opcode::make_env_); }
+BC BC::callerEnv() { return BC(Opcode::caller_env_); }
 BC BC::getEnv() { return BC(Opcode::get_env_); }
 BC BC::setEnv() { return BC(Opcode::set_env_); }
 BC BC::ret() { return BC(Opcode::ret_); }
@@ -237,6 +238,7 @@ BC BC::gt() { return BC(Opcode::gt_); }
 BC BC::le() { return BC(Opcode::le_); }
 BC BC::ge() { return BC(Opcode::ge_); }
 BC BC::eq() { return BC(Opcode::eq_); }
+BC BC::identical() { return BC(Opcode::identical_); }
 BC BC::ne() { return BC(Opcode::ne_); }
 BC BC::invisible() { return BC(Opcode::invisible_); }
 BC BC::visible() { return BC(Opcode::visible_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -149,11 +149,12 @@ class BC {
     inline size_t popCount() {
         // return also is a leave
         assert(bc != Opcode::return_);
-        if (bc == Opcode::call_stack_ || bc == Opcode::call_stack_lazy_)
+        if (bc == Opcode::call_stack_eager_ ||
+            bc == Opcode::call_stack_promised_)
             return immediate.call_args.nargs + 1;
-        if (bc == Opcode::static_call_stack_ ||
-            bc == Opcode::static_call_stack_lazy_ ||
-            bc == Opcode::dispatch_stack_)
+        if (bc == Opcode::static_call_stack_eager_ ||
+            bc == Opcode::static_call_stack_promised_ ||
+            bc == Opcode::dispatch_stack_eager_)
             return immediate.call_args.nargs;
         return popCount(bc);
     }
@@ -182,10 +183,11 @@ class BC {
 
     bool isCallsite() const {
         return bc == Opcode::call_ || bc == Opcode::dispatch_ ||
-               bc == Opcode::call_stack_ || bc == Opcode::dispatch_stack_ ||
-               bc == Opcode::static_call_stack_ ||
-               bc == Opcode::call_stack_lazy_ ||
-               bc == Opcode::static_call_stack_lazy_;
+               bc == Opcode::call_stack_eager_ ||
+               bc == Opcode::dispatch_stack_eager_ ||
+               bc == Opcode::static_call_stack_eager_ ||
+               bc == Opcode::call_stack_promised_ ||
+               bc == Opcode::static_call_stack_promised_;
     }
 
     bool hasPromargs() const {
@@ -421,13 +423,13 @@ class BC {
         case Opcode::subassign2_:
             immediate.pool = *(PoolIdxT*)pc;
             break;
-        case Opcode::dispatch_stack_:
+        case Opcode::dispatch_stack_eager_:
         case Opcode::call_:
         case Opcode::dispatch_:
-        case Opcode::call_stack_:
-        case Opcode::call_stack_lazy_:
-        case Opcode::static_call_stack_:
-        case Opcode::static_call_stack_lazy_:
+        case Opcode::call_stack_eager_:
+        case Opcode::call_stack_promised_:
+        case Opcode::static_call_stack_eager_:
+        case Opcode::static_call_stack_promised_:
             immediate.call_args = *(CallArgs*)pc;
             break;
         case Opcode::guard_env_:

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -234,6 +234,7 @@ class BC {
     // to create new BC objects, which can be streamed to a CodeStream
     inline static BC nop();
     inline static BC makeEnv();
+    inline static BC callerEnv();
     inline static BC getEnv();
     inline static BC setEnv();
     inline static BC push(SEXP constant);
@@ -294,6 +295,7 @@ class BC {
     inline static BC le();
     inline static BC ge();
     inline static BC eq();
+    inline static BC identical();
     inline static BC ne();
     inline static BC seq();
     inline static BC colon();
@@ -460,6 +462,7 @@ class BC {
         case Opcode::nop_:
         case Opcode::make_env_:
         case Opcode::get_env_:
+        case Opcode::caller_env_:
         case Opcode::set_env_:
         case Opcode::for_seq_size_:
         case Opcode::extract1_1_:
@@ -499,6 +502,7 @@ class BC {
         case Opcode::le_:
         case Opcode::ge_:
         case Opcode::eq_:
+        case Opcode::identical_:
         case Opcode::ne_:
         case Opcode::return_:
         case Opcode::isfun_:

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -149,9 +149,11 @@ class BC {
     inline size_t popCount() {
         // return also is a leave
         assert(bc != Opcode::return_);
-        if (bc == Opcode::call_stack_)
+        if (bc == Opcode::call_stack_ || bc == Opcode::call_stack_lazy_)
             return immediate.call_args.nargs + 1;
-        if (bc == Opcode::static_call_stack_ || bc == Opcode::dispatch_stack_)
+        if (bc == Opcode::static_call_stack_ ||
+            bc == Opcode::static_call_stack_lazy_ ||
+            bc == Opcode::dispatch_stack_)
             return immediate.call_args.nargs;
         return popCount(bc);
     }
@@ -181,7 +183,9 @@ class BC {
     bool isCallsite() const {
         return bc == Opcode::call_ || bc == Opcode::dispatch_ ||
                bc == Opcode::call_stack_ || bc == Opcode::dispatch_stack_ ||
-               bc == Opcode::static_call_stack_;
+               bc == Opcode::static_call_stack_ ||
+               bc == Opcode::call_stack_lazy_ ||
+               bc == Opcode::static_call_stack_lazy_;
     }
 
     bool hasPromargs() const {
@@ -421,7 +425,9 @@ class BC {
         case Opcode::call_:
         case Opcode::dispatch_:
         case Opcode::call_stack_:
+        case Opcode::call_stack_lazy_:
         case Opcode::static_call_stack_:
+        case Opcode::static_call_stack_lazy_:
             immediate.call_args = *(CallArgs*)pc;
             break;
         case Opcode::guard_env_:

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -107,9 +107,9 @@ class CodeStream {
         cs->call = Pool::insert(call);
         cs->hasProfile = false;
         cs->hasNames = hasNames;
-        cs->hasSelector = (bc == Opcode::dispatch_stack_);
-        cs->hasTarget = (bc == Opcode::static_call_stack_ ||
-                         bc == Opcode::static_call_stack_lazy_);
+        cs->hasSelector = (bc == Opcode::dispatch_stack_eager_);
+        cs->hasTarget = (bc == Opcode::static_call_stack_eager_ ||
+                         bc == Opcode::static_call_stack_promised_);
         cs->hasImmediateArgs = false;
 
         cs->signature = signature;
@@ -120,11 +120,11 @@ class CodeStream {
             }
         }
 
-        if (bc == Opcode::dispatch_stack_) {
+        if (bc == Opcode::dispatch_stack_eager_) {
             assert(TYPEOF(targOrSelector) == SYMSXP);
             *cs->selector() = Pool::insert(targOrSelector);
-        } else if (bc == Opcode::static_call_stack_ ||
-                   bc == Opcode::static_call_stack_lazy_) {
+        } else if (bc == Opcode::static_call_stack_eager_ ||
+                   bc == Opcode::static_call_stack_promised_) {
             assert(TYPEOF(targOrSelector) == CLOSXP ||
                    TYPEOF(targOrSelector) == BUILTINSXP);
             *cs->target() = Pool::insert(targOrSelector);

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -108,7 +108,8 @@ class CodeStream {
         cs->hasProfile = false;
         cs->hasNames = hasNames;
         cs->hasSelector = (bc == Opcode::dispatch_stack_);
-        cs->hasTarget = (bc == Opcode::static_call_stack_);
+        cs->hasTarget = (bc == Opcode::static_call_stack_ ||
+                         bc == Opcode::static_call_stack_lazy_);
         cs->hasImmediateArgs = false;
 
         cs->signature = signature;
@@ -122,7 +123,8 @@ class CodeStream {
         if (bc == Opcode::dispatch_stack_) {
             assert(TYPEOF(targOrSelector) == SYMSXP);
             *cs->selector() = Pool::insert(targOrSelector);
-        } else if (bc == Opcode::static_call_stack_) {
+        } else if (bc == Opcode::static_call_stack_ ||
+                   bc == Opcode::static_call_stack_lazy_) {
             assert(TYPEOF(targOrSelector) == CLOSXP ||
                    TYPEOF(targOrSelector) == BUILTINSXP);
             *cs->target() = Pool::insert(targOrSelector);

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -198,8 +198,8 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
                 assert(TYPEOF(sym) == SYMSXP);
                 assert(strlen(CHAR(PRINTNAME(sym))));
             }
-            if (*cptr == Opcode::dispatch_stack_ ||
-                *cptr == Opcode::call_stack_) {
+            if (*cptr == Opcode::dispatch_stack_eager_ ||
+                *cptr == Opcode::call_stack_eager_) {
                 unsigned callIdx = *reinterpret_cast<ArgT*>(cptr + 1);
                 CallSite* cs = c->callSite(callIdx);
                 uint32_t nargs = *reinterpret_cast<ArgT*>(cptr + 5);
@@ -215,7 +215,7 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
                         }
                     }
                 }
-                if (*cptr == Opcode::dispatch_stack_) {
+                if (*cptr == Opcode::dispatch_stack_eager_) {
                     SEXP selector = cp_pool_at(ctx, *cs->selector());
                     assert(TYPEOF(selector) == SYMSXP);
                 }

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -47,7 +47,6 @@ class State {
 
     void advance() {
         BC bc = BC::advance(&pc);
-
         if (bc.bc == Opcode::return_)
             ostack = 0;
         else

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -471,7 +471,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
                         // Do dispatch using args from the stack
                         cs.insertStackCall(
-                            Opcode::dispatch_stack_, 3,
+                            Opcode::dispatch_stack_eager_, 3,
                             {R_NilValue, R_NilValue, symbol::value}, rewrite,
                             setter);
 
@@ -537,8 +537,8 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                     SEXP rewrite = Rf_shallow_duplicate(g);
                     ctx.preserve(rewrite);
                     SETCAR(CDR(rewrite), symbol::getterPlaceholder);
-                    cs.insertStackCall(Opcode::call_stack_, names.size(), names,
-                                       rewrite);
+                    cs.insertStackCall(Opcode::call_stack_eager_, names.size(),
+                                       names, rewrite);
                 }
                 Else(assert(false);)
             }
@@ -605,7 +605,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
             SET_TAG(value, symbol::value);
             SETCDR(a, value);
 
-            cs.insertStackCall(Opcode::call_stack_, names.size(), names,
+            cs.insertStackCall(Opcode::call_stack_eager_, names.size(), names,
                                rewrite);
         }
 
@@ -944,8 +944,8 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                 cs << BC::guardNamePrimitive(symbol::Internal);
                 for (auto a : args)
                     compileExpr(ctx, a);
-                cs.insertStackCall(Opcode::static_call_stack_, args.length(),
-                                   {}, inAst, internal);
+                cs.insertStackCall(Opcode::static_call_stack_eager_,
+                                   args.length(), {}, inAst, internal);
 
                 return true;
             }
@@ -1015,8 +1015,8 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                                 LCONS(symbol::getterPlaceholder, R_NilValue));
 
                 cs << objBranch << BC::swap();
-                cs.insertStackCall(Opcode::dispatch_stack_, 2, {}, extractCall,
-                                   symbol::DoubleBracket);
+                cs.insertStackCall(Opcode::dispatch_stack_eager_, 2, {},
+                                   extractCall, symbol::DoubleBracket);
 
                 cs << contBranch;
 
@@ -1024,7 +1024,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                 SEXP rewritten = LCONS(args[1],
                         LCONS(symbol::getterPlaceholder, R_NilValue));
 
-                cs.insertStackCall(Opcode::call_stack_, 1, {}, rewritten);
+                cs.insertStackCall(Opcode::call_stack_eager_, 1, {}, rewritten);
 
                 // store result
                 cs << BC::pick(3)
@@ -1065,8 +1065,8 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
 
         for (auto a : args)
             compileExpr(ctx, a);
-        cs.insertStackCall(Opcode::static_call_stack_, args.length(), {}, ast,
-                           builtin);
+        cs.insertStackCall(Opcode::static_call_stack_eager_, args.length(), {},
+                           ast, builtin);
 
         return true;
     }
@@ -1153,7 +1153,8 @@ bool compileWithGuess(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         signature->pushArgument({true, TYPEOF(a)});
     }
 
-    cs.insertStackCall(Opcode::static_call_stack_, args.length(), {}, ast, cls, signature);
+    cs.insertStackCall(Opcode::static_call_stack_eager_, args.length(), {}, ast,
+                       cls, signature);
 
     return true;
 }

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -528,7 +528,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                         names.push_back(arg.tag());
                         if (TYPEOF(*arg) == LANGSXP || TYPEOF(*arg) == SYMSXP) {
                             auto p = compilePromise(ctx, *arg);
-                            cs << BC::promise(p);
+                            cs << BC::push(R_UnboundValue) << BC::promise(p);
                         } else {
                             compileExpr(ctx, *arg);
                         }
@@ -581,7 +581,7 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
                 names.push_back(arg.tag());
                 if (TYPEOF(*arg) == LANGSXP || TYPEOF(*arg) == SYMSXP) {
                     auto p = compilePromise(ctx, *arg);
-                    cs << BC::promise(p);
+                    cs << BC::push(R_UnboundValue) << BC::promise(p);
                 } else {
                     compileExpr(ctx, *arg);
                 }

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -20,6 +20,11 @@ DEF_INSTR(nop_, 0, 0, 0, 1)
 DEF_INSTR(make_env_, 0, 1, 1, 1)
 
 /**
+ * caller_env_:: push caller env to tos
+ */
+DEF_INSTR(caller_env_, 0, 0, 1, 1)
+
+/**
  * get_env_:: push current env to tos
  */
 DEF_INSTR(get_env_, 0, 0, 1, 1)
@@ -234,6 +239,8 @@ DEF_INSTR(le_, 0, 2, 1, 0)
 DEF_INSTR(ge_, 0, 2, 1, 0)
 DEF_INSTR(eq_, 0, 2, 1, 0)
 DEF_INSTR(ne_, 0, 2, 1, 0)
+
+DEF_INSTR(identical_, 0, 2, 1, 0)
 
 /**
  * not_:: unary negation operator !

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -111,10 +111,23 @@ DEF_INSTR(movloc_, 2, 0, 0, 1)
 DEF_INSTR(call_, 2, 1, 1, 0)
 
 /**
- * call_stack_:: Like call_, but expects arguments on the stack
+ * call_stack_lazy_:: Like call_, but expects promised arguments on the stack
+ *               on top of the callee.
+ */
+DEF_INSTR(call_stack_lazy_, 2, -1, 1, 0)
+
+/**
+ * call_stack_:: Like call_, but expects eager arguments on the stack
  *               on top of the callee.
  */
 DEF_INSTR(call_stack_, 2, -1, 1, 0)
+
+/**
+ * static_call_stack_lazy_:: Like call_stack_, but the callee is known
+ * statically and accessed through the callsite (immediate arg), not on the
+ * stack.
+ */
+DEF_INSTR(static_call_stack_lazy_, 2, -1, 1, 0)
 
 /**
  * static_call_stack_:: Like call_stack_, but the callee is known statically
@@ -152,7 +165,7 @@ DEF_INSTR(isfun_, 0, 1, 1, 1)
  * promise_:: take immediate CP index of Code, create promise & push on object
  * stack
  */
-DEF_INSTR(promise_, 1, 0, 1, 1)
+DEF_INSTR(promise_, 1, 1, 1, 1)
 
 /**
  * force_:: pop from objet stack, evaluate, push promise's value

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -111,30 +111,29 @@ DEF_INSTR(movloc_, 2, 0, 0, 1)
 DEF_INSTR(call_, 2, 1, 1, 0)
 
 /**
- * call_stack_lazy_:: Like call_, but expects promised arguments on the stack
- *               on top of the callee.
+ * call_stack_promised_:: Like call_, but expects promised arguments on the
+ * stack on top of the callee.
  */
-DEF_INSTR(call_stack_lazy_, 2, -1, 1, 0)
+DEF_INSTR(call_stack_promised_, 2, -1, 1, 0)
 
 /**
- * call_stack_:: Like call_, but expects eager arguments on the stack
+ * call_stack_eager_:: Like call_, but expects eager arguments on the stack
  *               on top of the callee.
  */
-DEF_INSTR(call_stack_, 2, -1, 1, 0)
+DEF_INSTR(call_stack_eager_, 2, -1, 1, 0)
 
 /**
- * static_call_stack_lazy_:: Like call_stack_, but the callee is known
+ * static_call_stack_promised_:: Like static_call_stack_, but expects promised
+ *                           arguments on the stack.
+ */
+DEF_INSTR(static_call_stack_promised_, 2, -1, 1, 0)
+
+/**
+ * static_call_stack_eager_:: Like call_stack_, but the callee is known
  * statically and accessed through the callsite (immediate arg), not on the
  * stack.
  */
-DEF_INSTR(static_call_stack_lazy_, 2, -1, 1, 0)
-
-/**
- * static_call_stack_:: Like call_stack_, but the callee is known statically
- *                      and accessed through the callsite (immediate arg),
- *                      not on the stack.
- */
-DEF_INSTR(static_call_stack_, 2, -1, 1, 0)
+DEF_INSTR(static_call_stack_eager_, 2, -1, 1, 0)
 
 /**
  * dispatch_:: Similar to call_, but also looks for the callee (the selector
@@ -144,11 +143,11 @@ DEF_INSTR(static_call_stack_, 2, -1, 1, 0)
 DEF_INSTR(dispatch_, 2, 1, 1, 0)
 
 /**
- * dispatch_stack_:: Similar to dispatch_, but expects the receiver and
+ * dispatch_stack_eager_:: Similar to dispatch_, but expects the receiver and
  *                   all other args on the stack.
  *                   Note: nargs includes the receiver!
  */
-DEF_INSTR(dispatch_stack_, 2, -1, 1, 0)
+DEF_INSTR(dispatch_stack_eager_, 2, -1, 1, 0)
 
 /**
  * close_:: pop body and argument list, create closure, and push on object stack

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -36,12 +36,12 @@ struct DispatchTable {
         return d->info.magic == DISPATCH_TABLE_MAGIC ? d : nullptr;
     }
 
-    Function* at(size_t i) { return Function::unpack(entry[i]); }
-
-    SEXP slot(size_t i) {
-        assert(i < capacity() && "invalid dispatch table slot access");
+    bool available(size_t i) {
+        assert(i < capacity());
         return entry[i];
     }
+
+    Function* at(size_t i) { return Function::unpack(entry[i]); }
 
     void put(size_t i, Function* f) {
         assert(i < capacity());


### PR DESCRIPTION
For every piece of code we compile, assert that it can be successfully
compiled to pir and back to rir. The result is thrown away.

For this change to work a couple of bugs are fixed:

1.
promises can be recursive. We can refer to a promise in a promise.
Therefore it is not possible to compile promises in a fixed order.
We need to compile them on demand.

(Recursive dependencies should not exist)

2.
Support for environment arguments was not very robust. This patch
simplifies the code by abstracting the handling of arguments somewhat.

Before every pir instruction, we always load all arguments; after every
pir instruction we always store the result.

The special cases are:

* Some instructions want the argument implicitly. If an instruction
  takes an environment and does not consume it explicitly, then
  there is a preamble that loads the env and issues a setEnv.

* ~~MkArg is currently a bit of a hack, and it still is in this patch:
  either, we have an eager arg, then the result of mkarg is that
  eager arg. Otherwise it does not have a result.
  Then the call is responsible for consuming all the eager args.~~

The implicit environment loading gets very annoying, if the environment
is not the TOS. Therefore this patch changes the order of vararg
instructions, such that (as in the fixed argument length case), the
environment always comes last.

This allows us to evaluate the arguments in the pir-order, when
translating back to rir; and we always find the env to be tos,
therefore to consume it, we just issue a set_env_

3.
Our guard function was using `==` to compare closure values. That
fails for primitives. Add a new `identical_` bytecode that does
pointer equality.

4.
Currently we don't have deoptimization supprt. We'll need to add
it soon. This patch just aborts instead of deopting.