### PR TITLE
Segfault fix

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -559,9 +559,11 @@ unsigned dispatch(const CallContext& call, DispatchTable* vt) {
 
     // TODO: add support to `...` passing, ie. we pass our ellipsis arg
     // to the callee
-    for (size_t i = 0; i < call.nargs(); ++i)
-        if (call.callSite->args()[i] == DOTS_ARG_IDX)
-            return 0;
+    if (!call.hasStackArgs()) {
+        for (size_t i = 0; i < call.nargs(); ++i)
+            if (call.callSite->args()[i] == DOTS_ARG_IDX)
+                return 0;
+    }
 
     return 1;
 };

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -557,6 +557,12 @@ unsigned dispatch(const CallContext& call, DispatchTable* vt) {
         return 0;
     }
 
+    // TODO: add support to `...` passing, ie. we pass our ellipsis arg
+    // to the callee
+    for (size_t i = 0; i < call.nargs(); ++i)
+        if (call.callSite->args()[i] == DOTS_ARG_IDX)
+            return 0;
+
     return 1;
 };
 


### PR DESCRIPTION
We dispatched to PIR code even if the callsite had an ellipsis argument. This failed later when `ldarg_` attempted to look at a `Code` object at the `DOTS_ARG_IDX` offset