### PR TITLE
Some docs and a script for Travis debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ benchmarks/
 *.dylib
 .R_HOME
 .vscode/
+.travis_token

--- a/README.md
+++ b/README.md
@@ -104,3 +104,35 @@ Or use `make setup`
 [performance](http://ginger.ele.fit.cvut.cz/~oli/r-we-fast/)
 
 ![travis](https://api.travis-ci.org/reactorlabs/rir.svg?branch=master) ([travis](https://travis-ci.org/reactorlabs/rir))
+
+### Debugging a Travis build
+
+Debug mode has been enabled for our repository. To simplify the process, we have
+a script `tools/travis-debug.sh`.
+
+To set up, go to your [Travis-CI.org profile](https://travis-ci.org/profile)
+(note travis-ci.org, NOT travis-ci.com) and copy your API token. Paste it in
+a file `.travis_token` in the repository root.
+
+To use the debug script, first find the job you want to debug, e.g.:
+https://travis-ci.org/reactorlabs/rir/jobs/<job id>
+
+Now you can run `tools/travis-debug.sh <job id>` which will POST to the API
+endpoint and restart the build. Then you can go back to the job on the Travis
+website and use the SSH command to access the machine.
+
+The debug VM will be in a state before the `before_install` phase runs. You will
+have to manually run the build phases:
+
+```
+travis_run_before_install
+travis_run_install
+travis_run_before_script
+travis_run_script
+travis_run_after_success
+travis_run_after_failure
+travis_run_after_script
+```
+
+For more information, see:
+https://docs.travis-ci.com/user/running-build-in-debug-mode/

--- a/tools/travis-debug.sh
+++ b/tools/travis-debug.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+REPO="reactorlabs/rir"
+
+SCRIPTPATH=`cd $(dirname "$0") && pwd`
+if [ ! -d $SCRIPTPATH ]; then
+    echo "Could not determine absolute dir of $0"
+    echo "Maybe accessed with symlink"
+fi
+
+TOKENPATH=$SCRIPTPATH/../.travis_token
+
+if [ ! -f $TOKENPATH ]; then
+    echo "Please set your Travis API token"
+    echo "Go to https://travis-ci.org/profile and copy the API token to the file '.travis_token' in the repository root."
+    exit 1
+fi
+
+TOKEN=`cat $TOKENPATH`
+
+if [ $# -ne 1 ]; then
+    echo "Initiates a Travis debug build for the given job id"
+    echo
+    echo "Make sure your Travis API token has been set."
+    echo "Go to https://travis-ci.org/profile and copy the API token to the file '.travis_token' in the repository root."
+    echo "The <job id> will be in the URL: https://travis-ci.org/$REPO/jobs/<job id>"
+    echo "(Note: <job id> is not the same as build id!)"
+    echo
+    echo "usage: $0 <job id>"
+    exit 1
+fi
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $TOKEN" \
+  -d "{\"quiet\": true}" \
+  https://api.travis-ci.org/job/$1/debug
+echo ""
+
+echo "If the response has no error, the job has been restarted in debug mode."
+echo "Go to https://travis-ci.org/$REPO/jobs/$1 to get the SSH command"
+echo "For more information, see https://docs.travis-ci.com/user/running-build-in-debug-mode/"


### PR DESCRIPTION
We have [debug mode](https://docs.travis-ci.com/user/running-build-in-debug-mode/) set up, but it's a pain to grab the proper curl invocation, and then you use the wrong URL (travis-ci.org, don't use travis-ci.com) or the wrong API token, and then get very confused.

Hopefully this script should make it a lot easier. I also added some docs that should help.