### PR TITLE
unify calls and callvalues

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -79,13 +79,8 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
         }
     } else if (CallInstruction::CastCall(i) && depth < maxDepth) {
         auto calli = CallInstruction::CastCall(i);
-        if (Call::Cast(i) || CallValues::Cast(i)) {
-            Value* trg = nullptr;
-            if (Call::Cast(i))
-                trg = Call::Cast(i)->cls();
-            else if (CallValues::Cast(i))
-                trg = CallValues::Cast(i)->cls();
-            if (trg) {
+        if (auto call = Call::Cast(i)) {
+            if (auto trg = call->cls()) {
                 MkFunCls* cls = envs.findClosure(i->env(), trg);
                 if (cls != AbstractREnvironment::UnknownClosure) {
                     if (cls->fun->argNames.size() == calli->nCallArgs()) {
@@ -98,12 +93,8 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
                     }
                 }
             }
-        } else {
-            Closure* trg = nullptr;
-            if (StaticCall::Cast(i))
-                trg = StaticCall::Cast(i)->cls();
-            else if (StaticCallValues::Cast(i))
-                trg = StaticCallValues::Cast(i)->cls();
+        } else if (auto call = StaticCall::Cast(i)) {
+            auto trg = call->cls();
             if (trg && trg->argNames.size() == calli->nCallArgs()) {
                 TheScopeAnalysis nextFun(trg, trg->argNames, trg->closureEnv(),
                                          trg->entry, envs, depth + 1);

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -23,60 +23,6 @@ class TheCleanup {
             while (ip != bb->end()) {
                 Instruction* i = *ip;
                 auto next = ip + 1;
-
-                // Convert lazy calls to eager calls, if all args are eager.
-                {
-                    auto call = Call::Cast(i);
-                    if (call) {
-                        bool allEager = true;
-                        std::vector<Value*> args;
-                        call->eachCallArg([&](Value* v) {
-                            auto arg = MkArg::Cast(v);
-                            if (arg && arg->eagerArg() == Missing::instance())
-                                allEager = false;
-                            if (allEager)
-                                args.push_back(arg->eagerArg());
-                        });
-                        if (allEager) {
-                            auto eagerCall = new CallValues(
-                                call->env(), call->cls(), args, call->srcIdx);
-                            call->replaceUsesWith(eagerCall);
-                            bb->replace(ip, eagerCall);
-                        }
-                    }
-                }
-
-                {
-                    auto call = StaticCall::Cast(i);
-                    if (call) {
-                        bool allEager = true;
-                        std::vector<Value*> args;
-                        call->eachCallArg([&](Value* v) {
-                            auto arg = MkArg::Cast(v);
-                            if (arg && arg->eagerArg() == Missing::instance())
-                                allEager = false;
-                            if (allEager)
-                                args.push_back(arg->eagerArg());
-                        });
-                        if (allEager) {
-                            auto eagerCall = new StaticCallValues(
-                                call->env(), call->cls(), args, call->srcIdx,
-                                call->origin());
-                            call->replaceUsesWith(eagerCall);
-                            bb->replace(ip, eagerCall);
-                        }
-                    }
-                }
-
-                ip = next;
-            }
-        });
-
-        Visitor::run(function->entry, [&](BB* bb) {
-            auto ip = bb->begin();
-            while (ip != bb->end()) {
-                Instruction* i = *ip;
-                auto next = ip + 1;
                 Force* force = Force::Cast(i);
                 ChkClosure* chkcls = ChkClosure::Cast(i);
                 ChkMissing* missing = ChkMissing::Cast(i);

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -40,19 +40,7 @@ class TheInliner {
                         continue;
                     assert(cls->fun->closureEnv() == Env::notClosed());
                     staticEnv = cls->env();
-                } else if (auto call = CallValues::Cast(*it)) {
-                    auto cls = MkFunCls::Cast(call->cls());
-                    if (!cls)
-                        continue;
-                    inlinee = cls->fun;
-                    if (inlinee->argNames.size() != call->nCallArgs())
-                        continue;
-                    assert(cls->fun->closureEnv() == Env::notClosed());
-                    staticEnv = cls->env();
                 } else if (auto call = StaticCall::Cast(*it)) {
-                    inlinee = call->cls();
-                    staticEnv = inlinee->closureEnv();
-                } else if (auto call = StaticCallValues::Cast(*it)) {
                     inlinee = call->cls();
                     staticEnv = inlinee->closureEnv();
                 } else {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -286,13 +286,6 @@ void MkFunCls::printArgs(std::ostream& out) {
     Instruction::printArgs(out);
 }
 
-void StaticCallValues::printArgs(std::ostream& out) {
-    out << *cls_;
-    if (nargs() > 0)
-        out << ", ";
-    Instruction::printArgs(out);
-}
-
 void StaticCall::printArgs(std::ostream& out) {
     out << *cls_;
     if (nargs() > 0)
@@ -306,10 +299,6 @@ CallInstruction* CallInstruction::CastCall(Value* v) {
         return Call::Cast(v);
     case Tag::StaticCall:
         return StaticCall::Cast(v);
-    case Tag::CallValues:
-        return CallValues::Cast(v);
-    case Tag::StaticCallValues:
-        return StaticCallValues::Cast(v);
     case Tag::CallBuiltin:
         return CallBuiltin::Cast(v);
     case Tag::CallSafeBuiltin:

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -816,7 +816,7 @@ class ACallInstructionImplementation(Call, Effect::Any, EnvAccess::Leak, true) {
         : CallInstructionImplementation(PirType::valOrLazy(), e) {
         pushArg(fun, RType::closure);
         for (unsigned i = 0; i < args.size(); ++i)
-            pushArg(args[i], RType::prom);
+            pushArg(args[i], PirType::val());
         srcIdx = src;
     }
 };
@@ -837,49 +837,7 @@ class ACallInstructionImplementation(StaticCall, Effect::Any, EnvAccess::Leak,
         : CallInstructionImplementation(PirType::valOrLazy(), e), cls_(cls),
           origin_(origin) {
         for (unsigned i = 0; i < args.size(); ++i)
-            pushArg(args[i], RType::prom);
-    }
-
-    void printArgs(std::ostream&) override;
-};
-
-// Call instruction for eager calls. Closure is
-// passed as first arg.
-class ACallInstructionImplementation(CallValues, Effect::Any, EnvAccess::Leak,
-                                     true) {
-  public:
-    constexpr static size_t clsIdx = 0;
-
-    Value* cls() { return arg(clsIdx).val(); }
-
-    CallValues(Value * e, Value * cls, const std::vector<Value*>& args,
-               unsigned src)
-        : CallInstructionImplementation(PirType::valOrLazy(), e) {
-        pushArg(cls, RType::closure);
-        for (unsigned i = 0; i < args.size(); ++i)
             pushArg(args[i], PirType::val());
-        srcIdx = src;
-    }
-};
-
-// Call instruction for eager, staticatlly resolved calls. Closure is
-// specified as `cls_`, args passed as values.
-class ACallInstructionImplementation(StaticCallValues, Effect::Any,
-                                     EnvAccess::Leak, false) {
-    Closure* cls_;
-    SEXP origin_;
-
-  public:
-    Closure* cls() { return cls_; }
-    SEXP origin() { return origin_; }
-
-    StaticCallValues(Value * e, Closure * cls, const std::vector<Value*>& args,
-                     unsigned src, SEXP origin)
-        : CallInstructionImplementation(PirType::valOrLazy(), e), cls_(cls),
-          origin_(origin) {
-        for (unsigned i = 0; i < args.size(); ++i)
-            pushArg(args[i], PirType::val());
-        srcIdx = src;
     }
 
     void printArgs(std::ostream&) override;

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -25,8 +25,6 @@
     V(ChkClosure)                                                              \
     V(Call)                                                                    \
     V(StaticCall)                                                              \
-    V(StaticCallValues)                                                        \
-    V(CallValues)                                                              \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
     V(MkEnv)                                                                   \

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -932,20 +932,6 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                                    Pool::get(call->srcIdx), call->origin());
                 break;
             }
-            case Tag::CallValues: {
-                auto call = CallValues::Cast(instr);
-                cs.insertStackCall(Opcode::call_values_, call->nCallArgs(), {},
-                                   Pool::get(call->srcIdx));
-                break;
-            }
-            case Tag::StaticCallValues: {
-                auto call = StaticCallValues::Cast(instr);
-                compiler.compile(call->cls(), call->origin());
-                cs.insertStackCall(Opcode::static_call_values_,
-                                   call->nCallArgs(), {},
-                                   Pool::get(call->srcIdx), call->origin());
-                break;
-            }
             case Tag::CallBuiltin: {
                 auto blt = CallBuiltin::Cast(instr);
                 cs.insertStackCall(Opcode::static_call_values_,

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -210,7 +210,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
         break;
     }
 
-    case Opcode::static_call_values_: {
+    case Opcode::static_call_: {
         unsigned n = bc.immediate.call_args.nargs;
         rir::CallSite* cs = bc.callSite(srcCode);
         SEXP target = rir::Pool::get(*cs->target());
@@ -239,8 +239,8 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
             rir2pir.compiler.compileClosure(
                 target,
                 [&](Closure* f) {
-                    push(insert(
-                        new StaticCallValues(env, f, args, cs->call, target)));
+                    push(
+                        insert(new StaticCall(env, f, args, cs->call, target)));
                 },
                 [&]() { failed = true; });
             if (failed)
@@ -422,7 +422,6 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::movloc_:
     case Opcode::isobj_:
     case Opcode::check_missing_:
-    case Opcode::static_call_:
     case Opcode::call_:
         assert(false && "Recompiling PIR not supported for now.");
 


### PR DESCRIPTION
tests fail because rir still uses the removed opcodes