### PR TITLE
fix some logging brokenness

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -20,8 +20,8 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what, debugFlags = pir.debugFlags()) {
-    .Call("pir_compile", what, debugFlags)
+pir.compile <- function(what, debugFlags) {
+    .Call("pir_compile", what, if (missing(debugFlags)) NULL else debugFlags)
 }
 
 pir.tests <- function() {
@@ -32,28 +32,28 @@ pir.tests <- function() {
 pir.debugFlags <- function(ShowWarnings = FALSE,
                            DryRun = FALSE,
                            PreserveVersions = FALSE,
-                           DebugAllocator = FALSE,
                            PrintIntoFiles = FALSE,
                            PrintIntoStdout = FALSE,
                            PrintEarlyRir = FALSE,
                            PrintEarlyPir = FALSE,
                            PrintOptimizationPasses = FALSE,
                            PrintCSSA = FALSE,
-                           PrintLivenessIntervals = FALSE,
+                           PrintAllocator = FALSE,
                            PrintFinalPir = FALSE,
                            PrintFinalRir = FALSE) {
     # !!!  This list of arguments *must* be exactly equal to the   !!!
     # !!!    LIST_OF_PIR_DEBUGGING_FLAGS in compiler/debugging.h   !!!
     .Call("pir_debugFlags", ShowWarnings, DryRun, PreserveVersions,
-          DebugAllocator, PrintIntoFiles, PrintIntoStdout, PrintEarlyRir, PrintEarlyPir, PrintOptimizationPasses,
-          PrintCSSA, PrintLivenessIntervals, PrintFinalPir, PrintFinalRir,
+          PrintIntoFiles, PrintIntoStdout, PrintEarlyRir, PrintEarlyPir,
+          PrintOptimizationPasses, PrintCSSA, PrintAllocator, PrintFinalPir,
+          PrintFinalRir,
           # wants a dummy parameter at the end for technical reasons
           NULL)
 }
 
 # sets the default debug options for pir compiler
 pir.setDebugFlags <- function(debugFlags = pir.debugFlags()) {
-    .Call("pir_setDebugFlags", debugFlags)
+    invisible(.Call("pir_setDebugFlags", debugFlags))
 }
 
 # compiles code of the given file and returns the list of compiled version.

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -129,7 +129,6 @@ REXPORT SEXP pir_setDebugFlags(SEXP debugFlags) {
 }
 
 SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
-    debug = debug | PirDebug;
 
     if (!isValidClosureSEXP(what)) {
         Rf_error("not a compiled closure");
@@ -152,7 +151,7 @@ SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
                            cmp.optimizeModule();
 
                            // compile back to rir
-                           pir::Pir2RirCompiler p2r(debug, cmp.getLog());
+                           pir::Pir2RirCompiler p2r(debug, cmp.getLogger());
                            p2r.compile(c, what);
                        },
                        [&]() {
@@ -166,9 +165,12 @@ SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
 }
 
 REXPORT SEXP pir_compile(SEXP what, SEXP debugFlags) {
-    if (TYPEOF(debugFlags) != INTSXP || Rf_length(debugFlags) < 1)
+    if (debugFlags != R_NilValue &&
+        (TYPEOF(debugFlags) != INTSXP || Rf_length(debugFlags) < 1))
         Rf_error("pir_compile expects an integer vector as second parameter");
-    return pirCompile(what, pir::DebugOptions(INTEGER(debugFlags)[0]));
+    return pirCompile(what, debugFlags == R_NilValue
+                                ? PirDebug
+                                : pir::DebugOptions(INTEGER(debugFlags)[0]));
 }
 
 REXPORT SEXP pir_tests() {

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -22,7 +22,7 @@ const std::string WARNING_GUARD_STRING = "Guard ignored";
     V(PrintEarlyPir)                                                           \
     V(PrintOptimizationPasses)                                                 \
     V(PrintCSSA)                                                               \
-    V(PrintLivenessIntervals)                                                  \
+    V(PrintAllocator)                                                          \
     V(PrintFinalPir)                                                           \
     V(PrintFinalRir)
 
@@ -30,7 +30,6 @@ const std::string WARNING_GUARD_STRING = "Guard ignored";
     V(ShowWarnings)                                                            \
     V(DryRun)                                                                  \
     V(PreserveVersions)                                                        \
-    V(DebugAllocator)                                                          \
     V(PrintIntoFiles)                                                          \
     V(PrintIntoStdout)                                                         \
     LIST_OF_PIR_PRINT_DEBUGGING_FLAGS(V)
@@ -54,4 +53,5 @@ const static DebugOptions PrintDebugPasses =
 
 } // namespace pir
 } // namespace rir
+
 #endif

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -14,16 +14,16 @@ namespace pir {
 
 class Pir2RirCompiler {
   public:
-    Pir2RirCompiler(const DebugOptions& debug, StreamLogger& log)
-        : debug(debug), log(log) {}
+    Pir2RirCompiler(const DebugOptions& debug, StreamLogger& logger)
+        : debug(debug), logger(logger) {}
 
     const DebugOptions debug;
 
     void compile(Closure* cls, SEXP origin);
-    StreamLogger& getLog() { return log; }
+    StreamLogger& getLogger() { return logger; }
 
   private:
-    StreamLogger& log;
+    StreamLogger& logger;
     std::unordered_set<Closure*> done;
 };
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -181,7 +181,7 @@ bool Rir2Pir::compileBC(
         break;
 
     case Opcode::guard_fun_:
-        compiler.getLog().warningBC(srcFunction, WARNING_GUARD_STRING, bc);
+        compiler.getLogger().warningBC(srcFunction, WARNING_GUARD_STRING, bc);
         break;
 
     case Opcode::swap_:
@@ -734,9 +734,8 @@ void Rir2Pir::translate(rir::Code* srcCode, Builder& insert,
         if (!skip) {
             int size = cur.stack.size();
             if (!compileBC(bc, pos, srcCode, cur.stack, insert, callFeedback)) {
-                compiler.getLog().warningBC(srcFunction,
-                                            "Abort r2p due to unsupported bc",
-                                            pos);
+                compiler.getLogger().warningBC(
+                    srcFunction, "Abort r2p due to unsupported bc", pos);
                 fail();
                 return;
             }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -20,7 +20,7 @@ namespace rir {
 namespace pir {
 
 Rir2PirCompiler::Rir2PirCompiler(Module* module, const DebugOptions& debug)
-    : RirCompiler(module, debug), log(debug) {
+    : RirCompiler(module, debug), logger(debug) {
     for (auto& optimization : pirConfigurations()->pirOptimizations()) {
         translations.push_back(optimization);
     }
@@ -72,16 +72,16 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
             Rir2Pir rir2pir(*this, srcFunction);
 
             if (rir2pir.tryCompile(srcFunction->body(), builder)) {
-                LOGGING(log.compilationEarlyPir(*(builder.function)));
+                LOGGING(logger.compilationEarlyPir(*(builder.function)));
                 if (!Verify::apply(pirFunction)) {
                     failed = true;
-                    LOGGING(log.failCompilingPir(srcFunction));
+                    LOGGING(logger.failCompilingPir(srcFunction));
                     assert(false);
                     return false;
                 }
                 return true;
             }
-            LOGGING(log.failCompilingPir(srcFunction));
+            LOGGING(logger.failCompilingPir(srcFunction));
             failed = true;
             return false;
         });
@@ -101,7 +101,8 @@ void Rir2PirCompiler::optimizeModule() {
                 v.saveVersion();
 
             translation->apply(f);
-            LOGGING(log.pirOptimizations(*f, translation->getName(), passnr++));
+            LOGGING(
+                logger.pirOptimizations(*f, translation->getName(), passnr++));
 
 #ifdef ENABLE_SLOWASSERT
             assert(Verify::apply(f));
@@ -114,5 +115,6 @@ void Rir2PirCompiler::optimizeModule() {
     });
 #endif
 }
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -18,14 +18,14 @@ class Rir2PirCompiler : public RirCompiler {
                          Maybe fail);
     void optimizeModule();
 
-    StreamLogger& getLog() { return log; }
+    StreamLogger& getLogger() { return logger; }
 
   private:
     void compileClosure(rir::Function*, FormalArgs const&, Env* closureEnv,
                         MaybeCls success, Maybe fail);
     void applyOptimizations(Closure*, const std::string&);
 
-    StreamLogger log;
+    StreamLogger logger;
 };
 } // namespace pir
 } // namespace rir


### PR DESCRIPTION
* files were not working (everything went into the same file)
* files were written into .pir directory, if that didn't exist, nothing would be logged (c++ doesn't deal with directories I think) - one idea would be to have the directory as a debug option and create the directory from R
* files were opened for the whole logger lifetime, now use stringstreams instead and only write at the end
* contradicting options - both print into files and stdout would only print into files, now it does both
* allocator was not implemented
* use raii to clean up the logger