### PR TITLE
Re-introduce subassign bytecodes

### DIFF
--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -51,6 +51,7 @@ class StreamLogger {
     void innerHeader(rir::Function*, std::string);
 
     std::ostream& getLog(rir::Function* function) {
+        return std::cout;
         if (!streams.count(function))
             startLogging(function);
         return *streams.at(function);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -636,24 +636,30 @@ class FLI(AsTest, 1, Effect::None, EnvAccess::None) {
         : FixedLenInstruction(NativeType::test, {{RType::logical}}, {{in}}) {}
 };
 
-class FLI(Subassign1_1D, 3, Effect::None, EnvAccess::None) {
+class FLI(Subassign1_1D, 4, Effect::None, EnvAccess::Leak) {
   public:
-    Subassign1_1D(Value* vec, Value* index, Value* val)
+    Subassign1_1D(Value* val, Value* vec, Value* idx, Value* env,
+                  unsigned srcIdx)
         : FixedLenInstruction(
               PirType::val(),
               {{PirType::val(), PirType::val(), PirType::val()}},
-              {{vec, index, val}}) {}
+              {{val, vec, idx}}, env, srcIdx) {}
+    Value* rhs() { return arg(0).val(); }
+    Value* lhsValue() { return arg(1).val(); }
+    Value* idx() { return arg(2).val(); }
 };
 
-class FLI(Subassign2_1D, 3, Effect::None, EnvAccess::None) {
+class FLI(Subassign2_1D, 4, Effect::None, EnvAccess::Leak) {
   public:
-    Subassign2_1D(Value* vec, Value* index, Value* value, SEXP sym)
+    Subassign2_1D(Value* val, Value* vec, Value* idx, Value* env,
+                  unsigned srcIdx)
         : FixedLenInstruction(
               PirType::val(),
               {{PirType::val(), PirType::val(), PirType::val()}},
-              {{vec, index, value}}),
-          sym(sym) {}
-    SEXP sym;
+              {{val, vec, idx}}, env, srcIdx) {}
+    Value* rhs() { return arg(0).val(); }
+    Value* lhsValue() { return arg(1).val(); }
+    Value* idx() { return arg(2).val(); }
 };
 
 class FLI(Extract1_1D, 3, Effect::None, EnvAccess::Leak) {

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -863,8 +863,8 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 break;
             }
             case Tag::Subassign2_1D: {
-                auto res = Subassign2_1D::Cast(instr);
-                cs << BC::subassign2(res->sym);
+                cs << BC::subassign2();
+                cs.addSrcIdx(instr->srcIdx);
                 break;
             }
 
@@ -900,7 +900,6 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE(ChkClosure, isfun);
                 SIMPLE(Seq, seq);
                 SIMPLE(MkCls, close);
-                SIMPLE(Subassign1_1D, subassign1);
                 SIMPLE(IsObject, isObj);
                 SIMPLE(Int3, int3);
                 SIMPLE(SetShared, setShared);
@@ -934,6 +933,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE_WITH_SRCIDX(Extract2_1D, extract2_1);
                 SIMPLE_WITH_SRCIDX(Extract1_2D, extract1_2);
                 SIMPLE_WITH_SRCIDX(Extract2_2D, extract2_2);
+                SIMPLE_WITH_SRCIDX(Subassign1_1D, subassign1);
 #undef SIMPLE_WITH_SRCIDX
 
             case Tag::Call: {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -384,19 +384,18 @@ bool Rir2Pir::compileBC(
     }
 
     case Opcode::subassign1_: {
-        Value* val = pop();
         Value* idx = pop();
         Value* vec = pop();
-        push(insert(new Subassign1_1D(vec, idx, val)));
+        Value* val = pop();
+        push(insert(new Subassign1_1D(val, vec, idx, env, srcIdx)));
         break;
     }
 
     case Opcode::subassign2_: {
-        SEXP sym = rir::Pool::get(bc.immediate.pool);
-        Value* val = pop();
         Value* idx = pop();
         Value* vec = pop();
-        push(insert(new Subassign2_1D(vec, idx, val, sym)));
+        Value* val = pop();
+        push(insert(new Subassign2_1D(val, vec, idx, env, srcIdx)));
         break;
     }
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2,6 +2,7 @@
 #include <assert.h>
 
 #include "R/Funtab.h"
+#include "R/Symbols.h"
 #include "interp.h"
 #include "interp_context.h"
 #include "ir/Deoptimization.h"
@@ -1187,7 +1188,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
-                Rf_error("object not found");
+                SEXP sym = cp_pool_at(ctx, id);
+                Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
             } else if (res == R_MissingArg) {
                 SEXP sym = cp_pool_at(ctx, id);
                 Rf_error("argument \"%s\" is missing, with no default",
@@ -1212,7 +1214,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
-                Rf_error("object not found");
+                SEXP sym = cp_pool_at(ctx, id);
+                Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
             }
 
             if (NAMED(res) == 0 && res != R_NilValue)
@@ -1229,10 +1232,10 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
-                Rf_error("object not found");
+                Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
             } else if (res == R_MissingArg) {
                 Rf_error("argument \"%s\" is missing, with no default",
-                         CHAR(PRINTNAME(res)));
+                         CHAR(PRINTNAME(sym)));
             }
 
             // if promise, evaluate & return
@@ -1253,7 +1256,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
-                Rf_error("object not found");
+                Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
             }
 
             if (NAMED(res) == 0 && res != R_NilValue)
@@ -1269,11 +1272,11 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             res = Rf_ddfindVar(sym, getenv());
             R_Visible = TRUE;
 
-            // TODO better errors
             if (res == R_UnboundValue) {
-                Rf_error("object not found");
+                Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
             } else if (res == R_MissingArg) {
-                Rf_error("argument is missing, with no default");
+                Rf_error("argument \"%s\" is missing, with no default",
+                         CHAR(PRINTNAME(sym)));
             }
 
             // if promise, evaluate & return
@@ -2109,7 +2112,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             ostack_push(ctx, args);
 
             if (isObject(val)) {
-                SEXP call = getSrcAt(c, pc - 1, ctx);
+                SEXP call = getSrcForCall(c, pc - 1, ctx);
                 res =
                     dispatchApply(call, val, args, R_SubsetSym, getenv(), ctx);
                 if (!res)
@@ -2137,7 +2140,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             ostack_push(ctx, args);
 
             if (isObject(val)) {
-                SEXP call = getSrcAt(c, pc - 1, ctx);
+                SEXP call = getSrcForCall(c, pc - 1, ctx);
                 res =
                     dispatchApply(call, val, args, R_SubsetSym, getenv(), ctx);
                 if (!res)
@@ -2155,16 +2158,34 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
         }
 
         INSTRUCTION(subassign1_) {
-            SEXP vec = ostack_at(ctx, 2);
-            SEXP idx = ostack_at(ctx, 1);
-            SEXP val = ostack_at(ctx, 0);
+            SEXP idx = ostack_at(ctx, 0);
+            SEXP vec = ostack_at(ctx, 1);
+            SEXP val = ostack_at(ctx, 2);
 
-            INCREMENT_NAMED(vec);
+            if (MAYBE_SHARED(vec)) {
+                vec = duplicate(vec);
+                ostack_at(ctx, 1) = vec;
+            }
+
             SEXP args = CONS_NR(val, R_NilValue);
+            SET_TAG(args, symbol::value);
             args = CONS_NR(idx, args);
             args = CONS_NR(vec, args);
             PROTECT(args);
-            res = do_subassign_dflt(R_NilValue, R_SubassignSym, args, getenv());
+            res = nullptr;
+            SEXP call = getSrcForCall(c, pc - 1, ctx);
+            SEXP selector = CAR(call) == symbol::SuperAssign
+                                ? symbol::SuperAssignBracket
+                                : symbol::AssignBracket;
+            if (isObject(vec)) {
+                res = dispatchApply(call, vec, args, selector, getenv(), ctx);
+            }
+            if (!res) {
+                res = do_subassign_dflt(call, selector, args, getenv());
+                // We duplicated the vector above, and there is a stvar
+                // following
+                SET_NAMED(res, 0);
+            }
             ostack_popn(ctx, 3);
             UNPROTECT(1);
 
@@ -2268,7 +2289,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
             args = CONS_NR(val, args);
             ostack_push(ctx, args);
             if (isObject(val)) {
-                SEXP call = getSrcAt(c, pc - 1, ctx);
+                SEXP call = getSrcForCall(c, pc - 1, ctx);
                 res =
                     dispatchApply(call, val, args, R_Subset2Sym, getenv(), ctx);
                 if (!res)
@@ -2284,15 +2305,12 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
         }
 
         INSTRUCTION(subassign2_) {
-            SEXP vec = ostack_at(ctx, 2);
-            SEXP idx = ostack_at(ctx, 1);
-            SEXP val = ostack_at(ctx, 0);
-
-            unsigned targetI = readImmediate();
-            advanceImmediate();
+            SEXP idx = ostack_at(ctx, 0);
+            SEXP vec = ostack_at(ctx, 1);
+            SEXP val = ostack_at(ctx, 2);
 
             // Fast case
-            if (!MAYBE_SHARED(vec)) {
+            if (!MAYBE_SHARED(vec) && !isObject(vec)) {
                 SEXPTYPE vectorT = TYPEOF(vec);
                 SEXPTYPE valT = TYPEOF(val);
                 SEXPTYPE idxT = TYPEOF(idx);
@@ -2311,15 +2329,6 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
                      (vectorT == VECSXP)) &&
                     (XLENGTH(val) == 1 || vectorT == VECSXP)) { // 3
 
-                    // if the target == R_NilValue that means this is a stack
-                    // allocated
-                    // vector
-                    SEXP target = cp_pool_at(ctx, targetI);
-                    bool localBinding = (target == R_NilValue) ||
-                                        !R_VARLOC_IS_NULL(R_findVarLocInFrame(
-                                            getenv(), target));
-
-                    if (localBinding) {
                         int idx_ = -1;
 
                         if (idxT == REALSXP) {
@@ -2346,32 +2355,38 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
                             }
                             ostack_popn(ctx, 3);
 
-                            // this is a very nice and dirty hack...
-                            // if the next instruction is a matching stvar
-                            // (which is highly probably) then we do not
-                            // have to execute it, since we changed the value
-                            // inline
-                            if (target != R_NilValue && *pc == Opcode::stvar_ &&
-                                *(int*)(pc - sizeof(int)) == *(int*)(pc + 1)) {
-                                pc = pc + sizeof(int) + 1;
-                                if (NAMED(vec) == 0)
-                                    SET_NAMED(vec, 1);
-                            } else {
-                                ostack_push(ctx, vec);
-                            }
+                            ostack_push(ctx, vec);
                             NEXT();
                         }
                     }
-                }
             }
 
-            INCREMENT_NAMED(vec);
+            if (MAYBE_SHARED(vec)) {
+                vec = duplicate(vec);
+                ostack_at(ctx, 1) = vec;
+            }
+
             SEXP args = CONS_NR(val, R_NilValue);
+            SET_TAG(args, symbol::value);
             args = CONS_NR(idx, args);
             args = CONS_NR(vec, args);
             PROTECT(args);
-            res =
-                do_subassign2_dflt(R_NilValue, R_Subassign2Sym, args, getenv());
+            res = nullptr;
+
+            SEXP call = getSrcForCall(c, pc - 1, ctx);
+            SEXP selector = CAR(call) == symbol::SuperAssign
+                                ? symbol::SuperAssignDoubleBracket
+                                : symbol::AssignDoubleBracket;
+            if (isObject(vec)) {
+                res = dispatchApply(call, vec, args, selector, getenv(), ctx);
+            }
+
+            if (!res) {
+                res = do_subassign2_dflt(call, selector, args, getenv());
+                // We duplicated the vector above, and there is a stvar
+                // following
+                SET_NAMED(res, 0);
+            }
             ostack_popn(ctx, 3);
             UNPROTECT(1);
 
@@ -2569,7 +2584,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env,
 
         INSTRUCTION(set_shared_) {
             SEXP val = ostack_top(ctx);
-            ENSURE_NAMEDMAX(val);
+            INCREMENT_NAMED(val);
             NEXT();
         }
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -27,7 +27,6 @@ void BC::write(CodeStream& cs) const {
     case Opcode::stvar_:
     case Opcode::stvar_super_:
     case Opcode::missing_:
-    case Opcode::subassign2_:
         cs.insert(immediate.pool);
         return;
 
@@ -160,6 +159,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::visible_:
     case Opcode::endcontext_:
     case Opcode::subassign1_:
+    case Opcode::subassign2_:
     case Opcode::isobj_:
     case Opcode::check_missing_:
         return;

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -162,13 +162,7 @@ BC BC::stvarSuper(SEXP sym) {
     return BC(Opcode::stvar_super_, i);
 }
 BC BC::subassign1() { return BC(Opcode::subassign1_); }
-BC BC::subassign2(SEXP sym) {
-    assert(sym == R_NilValue ||
-           (TYPEOF(sym) == SYMSXP && strlen(CHAR(PRINTNAME(sym)))));
-    ImmediateArguments i;
-    i.pool = Pool::insert(sym);
-    return BC(Opcode::subassign2_, i);
-}
+BC BC::subassign2() { return BC(Opcode::subassign2_); }
 BC BC::seq() { return BC(Opcode::seq_); }
 BC BC::colon() { return BC(Opcode::colon_); }
 BC BC::asbool() { return BC(Opcode::asbool_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -321,7 +321,7 @@ class BC {
     inline static BC missing(SEXP sym);
     inline static BC checkMissing();
     inline static BC subassign1();
-    inline static BC subassign2(SEXP sym);
+    inline static BC subassign2();
     inline static BC length();
     inline static BC names();
     inline static BC setNames();
@@ -477,7 +477,6 @@ class BC {
         case Opcode::stvar_:
         case Opcode::stvar_super_:
         case Opcode::missing_:
-        case Opcode::subassign2_:
             immediate.pool = *(PoolIdx*)pc;
             break;
         case Opcode::call_implicit_:
@@ -579,6 +578,7 @@ class BC {
         case Opcode::visible_:
         case Opcode::endcontext_:
         case Opcode::subassign1_:
+        case Opcode::subassign2_:
         case Opcode::length_:
         case Opcode::names_:
         case Opcode::set_names_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -91,11 +91,11 @@ static Sources hasSources(Opcode bc) {
     case Opcode::eq_:
     case Opcode::ne_:
     case Opcode::colon_:
+    case Opcode::subassign1_:
+    case Opcode::subassign2_:
         return Sources::Required;
 
     case Opcode::inc_:
-    case Opcode::subassign1_:
-    case Opcode::subassign2_:
     case Opcode::identical_:
     case Opcode::push_:
     case Opcode::ldfun_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -347,7 +347,7 @@ DEF_INSTR(extract2_2_, 0, 3, 1, 1)
 /**
  * subassign2_ :: [[<-(a,b,c)
  */
-DEF_INSTR(subassign2_, 1, 3, 1, 1)
+DEF_INSTR(subassign2_, 0, 3, 1, 1)
 
 /**
  * guard_fun_:: takes symbol, target, id, checks findFun(symbol) == target


### PR DESCRIPTION
this patch adds subassign1 and subassign2 again. Those bytecodes
support `[<-` and `[[<-`, in the case of one dimensional lists and
vectors.

This patch additionally enables object support for them.