### PR TITLE
fix tools/R for multiple builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ MARK_AS_ADVANCED(
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_bin_create")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/tests"           "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/tests $@")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/R"               "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/R $@")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/Rscript"         "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/Rscript $@")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/gnur-make"       "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/gnur-make $@")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/gnur-make-tests" "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/gnur-make-tests $@")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,18 @@ MARK_AS_ADVANCED(
     CMAKE_CXX_FLAGS_SANITIZE
     CMAKE_C_FLAGS_SANITIZE)
 
+
+# Create proxy scripts for the scripts in /tools
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_bin_create")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/tests"           "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/tests $@")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/R"               "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/R $@")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/gnur-make"       "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/gnur-make $@")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/gnur-make-tests" "#!/bin/sh\n${CMAKE_SOURCE_DIR}/tools/gnur-make-tests $@")
+
+file(GLOB BIN_IN "${CMAKE_CURRENT_BINARY_DIR}/_bin_create/*")
+file(INSTALL ${BIN_IN} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin" FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE)
+file(GLOB BIN "${CMAKE_CURRENT_BINARY_DIR}/bin/*")
+
 if(NOT DEFINED NO_LOCAL_CONFIG)
     #include any local configuration, overriding the default values above
     include(${CMAKE_SOURCE_DIR}/local/cmake.cmake OPTIONAL)
@@ -70,36 +82,8 @@ file(GLOB_RECURSE SRC "rir/src/*.cpp" "rir/src/*.c" "rir/*/*.cpp" "rir/src/*.h" 
 add_library(${PROJECT_NAME} SHARED ${SRC})
 add_dependencies(${PROJECT_NAME} setup-build-dir)
 
-set(PACKAGE_NAME "rir_0.1.tar.gz")
-add_custom_target(rpkg
-    COMMAND ${R_COMMAND} CMD build rir WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-add_custom_target(rpkg_check
-    DEPENDS rpkg
-    COMMAND ${R_COMMAND} CMD check ${PACKAGE_NAME} --no-manual --no-vignettes
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-add_custom_target(rpkg_install
-    DEPENDS rpkg
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${R_LIBRARY_TREE} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMAND ${R_COMMAND} CMD INSTALL -l ${R_LIBRARY_TREE} ${PACKAGE_NAME} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-
-file(GLOB_RECURSE BENCHMARKS "benchmarks/*.R" "benchmarks/*.r")
-
-add_custom_target(benchmarks SOURCES ${BENCHMARKS})
-
-# dummy target so that IDEs show the local folder in solution explorers. The local
-# folder is ignored by git and can be used for local scripts and stuff
-file(GLOB SCRIPTS "local/*.sh")
-add_custom_target(scripts SOURCES ${SCRIPTS})
-
 # dummy target so that IDEs show the tools folder in solution explorers
-file(GLOB TOOLS "tools/*.*")
-add_custom_target(tools SOURCES ${TOOLS})
+add_custom_target(tools SOURCES ${BIN})
 
 if(APPLE)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-L${R_HOME}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ add_custom_target(default-gnur
     COMMAND cd ${CMAKE_SOURCE_DIR}/external/custom-r && make -j 8
 )
 
+add_custom_target(vanilla-gnur
+    DEPENDS dependencies
+    COMMAND cd ${CMAKE_SOURCE_DIR}/external/vanilla-r && make -j 8
+)
+
 add_custom_target(setup
     DEPENDS dependencies
     DEPENDS default-gnur

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
     git clone https://github.com/reactorlabs/rir
     cd rir
-    cmake . -DCMAKE_BUILD_TYPE=debug
+    cmake -DCMAKE_BUILD_TYPE=debug .
     # Fetch and build dependencies. This will build gnur from source, which
     # takes a while. Note that on Mac OSX, you will need to install a fortran
     # compiler (eg. brew install gcc). 
@@ -15,23 +15,23 @@
 
 To run the basic test, just execute
 
-    tools/tests
+    bin/tests
 
 To run tests from gnur with rir enabled as a jit:
 
-    tools/gnur-make check-devel
+    bin/gnur-make check-devel
 
 ## Playing with RIR
 
 To run R with RIR use
 
-    tools/R
+    bin/R
 
 This loads a normal R environment with RIR replacing the R bytecode compiler
 and interpreter. If you want to automatically compile functions when they
 are executed use
 
-    R_ENABLE_JIT=2 tools/R
+    R_ENABLE_JIT=2 bin/R
 
 Functions compiled to RIR can be inspected using `rir.disassemble`.
 
@@ -41,6 +41,25 @@ To make changes to this repository please open a pull request. Ask somebody to
 review your changes and make sure travis is green.
 
 Caveat: we use submodules. If you are in the habit of blindly `git commit .` you are up for surprises. Please make sure that you do not by accident commit an updated submodule reference for external/custom-r.
+
+### Off-Tree builds
+
+You can have multiple builds at the same time.
+If you want to use that feature, you need to *not* run cmake in the main directory.
+Instead do this:
+
+     git clone https://github.com/reactorlabs/rir
+     cd rir
+     mkdir -p build/debug build/release
+     cd build/debug
+     cmake -DCMAKE_BUILD_TYPE=debug ../..
+     make setup && make
+     cd ../release
+     cmake -DCMAKE_BUILD_TYPE=release ../..
+
+### Building with ninja
+
+For faster build use ninja. To generate ninja files instead of makefiles add `-GNinja` to the cmake commands.
 
 ### Making changes to gnur
 
@@ -100,8 +119,6 @@ Fetch updated R:
 Or use `make setup`
 
 ## Build Status
-
-[performance](http://ginger.ele.fit.cvut.cz/~oli/r-we-fast/)
 
 ![travis](https://api.travis-ci.org/reactorlabs/rir.svg?branch=master) ([travis](https://travis-ci.org/reactorlabs/rir))
 

--- a/tools/R
+++ b/tools/R
@@ -2,19 +2,13 @@
 
 SCRIPTPATH=`cd $(dirname "$0") && pwd`
 
-ROOT_DIR="$SCRIPTPATH/.."
-
-R_HOME=`cat $ROOT_DIR/.R_HOME`
+R_HOME=`cat .R_HOME`
 CHK=$1
 LIBRARY_DIR=`pwd`
-PKG="$ROOT_DIR/rir/"
 
-export EXTRA_LOAD_SO=`ls $ROOT_DIR/librir.*`
+PKG="$SCRIPTPATH/../rir/"
+
+export EXTRA_LOAD_SO="`ls $LIBRARY_DIR/librir.*`"
 export EXTRA_LOAD_R="$PKG/R/rir.R"
 
-if [ "$1" = "-headless" ]
-then
-    $R_HOME/bin/Rscript "${@:2}"
-else
-    $R_HOME/bin/R "$@"
-fi
+$R_HOME/bin/R "$@"

--- a/tools/Rscript
+++ b/tools/Rscript
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+SCRIPTPATH=`cd $(dirname "$0") && pwd`
+
+R_HOME=`cat .R_HOME`
+CHK=$1
+LIBRARY_DIR=`pwd`
+
+PKG="$SCRIPTPATH/../rir/"
+
+export EXTRA_LOAD_SO="`ls $LIBRARY_DIR/librir.*`"
+export EXTRA_LOAD_R="$PKG/R/rir.R"
+
+$R_HOME/bin/Rscript "$@"


### PR DESCRIPTION
the idea is that the cmake will create a bin/R proxy script in every
build, that can be used. This avoids the neccessity for absolute paths
in tools/R

so instead of ${MAIN}/tools/xyz, you can now use ${BUILD}/bin/xyz