### PR TITLE
Fine grained debugging information

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -20,8 +20,8 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what, verbose = 0, dryRun = FALSE) {
-    .Call("pir_compile_", what, verbose, dryRun)
+pir.compile <- function(what, verbose = 0L, dryRun = FALSE) {
+    .Call("pir_compile", what, verbose, dryRun)
 }
 
 pir.tests <- function() {

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -20,8 +20,8 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what, verbose = FALSE, dryRun = FALSE) {
-    .Call("pir_compile", what, verbose, dryRun)
+pir.compile <- function(what, verbose = 0, dryRun = FALSE) {
+    .Call("pir_compile_", what, verbose, dryRun)
 }
 
 pir.tests <- function() {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -95,7 +95,7 @@ REXPORT SEXP rir_body(SEXP cls) {
     return f->container();
 }
 
-REXPORT SEXP pir_compile(SEXP what, unsigned int verbose, SEXP dryRun_) {
+REXPORT SEXP pir_compile(SEXP what, uint32_t verbose, SEXP dryRun_) {
     bool dryRun = false;
     if (dryRun_ && TYPEOF(dryRun_) == LGLSXP && Rf_length(dryRun_) > 0 &&
         LOGICAL(dryRun_)[0])
@@ -140,7 +140,7 @@ REXPORT SEXP pir_tests() {
 
 // startup ---------------------------------------------------------------------
 
-uint pir_verbose = (getenv("PIR_VERBOSE")) ? 
+uint32_t pir_verbose = (getenv("PIR_VERBOSE")) ? 
      std::stoul(getenv("PIR_VERBOSE"), nullptr, 0) : 0;
 
 SEXP pirOpt(SEXP fun) { return pir_compile(fun, pir_verbose, R_FalseValue); }

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -95,7 +95,7 @@ REXPORT SEXP rir_body(SEXP cls) {
     return f->container();
 }
 
-SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
+REXPORT SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
     bool dryRun = false;
     if (dryRun_ && TYPEOF(dryRun_) == LGLSXP && Rf_length(dryRun_) > 0 &&
         LOGICAL(dryRun_)[0])

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -95,7 +95,7 @@ REXPORT SEXP rir_body(SEXP cls) {
     return f->container();
 }
 
-REXPORT SEXP pir_compile(SEXP what, uint32_t verbose, SEXP dryRun_) {
+SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
     bool dryRun = false;
     if (dryRun_ && TYPEOF(dryRun_) == LGLSXP && Rf_length(dryRun_) > 0 &&
         LOGICAL(dryRun_)[0])
@@ -133,6 +133,10 @@ REXPORT SEXP pir_compile(SEXP what, uint32_t verbose, SEXP dryRun_) {
     return what;
 }
 
+REXPORT SEXP pir_compile(SEXP what, SEXP verbose, SEXP dryRun_) {
+    return pir_compile_(what, INTEGER(INTEGER(verbose))[0], dryRun_);
+}
+
 REXPORT SEXP pir_tests() {
     PirTests::run();
     return R_NilValue;
@@ -143,7 +147,7 @@ REXPORT SEXP pir_tests() {
 uint32_t pir_verbose = (getenv("PIR_VERBOSE")) ? 
      std::stoul(getenv("PIR_VERBOSE"), nullptr, 0) : 0;
 
-SEXP pirOpt(SEXP fun) { return pir_compile(fun, pir_verbose, R_FalseValue); }
+SEXP pirOpt(SEXP fun) { return pir_compile_(fun, pir_verbose, R_FalseValue); }
 
 bool startup() {
     auto pir = getenv("PIR_ENABLE");
@@ -156,8 +160,8 @@ bool startup() {
     } else if (pir && std::string(pir).compare("force_dryrun") == 0) {
         initializeRuntime(
             [](SEXP f, SEXP env) {
-                return pir_compile(rir_compile(f, env), pir_verbose,
-                                   R_TrueValue);
+                return pir_compile_(rir_compile(f, env), pir_verbose,
+                                    R_TrueValue);
             },
             [](SEXP f) { return f; });
     } else {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -143,16 +143,6 @@ REXPORT SEXP pir_tests() {
 uint pir_verbose = (getenv("PIR_VERBOSE")) ? 
      std::stoul(getenv("PIR_VERBOSE"), nullptr, 0) : 0;
 
-/********** VERBOSE BIT MODES ***********
-1: RIR Original version
-2: PIR Raw
-3: PIR Optimization phases
-4: PIR Inlining phases
-5: PIR Convert to CSSA
-6: PIR After liveness analysis phase
-7: RIR After stack allocation phase 
-8: RIR After passing through PIR*/
-
 SEXP pirOpt(SEXP fun) { return pir_compile(fun, pir_verbose, R_FalseValue); }
 
 bool startup() {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -134,7 +134,7 @@ REXPORT SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
 }
 
 REXPORT SEXP pir_compile(SEXP what, SEXP verbose, SEXP dryRun_) {
-    return pir_compile_(what, INTEGER(INTEGER(verbose))[0], dryRun_);
+    return pir_compile_(what, (uint32_t)INTEGER(INTEGER(verbose))[0], dryRun_);
 }
 
 REXPORT SEXP pir_tests() {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -140,7 +140,9 @@ REXPORT SEXP pir_tests() {
 
 // startup ---------------------------------------------------------------------
 
-uint pir_verbose = std::stoul(getenv("PIR_VERBOSE"), nullptr, 0);
+uint pir_verbose = (getenv("PIR_VERBOSE")) ? 
+     std::stoul(getenv("PIR_VERBOSE"), nullptr, 0) : 0;
+
 /********** VERBOSE BIT MODES ***********
 1: RIR Original version
 2: PIR Raw

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -95,7 +95,7 @@ REXPORT SEXP rir_body(SEXP cls) {
     return f->container();
 }
 
-REXPORT SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
+SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
     bool dryRun = false;
     if (dryRun_ && TYPEOF(dryRun_) == LGLSXP && Rf_length(dryRun_) > 0 &&
         LOGICAL(dryRun_)[0])
@@ -134,7 +134,9 @@ REXPORT SEXP pir_compile_(SEXP what, uint32_t verbose, SEXP dryRun_) {
 }
 
 REXPORT SEXP pir_compile(SEXP what, SEXP verbose, SEXP dryRun_) {
-    return pir_compile_(what, (uint32_t)INTEGER(INTEGER(verbose))[0], dryRun_);
+    if (TYPEOF(verbose) != INTSXP || Rf_length(verbose) < 1)
+        Rf_error("pir_compile expects an integer vector as second parameter");
+    return pir_compile_(what, (uint32_t)INTEGER(verbose)[0], dryRun_);
 }
 
 REXPORT SEXP pir_tests() {

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -2,6 +2,7 @@
 #define API_H_
 
 #include "R/r.h"
+#include <stdint.h>
 
 #define REXPORT extern "C"
 

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -8,6 +8,6 @@
 extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
-REXPORT SEXP pir_compile(SEXP, unsigned int, SEXP);
+REXPORT SEXP pir_compile(SEXP, uint32_t, SEXP);
 
 #endif // API_H_

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -8,6 +8,6 @@
 extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
-REXPORT SEXP pir_compile(SEXP, SEXP, SEXP);
+REXPORT SEXP pir_compile(SEXP, unsigned int, SEXP);
 
 #endif // API_H_

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -8,6 +8,7 @@
 extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
-REXPORT SEXP pir_compile(SEXP, uint32_t, SEXP);
+REXPORT SEXP pir_compile(SEXP, SEXP, SEXP);
+SEXP pir_compile_(SEXP, uint32_t, SEXP);
 
 #endif // API_H_

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -9,6 +9,6 @@ extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
 REXPORT SEXP pir_compile(SEXP, SEXP, SEXP);
-SEXP pir_compile_(SEXP, uint32_t, SEXP);
+REXPORT SEXP pir_compile_(SEXP, uint32_t, SEXP);
 
 #endif // API_H_

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -10,6 +10,6 @@ extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
 REXPORT SEXP pir_compile(SEXP, SEXP, SEXP);
-REXPORT SEXP pir_compile_(SEXP, uint32_t, SEXP);
+SEXP pir_compile_(SEXP, uint32_t, SEXP);
 
 #endif // API_H_

--- a/rir/src/compiler/pir/pir.h
+++ b/rir/src/compiler/pir/pir.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+// clang-format off
 const uint8_t PRINT_ORIGINAL_MASK   = 0x1;  // bit 1: RIR Original version
 const uint8_t PRINT_RAW_PIR_MASK    = 0x2;  // bit 2: PIR Raw
 const uint8_t PRINT_OPT_PHASES_MASK = 0x4;  // bit 3: PIR Optimization phases
@@ -11,7 +12,7 @@ const uint8_t PRINT_CSSA_MASK       = 0x10; // bit 5: PIR Convert to CSSA
 const uint8_t PRINT_LIVENESS_MASK   = 0x20; // bit 6: PIR After liveness analysis phase
 const uint8_t PRINT_STACK_MASK      = 0x40; // bit 7: RIR After stack allocation phase
 const uint8_t PRINT_FINAL_RIR_MASK  = 0x80; // bit 8: RIR After passing through PIR
-
+// clang-format on
 
 #include "type.h"
 // Forward declaration of PIR types. Use for headers.

--- a/rir/src/compiler/pir/pir.h
+++ b/rir/src/compiler/pir/pir.h
@@ -1,20 +1,19 @@
 #ifndef PIR_PIR_H
 #define PIR_PIR_H
 
-// clang-format off
-//********** VERBOSE BIT MASK ***********
-#define PRINT_ORIGINAL_MASK   0x1  // bit 1: RIR Original version
-#define PRINT_RAW_PIR_MASK    0x2  // bit 2: PIR Raw
-#define PRINT_OPT_PHASES_MASK 0x4  // bit 3: PIR Optimization phases
-#define PRINT_INLINIG_MASK    0x8  // bit 4: PIR Inlining phases
-#define PRINT_CSSA_MASK       0x10 // bit 5: PIR Convert to CSSA
-#define PRINT_LIVENESS_MASK   0x20 // bit 6: PIR After liveness analysis phase
-#define PRINT_STACK_MASK      0x40 // bit 7: RIR After stack allocation phase
-#define PRINT_FINAL_RIR_MASK  0x80 // bit 8: RIR After passing through PIR
+#include <stdint.h>
 
-// clang-format on
+const uint8_t PRINT_ORIGINAL_MASK   = 0x1;  // bit 1: RIR Original version
+const uint8_t PRINT_RAW_PIR_MASK    = 0x2;  // bit 2: PIR Raw
+const uint8_t PRINT_OPT_PHASES_MASK = 0x4;  // bit 3: PIR Optimization phases
+const uint8_t PRINT_INLINIG_MASK    = 0x8;  // bit 4: PIR Inlining phases
+const uint8_t PRINT_CSSA_MASK       = 0x10; // bit 5: PIR Convert to CSSA
+const uint8_t PRINT_LIVENESS_MASK   = 0x20; // bit 6: PIR After liveness analysis phase
+const uint8_t PRINT_STACK_MASK      = 0x40; // bit 7: RIR After stack allocation phase
+const uint8_t PRINT_FINAL_RIR_MASK  = 0x80; // bit 8: RIR After passing through PIR
+
+
 #include "type.h"
-
 // Forward declaration of PIR types. Use for headers.
 
 namespace rir {

--- a/rir/src/compiler/pir/pir.h
+++ b/rir/src/compiler/pir/pir.h
@@ -1,17 +1,18 @@
 #ifndef PIR_PIR_H
 #define PIR_PIR_H
 
+// clang-format off
 //********** VERBOSE BIT MASK ***********
-#define PRINT_ORIGINAL_MASK    0x1  //bit 1: RIR Original version
-#define PRINT_RAW_PIR_MASK     0x2  //bit 2: PIR Raw
-#define PRINT_OPT_PHASES_MASK  0x4  //bit 3: PIR Optimization phases
-#define PRINT_INLINIG_MASK     0x8  //bit 4: PIR Inlining phases
-#define PRINT_CSSA_MASK        0x10 //bit 5: PIR Convert to CSSA
-#define PRINT_LIVENESS_MASK    0x20 //bit 6: PIR After liveness analysis phase
-#define PRINT_STACK_MASK       0x40 //bit 7: RIR After stack allocation phase 
-#define PRINT_FINAL_RIR_MASK   0x80 //bit 8: RIR After passing through PIR
+#define PRINT_ORIGINAL_MASK   0x1  // bit 1: RIR Original version
+#define PRINT_RAW_PIR_MASK    0x2  // bit 2: PIR Raw
+#define PRINT_OPT_PHASES_MASK 0x4  // bit 3: PIR Optimization phases
+#define PRINT_INLINIG_MASK    0x8  // bit 4: PIR Inlining phases
+#define PRINT_CSSA_MASK       0x10 // bit 5: PIR Convert to CSSA
+#define PRINT_LIVENESS_MASK   0x20 // bit 6: PIR After liveness analysis phase
+#define PRINT_STACK_MASK      0x40 // bit 7: RIR After stack allocation phase
+#define PRINT_FINAL_RIR_MASK  0x80 // bit 8: RIR After passing through PIR
 
-
+// clang-format on
 #include "type.h"
 
 // Forward declaration of PIR types. Use for headers.

--- a/rir/src/compiler/pir/pir.h
+++ b/rir/src/compiler/pir/pir.h
@@ -1,6 +1,17 @@
 #ifndef PIR_PIR_H
 #define PIR_PIR_H
 
+//********** VERBOSE BIT MASK ***********
+#define PRINT_ORIGINAL_MASK    0x1  //bit 1: RIR Original version
+#define PRINT_RAW_PIR_MASK     0x2  //bit 2: PIR Raw
+#define PRINT_OPT_PHASES_MASK  0x4  //bit 3: PIR Optimization phases
+#define PRINT_INLINIG_MASK     0x8  //bit 4: PIR Inlining phases
+#define PRINT_CSSA_MASK        0x10 //bit 5: PIR Convert to CSSA
+#define PRINT_LIVENESS_MASK    0x20 //bit 6: PIR After liveness analysis phase
+#define PRINT_STACK_MASK       0x40 //bit 7: RIR After stack allocation phase 
+#define PRINT_FINAL_RIR_MASK   0x80 //bit 8: RIR After passing through PIR
+
+
 #include "type.h"
 
 // Forward declaration of PIR types. Use for headers.

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -275,7 +275,7 @@ bool testPir2Rir(std::string name, std::string fun, std::string args,
         rCall = createRWrapperCall(wrapper);
     }
 
-    pir_compile(rirFun, R_FalseValue, R_FalseValue);
+    pir_compile(rirFun, 0, R_FalseValue);
 
     auto after = p(Rf_eval(rCall, execEnv));
     if (verbose) {

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -275,7 +275,7 @@ bool testPir2Rir(std::string name, std::string fun, std::string args,
         rCall = createRWrapperCall(wrapper);
     }
 
-    pir_compile(rirFun, 0, R_FalseValue);
+    pir_compile_(rirFun, 0, R_FalseValue);
 
     auto after = p(Rf_eval(rCall, execEnv));
     if (verbose) {

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1102,7 +1102,11 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
 
     if (shouldPrintRIRAfterPIR()) {
         std::cout << "============= Final RIR Version ========\n";
-        fun->body()->print();
+        auto it = fun->begin();
+        while (it != fun->end()) {
+            (*it)->print();
+            ++it;
+        }
     }
 
     if (dryRun)

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1100,7 +1100,7 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
     Pir2Rir pir2rir(*this, cls);
     auto fun = pir2rir.finalize();
 
-    if (shouldPrintRIRAfterPIR()){
+    if (shouldPrintRIRAfterPIR()) {
         std::cout << "============= Final PIR Version ========\n";
         fun->body()->print();
     }

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -93,13 +93,13 @@ class SSAAllocator {
 
     SSAAllocator(Code* code, bool verbose)
         : cfg(code), dom(code), code(code), bbsSize(code->nextBBId) {
-        computeLiveness(verbose);
+        computeLiveness(verbose & 0X10000);
         computeStackAllocation();
         computeAllocation();
     }
 
     // Run backwards analysis to compute livenessintervals
-    void computeLiveness(bool verbose = false) {
+    void computeLiveness(bool verbose = 0) {
         // temp list of live out sets for every BB
         std::unordered_map<BB*, std::set<Value*>> liveAtEnd(bbsSize);
 
@@ -621,12 +621,12 @@ class Pir2Rir {
 size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
     toCSSA(code);
 
-    if (compiler.verbose)
+    if (compiler.shouldPrintCSSA())
         code->print(std::cout);
 
     SSAAllocator alloc(code, compiler.verbose);
 
-    if (compiler.verbose)
+    if (compiler.shouldPrintAllocations())
         alloc.print();
 
     alloc.verify();
@@ -1099,6 +1099,11 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
 
     Pir2Rir pir2rir(*this, cls);
     auto fun = pir2rir.finalize();
+
+    if (shouldPrintRIRAfterPIR()){
+        std::cout << "============= Final PIR Version ========\n";
+        fun->body()->print();
+    }
 
     if (dryRun)
         return;

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -93,7 +93,7 @@ class SSAAllocator {
 
     SSAAllocator(Code* code, bool verbose)
         : cfg(code), dom(code), code(code), bbsSize(code->nextBBId) {
-        computeLiveness(verbose & 0X10000);
+        computeLiveness(verbose & PRINT_LIVENESS_MASK);
         computeStackAllocation();
         computeAllocation();
     }

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1101,7 +1101,7 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
     auto fun = pir2rir.finalize();
 
     if (shouldPrintRIRAfterPIR()) {
-        std::cout << "============= Final PIR Version ========\n";
+        std::cout << "============= Final RIR Version ========\n";
         fun->body()->print();
     }
 

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -11,7 +11,7 @@ namespace pir {
 
 class Pir2RirCompiler {
   public:
-    uint verbose = 0;
+    uint32_t verbose = 0;
     bool dryRun = false;
 
     void compile(Closure* cls, SEXP origin);

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -10,11 +10,17 @@ namespace pir {
 
 class Pir2RirCompiler {
   public:
-    bool verbose = false;
+    uint verbose = 0;
     bool dryRun = false;
 
     void compile(Closure* cls, SEXP origin);
 
+    bool shouldPrintCSSA() { return verbose & 0X10000; }
+    bool shouldPrintAllocations() { return verbose & 0X100000; }
+    bool shouldPrintLiveness() { return verbose & 0X1000000; }
+    bool shouldPrintRIRAfterPIR() { return verbose & 0X10000000; }
+    bool isVerbose() { return verbose; }
+    
   private:
     std::unordered_set<Closure*> done;
 };

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../pir/pir.h"
 #include "../pir/module.h"
 #include "runtime/Function.h"
 
@@ -15,10 +16,10 @@ class Pir2RirCompiler {
 
     void compile(Closure* cls, SEXP origin);
 
-    bool shouldPrintCSSA() { return verbose & 0b10000; }
-    bool shouldPrintAllocations() { return verbose & 0b100000; }
-    bool shouldPrintLiveness() { return verbose & 0b1000000; }
-    bool shouldPrintRIRAfterPIR() { return verbose & 0b10000000; }
+    bool shouldPrintCSSA() { return verbose & PRINT_CSSA_MASK; }
+    bool shouldPrintAllocations() { return verbose & PRINT_LIVENESS_MASK; }
+    bool shouldPrintLiveness() { return verbose & PRINT_STACK_MASK; }
+    bool shouldPrintRIRAfterPIR() { return verbose & PRINT_FINAL_RIR_MASK; }
     bool isVerbose() { return verbose; }
 
   private:

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -20,7 +20,7 @@ class Pir2RirCompiler {
     bool shouldPrintLiveness() { return verbose & 0X1000000; }
     bool shouldPrintRIRAfterPIR() { return verbose & 0X10000000; }
     bool isVerbose() { return verbose; }
-    
+
   private:
     std::unordered_set<Closure*> done;
 };

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../pir/pir.h"
 #include "../pir/module.h"
+#include "../pir/pir.h"
 #include "runtime/Function.h"
 
 #include <unordered_set>

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -15,10 +15,10 @@ class Pir2RirCompiler {
 
     void compile(Closure* cls, SEXP origin);
 
-    bool shouldPrintCSSA() { return verbose & 0X10; }
-    bool shouldPrintAllocations() { return verbose & 0X20; }
-    bool shouldPrintLiveness() { return verbose & 0X40; }
-    bool shouldPrintRIRAfterPIR() { return verbose & 0X80; }
+    bool shouldPrintCSSA() { return verbose & 0b10000; }
+    bool shouldPrintAllocations() { return verbose & 0b100000; }
+    bool shouldPrintLiveness() { return verbose & 0b1000000; }
+    bool shouldPrintRIRAfterPIR() { return verbose & 0b10000000; }
     bool isVerbose() { return verbose; }
 
   private:

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -15,10 +15,10 @@ class Pir2RirCompiler {
 
     void compile(Closure* cls, SEXP origin);
 
-    bool shouldPrintCSSA() { return verbose & 0X10000; }
-    bool shouldPrintAllocations() { return verbose & 0X100000; }
-    bool shouldPrintLiveness() { return verbose & 0X1000000; }
-    bool shouldPrintRIRAfterPIR() { return verbose & 0X10000000; }
+    bool shouldPrintCSSA() { return verbose & 0X10; }
+    bool shouldPrintAllocations() { return verbose & 0X20; }
+    bool shouldPrintLiveness() { return verbose & 0X40; }
+    bool shouldPrintRIRAfterPIR() { return verbose & 0X80; }
     bool isVerbose() { return verbose; }
 
   private:

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -64,12 +64,15 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
             Builder builder(pirFunction, closureEnv);
             Rir2Pir rir2pir(*this, srcFunction);
             if (isVerbose()) {
-                std::cout << "\n\n**************************************************************\n";
-                std::cout << "*********** Start compiling:" << srcFunction << " **********\n";
-                std::cout << "**************************************************************\n";
+                std::cout << "\n\n*********************************************"
+                             "*****************\n";
+                std::cout << "*********** Start compiling:" << srcFunction
+                          << " **********\n";
+                std::cout << "*************************************************"
+                             "*************\n";
                 if (shouldPrintOriginalVersion()) {
                     std::cout << "=============== Original version:\n";
-                    srcFunction->body()->print();                    
+                    srcFunction->body()->print();
                 }
             }
 
@@ -85,15 +88,18 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                                   << srcFunction << "\n";
                     }
                     assert(false);
-                    std::cout << " ========= Finish compiling " << srcFunction << "\n\n";
+                    std::cout << " ========= Finish compiling " << srcFunction
+                              << "\n\n";
                     return false;
                 }
-                std::cout << " ========= Finish compiling " << srcFunction << "\n\n";
+                std::cout << " ========= Finish compiling " << srcFunction
+                          << "\n\n";
                 return true;
             }
             if (isVerbose()) {
                 std::cout << " Failed p2r compile " << srcFunction << "\n";
-                std::cout << " ========= Finish compiling " << srcFunction << "\n\n";
+                std::cout << " ========= Finish compiling " << srcFunction
+                          << "\n\n";
             }
             failed = true;
             return false;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -64,12 +64,11 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
             Builder builder(pirFunction, closureEnv);
             Rir2Pir rir2pir(*this, srcFunction);
             if (isVerbose()) {
-                std::cout << "\n\n*********************************************"
-                             "*****************\n";
-                std::cout << "*********** Start compiling:" << srcFunction
-                          << " **********\n";
-                std::cout << "*************************************************"
-                             "*************\n";
+                // clang-format off
+                std::cout << "\n\n**************************************************************\n";
+                std::cout << "*********** Start compiling:" << srcFunction << " **********\n";
+                std::cout << "**************************************************************\n";
+                // clang-format on
                 if (shouldPrintOriginalVersion()) {
                     std::cout << "=============== Original version:\n";
                     auto it = srcFunction->begin();

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -72,12 +72,16 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                              "*************\n";
                 if (shouldPrintOriginalVersion()) {
                     std::cout << "=============== Original version:\n";
-                    srcFunction->body()->print();
+                    auto it = srcFunction->begin();
+                    while (it != srcFunction->end()) {
+                        (*it)->print();
+                        ++it;
+                    }
                 }
             }
 
             if (rir2pir.tryCompile(srcFunction->body(), builder)) {
-                if (isVerbose()) {
+                if (shouldPrintCompiledVersion()) {
                     std::cout << " ========= Compiled to PIR Version:";
                     builder.function->print(std::cout);
                 }
@@ -86,14 +90,12 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                     if (isVerbose()) {
                         std::cout << " Failed verification after p2r compile "
                                   << srcFunction << "\n";
+                        std::cout << " ========= Finish compiling " << srcFunction
+                              << "\n\n";
                     }
                     assert(false);
-                    std::cout << " ========= Finish compiling " << srcFunction
-                              << "\n\n";
                     return false;
                 }
-                std::cout << " ========= Finish compiling " << srcFunction
-                          << "\n\n";
                 return true;
             }
             if (isVerbose()) {

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -1,9 +1,9 @@
 #ifndef RIR__PIR_COMPILER_H
 #define RIR__PIR_COMPILER_H
 
-#include "../pir/pir.h"
 #include "../pir/closure.h"
 #include "../pir/module.h"
+#include "../pir/pir.h"
 #include "../pir/value.h"
 #include "pir_translator.h"
 #include "runtime/Function.h"

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -26,14 +26,14 @@ class RirCompiler {
     }
 
     bool isVerbose() { return verbose; }
-    bool shouldPrintOriginalVersion() { return verbose & 0X1; }
-    bool shouldPrintCompiledVersion() { return verbose & 0X2; }
-    bool shouldPrintOptimizations() { return verbose & 0X4; }
-    bool shouldPrintInliningVersions() { return verbose & 0X8; }
+    bool shouldPrintOriginalVersion() { return verbose & 0b1; }
+    bool shouldPrintCompiledVersion() { return verbose & 0b10; }
+    bool shouldPrintOptimizations() { return verbose & 0b100; }
+    bool shouldPrintInliningVersions() { return verbose & 0b1000; }
     void setVerbose(uint v) { verbose = v; }
 
   private:
-    uint verbose = false;
+    uint32_t verbose = 0;
 
   protected:
     std::vector<PirTranslator*> translations;

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -27,9 +27,9 @@ class RirCompiler {
 
     bool isVerbose() { return verbose; }
     bool shouldPrintOriginalVersion() { return verbose & 0X1; }
-    bool shouldPrintCompiledVersion() { return verbose & 0X10; }
-    bool shouldPrintOptimizations() { return verbose & 0X100; }
-    bool shouldPrintInliningVersions() { return verbose & 0X1000; }
+    bool shouldPrintCompiledVersion() { return verbose & 0X2; }
+    bool shouldPrintOptimizations() { return verbose & 0X4; }
+    bool shouldPrintInliningVersions() { return verbose & 0X8; }
     void setVerbose(uint v) { verbose = v; }
 
   private:

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -31,7 +31,7 @@ class RirCompiler {
     bool shouldPrintCompiledVersion() { return verbose & PRINT_RAW_PIR_MASK; }
     bool shouldPrintOptimizations() { return verbose & PRINT_OPT_PHASES_MASK; }
     bool shouldPrintInliningVersions() { return verbose & PRINT_INLINIG_MASK; }
-    void setVerbose(uint v) { verbose = v; }
+    void setVerbose(uint32_t v) { verbose = v; }
 
   private:
     uint32_t verbose = 0;

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -26,10 +26,14 @@ class RirCompiler {
     }
 
     bool isVerbose() { return verbose; }
-    void setVerbose(bool v) { verbose = v; }
+    bool shouldPrintOriginalVersion() { return verbose & 0X1; }
+    bool shouldPrintCompiledVersion() { return verbose & 0X10; }
+    bool shouldPrintOptimizations() { return verbose & 0X100; }
+    bool shouldPrintInliningVersions() { return verbose & 0X1000; }
+    void setVerbose(uint v) { verbose = v; }
 
   private:
-    bool verbose = false;
+    uint verbose = false;
 
   protected:
     std::vector<PirTranslator*> translations;

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -1,6 +1,7 @@
 #ifndef RIR__PIR_COMPILER_H
 #define RIR__PIR_COMPILER_H
 
+#include "../pir/pir.h"
 #include "../pir/closure.h"
 #include "../pir/module.h"
 #include "../pir/value.h"
@@ -26,10 +27,10 @@ class RirCompiler {
     }
 
     bool isVerbose() { return verbose; }
-    bool shouldPrintOriginalVersion() { return verbose & 0b1; }
-    bool shouldPrintCompiledVersion() { return verbose & 0b10; }
-    bool shouldPrintOptimizations() { return verbose & 0b100; }
-    bool shouldPrintInliningVersions() { return verbose & 0b1000; }
+    bool shouldPrintOriginalVersion() { return verbose & PRINT_ORIGINAL_MASK; }
+    bool shouldPrintCompiledVersion() { return verbose & PRINT_RAW_PIR_MASK; }
+    bool shouldPrintOptimizations() { return verbose & PRINT_OPT_PHASES_MASK; }
+    bool shouldPrintInliningVersions() { return verbose & PRINT_INLINIG_MASK; }
     void setVerbose(uint v) { verbose = v; }
 
   private:


### PR DESCRIPTION
This PR intends to give developers some more fine-grained control on the debugging information printed when compiling using pir. There is still an **important need** to print the name of the function being compiled.
I even tried with walking through the environment programatically but I think the binding between name and the SEXP is done after the compilation...  