### PR TITLE
Add an evaluation breakpoint for R code

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -43,3 +43,9 @@ rir.eval <- function(what, env = globalenv()) {
 rir.body <- function(f) {
     .Call("rir_body", f);
 }
+
+# breakpoint during evaluation
+# insert a call to `debug.break()` in R code and get a breakpoint when the function is evaluated
+debug.break <- function() {
+    .Call("debug_break")
+}

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -45,7 +45,7 @@ rir.body <- function(f) {
 }
 
 # breakpoint during evaluation
-# insert a call to `debug.break()` in R code and get a breakpoint when the function is evaluated
-debug.break <- function() {
+# insert a call to `.debug.break()` in R code and get a breakpoint when the function is evaluated
+.debug.break <- function() {
     .Call("debug_break")
 }

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -145,6 +145,11 @@ REXPORT SEXP pir_tests() {
     return R_NilValue;
 }
 
+REXPORT SEXP debug_break() {
+    asm("int $3");
+    return R_NilValue;
+}
+
 // startup ---------------------------------------------------------------------
 
 SEXP pirOpt(SEXP fun) { return pir_compile(fun, R_FalseValue, R_FalseValue); }


### PR DESCRIPTION
In R code, insert a call to `debug.break()`. If a debugger is attached,
when this function is evaluated, it will trigger a breakpoint.
Otherwise, R will simply crash.

---

Note that you'll end up deep in some call stack, so it will take some effort to step out of the call and back to the point of interest (and hopefully you don't step past it either). But this should get you much closer to the point of failure.

A related thing would be to have a debug instruction that triggers a breakpoint during (1) RIR compilation, (2) RIR to PIR compilation, and/or (3) PIR to RIR compilation. But it seems like this would be a lot more work, and would require changes to GNU R.