### PR TITLE
Add an evaluation breakpoint for R code (attempt 2)

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -46,6 +46,5 @@ rir.body <- function(f) {
 
 # breakpoint during evaluation
 # insert a call to `.debug.break()` in R code and get a breakpoint when the function is evaluated
-.debug.break <- function() {
-    .Call("debug_break")
-}
+# this is an empty function because it gets directly lowered to the "int3_" bytecode
+.debug.break <- function() { }

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -45,6 +45,8 @@ rir.body <- function(f) {
 }
 
 # breakpoint during evaluation
-# insert a call to `.debug.break()` in R code and get a breakpoint when the function is evaluated
-# this is an empty function because it gets directly lowered to the "int3_" bytecode
-.debug.break <- function() { }
+# insert a call to `.debug.break()` in R code and get a breakpoint when it is evaluated
+# note: the actual body of this function is replaced by an "int3_" bytecode
+.debug.break <- function() {
+    stop("missed breakpoint, did you re-compile RIR?")
+}

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -43,3 +43,9 @@ rir.eval <- function(what, env = globalenv()) {
 rir.body <- function(f) {
     .Call("rir_body", f);
 }
+
+# breakpoint during evaluation
+# insert a call to `.debug.break()` in R code and get a breakpoint when the function is evaluated
+.debug.break <- function() {
+    .Call("debug_break")
+}

--- a/rir/src/R/Symbols.cpp
+++ b/rir/src/R/Symbols.cpp
@@ -73,6 +73,7 @@ DECLARE(packageSlot, "packageSlot");
 DECLARE(attributes, "attributes");
 DECLARE(c, "c");
 DECLARE(standardGeneric, "standardGeneric");
+DECLARE(debugBreak, ".debug.break");
 
 #undef DECLARE
 } // namespace symbol

--- a/rir/src/R/Symbols.h
+++ b/rir/src/R/Symbols.h
@@ -76,6 +76,7 @@ DECLARE(packageSlot, "packageSlot");
 DECLARE(attributes, "attributes");
 DECLARE(c, "c");
 DECLARE(standardGeneric, "standardGeneric");
+DECLARE(debugBreak, ".debug.break");
 
 #undef DECLARE
 } // namespace symbol

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -144,11 +144,6 @@ REXPORT SEXP pir_tests() {
     return R_NilValue;
 }
 
-REXPORT SEXP debug_break() {
-    asm("int $3");
-    return R_NilValue;
-}
-
 // startup ---------------------------------------------------------------------
 
 uint32_t pir_verbose = (getenv("PIR_VERBOSE")) ? 

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -144,6 +144,11 @@ REXPORT SEXP pir_tests() {
     return R_NilValue;
 }
 
+REXPORT SEXP debug_break() {
+    asm("int $3");
+    return R_NilValue;
+}
+
 // startup ---------------------------------------------------------------------
 
 uint32_t pir_verbose = (getenv("PIR_VERBOSE")) ? 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -706,6 +706,12 @@ class FLI(Identical, 2, Effect::None, EnvAccess::None) {
                               {{PirType::any(), PirType::any()}}, {{a, b}}) {}
 };
 
+// Effect::Any prevents this instruction from being optimized away
+class FLI(Int3, 0, Effect::Any, EnvAccess::None) {
+  public:
+    Int3() : FixedLenInstruction(PirType::voyd()) {}
+};
+
 #define BINOP(Name, Type)                                                      \
     class FLI(Name, 3, Effect::None, EnvAccess::Leak) {                        \
       public:                                                                  \

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -62,6 +62,7 @@
     V(Deopt)                                                                   \
     V(Force)                                                                   \
     V(CastType)                                                                \
-    V(PirCopy)
+    V(PirCopy)                                                                 \
+    V(Int3)
 
 #endif

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -873,6 +873,10 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 cs << BC::is(is->sexpTag);
                 break;
             }
+            case Tag::Int3: {
+                cs << BC::int3();
+                break;
+            }
 
 #define SIMPLE_INSTR(Name, Factory)                                            \
     case Tag::Name: {                                                          \

--- a/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/stack_machine.cpp
@@ -416,6 +416,10 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
         break;
     }
 
+    case Opcode::int3_:
+        insert(new Int3());
+        break;
+
     // TODO implement!
     // (silently ignored)
     case Opcode::set_shared_:
@@ -469,7 +473,6 @@ bool StackMachine::tryRunCurrentBC(const Rir2Pir& rir2pir, Builder& insert) {
     case Opcode::beginloop_:
     case Opcode::endcontext_:
     case Opcode::ldddvar_:
-    case Opcode::int3_:
         return false;
     }
     return true;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -935,11 +935,9 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         return true;
     }
 
-    // Is this a debug breakpoint?
-    // Check if the symbol name is ".debug.break"; if so, generate an int3_
-    // instruction. Push R_NilValue because the function "call" needs to return
-    // something.
-    if (strcmp(CHAR(PRINTNAME(fun)), ".debug.break") == 0) {
+    if (fun == symbol::debugBreak) {
+        // Push R_NilValue because this is a "function call" and needs to return
+        // something.
         cs << BC::push(R_NilValue) << BC::int3();
         cs.addSrc(ast);
         return true;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -935,6 +935,16 @@ bool compileSpecialCall(Context& ctx, SEXP ast, SEXP fun, SEXP args_) {
         return true;
     }
 
+    // Is this a debug breakpoint?
+    // Check if the symbol name is ".debug.break"; if so, generate an int3_
+    // instruction. Push R_NilValue because the function "call" needs to return
+    // something.
+    if (strcmp(CHAR(PRINTNAME(fun)), ".debug.break") == 0) {
+        cs << BC::push(R_NilValue) << BC::int3();
+        cs.addSrc(ast);
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Supersedes #174. (Closing that PR was a mistake.)

Add a call to `.debug.break()` in your R code, and we compile it to the `int3_` instruction, so you get a nice breakpoint while evaluating R code. New in this version of the PR, we can compile the instruction to PIR and back.

One thing that bugs me is the `if (strcmp(CHAR(PRINTNAME(fun)), ".debug.break") == 0)` test in `Compiler.cpp`. Probably the "cleanest" way to do this is add a new symbol to R, so we don't have to compare strings? Thoughts on this?

Also, the reason I closed the other PR was because I wanted to do more, i.e. implement compilation breakpoints. But after experimenting for a bit, I'm not sure it's really worth it. You end up deep in some call stack, it's even harder to get back to a known location, and it's probably easier to put a breakpoint at `compileClosure` or whatever. And if you really wanted to break when `.debug.break()` is compiled, there's now obvious places to add the breakpoints.