### PR TITLE
print labels in disassembly

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -512,7 +512,6 @@ bool Rir2Pir::compileBC(
     case Opcode::make_unique_:
 
     // Invalid opcodes:
-    case Opcode::label:
     case Opcode::invalid_:
     case Opcode::num_of:
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -166,7 +166,6 @@ void BC::write(CodeStream& cs) const {
 
     case Opcode::invalid_:
     case Opcode::num_of:
-    case Opcode::label:
         assert(false);
         return;
     }
@@ -198,7 +197,7 @@ void BC::printNames(std::ostream& out) const {
 }
 
 void BC::print(std::ostream& out) const {
-    if (bc != Opcode::label && bc != Opcode::record_call_ &&
+    if (bc != Opcode::record_call_ &&
         bc != Opcode::record_binop_)
         out << "   " << name(bc) << " ";
 
@@ -397,11 +396,12 @@ void BC::print(std::ostream& out) const {
     case Opcode::br_:
         out << " " << immediate.offset;
         break;
-    case Opcode::label:
-        out << immediate.offset << ":";
-        break;
     }
     out << "\n";
+}
+
+void BC::printOpcode(std::ostream& out) const {
+    out << "   " << name(bc) << " ";
 }
 
 } // namespace rir

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -177,12 +177,6 @@ BC BC::alloc(int type) {
 }
 
 BC BC::isfun() { return BC(Opcode::isfun_); }
-
-BC BC::label(Jmp j) {
-    ImmediateArguments i;
-    i.offset = j;
-    return BC(Opcode::label, i);
-}
 BC BC::br(Jmp j) {
     ImmediateArguments i;
     i.offset = j;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -56,11 +56,7 @@ enum class Opcode : uint8_t {
 #define DEF_INSTR(name, ...) name,
 #include "insns.h"
 
-    // A label/jump target (used internally by CodeEditor only!)
-    label,
-
     num_of
-
 };
 
 // ============================================================
@@ -208,6 +204,7 @@ class BC {
     void printImmediateArgs(std::ostream& out) const;
     void printNames(std::ostream& out) const;
     void printProfile(std::ostream& out) const;
+    void printOpcode(std::ostream& out) const;
 
     // Accessors to load immediate constant from the pool
     SEXP immediateConst() const;
@@ -244,8 +241,6 @@ class BC {
     bool isReturn() const {
         return bc == Opcode::ret_ || bc == Opcode::return_;
     }
-
-    bool isLabel() const { return bc == Opcode::label; }
 
     // This code performs the same as `BC::decode(pc).size()`, but for
     // performance reasons, it avoids actually creating the BC object.
@@ -453,8 +448,6 @@ class BC {
     case Opcode::name:                                                         \
         return pure;
 #include "insns.h"
-        case Opcode::label:
-            return false;
         default:
             assert(false);
             return 0;
@@ -499,7 +492,6 @@ class BC {
         case Opcode::brtrue_:
         case Opcode::brobj_:
         case Opcode::brfalse_:
-        case Opcode::label:
         case Opcode::beginloop_:
             immediate.offset = *(Jmp*)pc;
             break;

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -72,8 +72,6 @@ class CodeStream {
     }
 
     CodeStream& operator<<(const BC& b) {
-        if (b.bc == Opcode::label)
-            return *this << b.immediate.offset;
         if (b.bc == Opcode::nop_)
             nops++;
         b.write(*this);

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -169,9 +169,7 @@ static Sources hasSources(Opcode bc) {
         return Sources::May;
 
     case Opcode::invalid_:
-    case Opcode::num_of:
-    case Opcode::label: {
-    }
+    case Opcode::num_of: {}
     }
     assert(false);
     return Sources::NotNeeded;


### PR DESCRIPTION
This attempts to simulate the disassembly format that CodeEditor used, ie. print labels in the code and in the jump instructions (instead of the offsets we have now - I was lazy to do the math in my head all the time)

- removes unused opcode for label
- in disassembly, prints labels and jump targets