### PR TITLE
fix promises keeping ast in pir

### DIFF
--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -112,7 +112,7 @@ class TheInliner {
                                 mk->prom = function->promises[newPromId[id]];
                             } else {
                                 Promise* clone =
-                                    function->createProm(mk->prom->ast);
+                                    function->createProm(mk->prom->srcPoolIdx);
                                 BB* promCopy =
                                     BBTransform::clone(mk->prom->entry, clone);
                                 clone->entry = promCopy;

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -111,7 +111,8 @@ class TheInliner {
                             if (copiedPromise[id]) {
                                 mk->prom = function->promises[newPromId[id]];
                             } else {
-                                Promise* clone = function->createProm();
+                                Promise* clone =
+                                    function->createProm(mk->prom->ast);
                                 BB* promCopy =
                                     BBTransform::clone(mk->prom->entry, clone);
                                 clone->entry = promCopy;

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -19,8 +19,8 @@ void Closure::print(std::ostream& out) {
 
 void Closure::print() { print(std::cout); }
 
-Promise* Closure::createProm() {
-    Promise* p = new Promise(this, promises.size());
+Promise* Closure::createProm(unsigned ast) {
+    Promise* p = new Promise(this, promises.size(), ast);
     promises.push_back(p);
     return p;
 }
@@ -43,7 +43,7 @@ Closure* Closure::clone() {
     for (auto p : promises) {
         if (!p)
             continue;
-        Promise* clonedP = new Promise(c, c->promises.size());
+        Promise* clonedP = new Promise(c, c->promises.size(), p->ast);
         c->promises.push_back(clonedP);
         clonedP->entry = BBTransform::clone(p->entry, clonedP);
         promMap[p] = clonedP;

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -19,8 +19,8 @@ void Closure::print(std::ostream& out) {
 
 void Closure::print() { print(std::cout); }
 
-Promise* Closure::createProm(unsigned ast) {
-    Promise* p = new Promise(this, promises.size(), ast);
+Promise* Closure::createProm(unsigned srcPoolIdx) {
+    Promise* p = new Promise(this, promises.size(), srcPoolIdx);
     promises.push_back(p);
     return p;
 }
@@ -43,7 +43,7 @@ Closure* Closure::clone() {
     for (auto p : promises) {
         if (!p)
             continue;
-        Promise* clonedP = new Promise(c, c->promises.size(), p->ast);
+        Promise* clonedP = new Promise(c, c->promises.size(), p->srcPoolIdx);
         c->promises.push_back(clonedP);
         clonedP->entry = BBTransform::clone(p->entry, clonedP);
         promMap[p] = clonedP;

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -37,7 +37,7 @@ class Closure : public Code {
     void print(std::ostream& out);
     void print();
 
-    Promise* createProm(unsigned ast);
+    Promise* createProm(unsigned srcPoolIdx);
 
     friend std::ostream& operator<<(std::ostream& out, const Closure& e) {
         out << "Func(" << (void*)&e << ")";

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -37,7 +37,7 @@ class Closure : public Code {
     void print(std::ostream& out);
     void print();
 
-    Promise* createProm();
+    Promise* createProm(unsigned ast);
 
     friend std::ostream& operator<<(std::ostream& out, const Closure& e) {
         out << "Func(" << (void*)&e << ")";

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -10,6 +10,7 @@ class Promise : public Code {
   public:
     unsigned id;
     Closure* fun;
+    unsigned ast;
 
     void print(std::ostream& out = std::cout) {
         out << "Prom " << id << ":\n";
@@ -23,7 +24,8 @@ class Promise : public Code {
 
   private:
     friend class Closure;
-    Promise(Closure* fun, unsigned id) : id(id), fun(fun) {}
+    Promise(Closure* fun, unsigned id, unsigned ast)
+        : id(id), fun(fun), ast(ast) {}
 };
 }
 }

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -10,7 +10,7 @@ class Promise : public Code {
   public:
     unsigned id;
     Closure* fun;
-    unsigned ast;
+    unsigned srcPoolIdx;
 
     void print(std::ostream& out = std::cout) {
         out << "Prom " << id << ":\n";
@@ -24,8 +24,8 @@ class Promise : public Code {
 
   private:
     friend class Closure;
-    Promise(Closure* fun, unsigned id, unsigned ast)
-        : id(id), fun(fun), ast(ast) {}
+    Promise(Closure* fun, unsigned id, unsigned src)
+        : id(id), fun(fun), srcPoolIdx(src) {}
 };
 }
 }

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1045,7 +1045,7 @@ void Pir2Rir::toCSSA(Code* code) {
 
 size_t Pir2Rir::getPromiseIdx(Context& ctx, Promise* p) {
     if (!promises.count(p)) {
-        ctx.pushPromise(R_NilValue);
+        ctx.pushPromise(src_pool_at(globalContext(), p->ast));
         size_t localsCnt = compileCode(ctx, p);
         promises[p] = ctx.finalizeCode(localsCnt);
     }
@@ -1053,8 +1053,6 @@ size_t Pir2Rir::getPromiseIdx(Context& ctx, Promise* p) {
 }
 
 rir::Function* Pir2Rir::finalize() {
-    // TODO: asts are NIL for now, how to deal with that? after inlining
-    // functions and asts don't correspond anymore
 
     FunctionWriter function = FunctionWriter::create();
     Context ctx(function);

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1054,6 +1054,10 @@ size_t Pir2Rir::getPromiseIdx(Context& ctx, Promise* p) {
 
 rir::Function* Pir2Rir::finalize() {
 
+    // TODO: keep track of source ast indices in the source pool
+    // (for now, calls, promises and operators do)
+    // + how to deal with inlined stuff?
+
     FunctionWriter function = FunctionWriter::create();
     Context ctx(function);
 

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1045,7 +1045,7 @@ void Pir2Rir::toCSSA(Code* code) {
 
 size_t Pir2Rir::getPromiseIdx(Context& ctx, Promise* p) {
     if (!promises.count(p)) {
-        ctx.pushPromise(src_pool_at(globalContext(), p->ast));
+        ctx.pushPromise(src_pool_at(globalContext(), p->srcPoolIdx));
         size_t localsCnt = compileCode(ctx, p);
         promises[p] = ctx.finalizeCode(localsCnt);
     }

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -148,7 +148,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
                 return false;
             }
             rir::Code* promiseCode = srcFunction->codeAt(argi);
-            Promise* prom = insert.function->createProm();
+            Promise* prom = insert.function->createProm(promiseCode->src);
             {
                 Builder promiseBuilder(insert.function, prom);
                 if (!Rir2Pir(rir2pir).tryCompile(promiseCode, promiseBuilder))
@@ -203,7 +203,7 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
         unsigned promi = bc.immediate.i;
         rir::Code* promiseCode = srcFunction->codeAt(promi);
         Value* val = pop();
-        Promise* prom = insert.function->createProm();
+        Promise* prom = insert.function->createProm(promiseCode->src);
         {
             Builder promiseBuilder(insert.function, prom);
             if (!Rir2Pir(rir2pir).tryCompile(promiseCode, promiseBuilder))


### PR DESCRIPTION
Note: this inserts the source into the source pool when going from PIR to RIR, we should maybe rewrite the `Pool` to work with sources as well? But this PR is just to fix the bug.