### PR TITLE
rewrite the logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ To try out the [PIR optimizer](documentation/pir.md) you can use `pir.compile` t
 Or you can pass the environment variable PIR_ENABLE, and set it to 'on' or 'force'.
 Those flags will either use the PIR optimizer for hot RIR functions, or always.
 
-To print intermediate debug information, `pir.compile` takes a `debugFlags` argument.
-Debug flags can be created using `pir.debugFlags`, for example to debug the register allocator, you could use `pir.compile(f, debugFlags=pir.debugFlags(PrintFinalPir=TRUE,DebugAllocator=TRUE))`.
-To change the default debug flags use `pir.setDebugFlags(pir.debugFlags(...))`.
+To print intermediate debug information, you have a number of options:
+* Use the shorthand flags on `pir.compile`, such as `WARN`, or `P_FINAL`.
+* Set the `PIR_DEBUG` environment variable to a comma separated list of flags to enable by default.
+* Or for even specific debugging use the `debugFlags` argument of `pir.compile`. Debug flags can be created using `pir.debugFlags`, for example to debug the register allocator, you could use `pir.compile(f, debugFlags=pir.debugFlags(PrintFinalPir=TRUE,DebugAllocator=TRUE))`.
+* To change the default debug flags at runtime use `pir.setDebugFlags(pir.debugFlags(...))`.
 
 We periodically [benchmark](documentation/benchmarking.md) the performance of the optimizer
 

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -20,8 +20,25 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what, debugFlags) {
-    .Call("pir_compile", what, if (missing(debugFlags)) NULL else debugFlags)
+pir.compile <- function(what, debugFlags, P_EARLY=FALSE, P_FINAL=FALSE, P_OPT=FALSE, WARN=FALSE) {
+    debugFlags <-
+        if (missing(debugFlags)) {
+            if (P_EARLY)
+                pir.debugFlags(PrintEarlyPir=TRUE)
+            else if (P_FINAL)
+                pir.debugFlags(PrintFinalPir=TRUE)
+            else if (P_OPT)
+                pir.debugFlags(PrintOptimizationPasses=TRUE)
+            else if (WARN)
+                pir.debugFlags(ShowWarnings=TRUE)
+        } else {
+            debugFlags
+        }
+
+    .Call("pir_compile",
+          what,
+          as.name(as.character(substitute(what))),
+          debugFlags)
 }
 
 pir.tests <- function() {

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -32,17 +32,9 @@ REXPORT SEXP rir_disassemble(SEXP what, SEXP verbose) {
         if (!t->available(entry))
             continue;
         Function* f = t->at(entry);
-        std::stringstream output;
-        output << "= vtable slot <" << entry << "> (" << f << ", invoked "
-               << f->invocationCount << ") =\n";
-        f->body()->disassemble(output);
-        for (auto c : *f) {
-            if (c != f->body()) {
-                output << "\n [Prom (index " << c->index << ")]\n";
-                c->disassemble(output);
-            }
-        }
-        std::cout << output.str();
+        std::cout << "= vtable slot <" << entry << "> (" << f << ", invoked "
+                  << f->invocationCount << ") =\n";
+        f->disassemble(std::cout);
     }
 
     return R_NilValue;
@@ -127,7 +119,7 @@ REXPORT SEXP pir_setDebugFlags(SEXP debugFlags) {
     return R_NilValue;
 }
 
-SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
+SEXP pirCompile(SEXP what, const std::string& name, pir::DebugOptions debug) {
 
     if (!isValidClosureSEXP(what)) {
         Rf_error("not a compiled closure");
@@ -142,16 +134,19 @@ SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
 
     PROTECT(what);
 
+    bool dryRun = debug.includes(pir::DebugFlag::DryRun);
+    bool preserveVersions = debug.includes(pir::DebugFlag::PreserveVersions);
     // compile to pir
     pir::Module* m = new pir::Module;
-    pir::Rir2PirCompiler cmp(m, debug);
-    cmp.compileClosure(what,
+    pir::StreamLogger logger(debug);
+    pir::Rir2PirCompiler cmp(m, logger);
+    cmp.compileClosure(what, name,
                        [&](pir::Closure* c) {
-                           cmp.optimizeModule();
+                           cmp.optimizeModule(logger, preserveVersions);
 
                            // compile back to rir
-                           pir::Pir2RirCompiler p2r(debug, cmp.getLogger());
-                           p2r.compile(c, what);
+                           pir::Pir2RirCompiler p2r(logger);
+                           p2r.compile(c, what, dryRun);
                        },
                        [&]() {
                            if (debug.includes(pir::DebugFlag::ShowWarnings))
@@ -163,13 +158,17 @@ SEXP pirCompile(SEXP what, pir::DebugOptions debug) {
     return what;
 }
 
-REXPORT SEXP pir_compile(SEXP what, SEXP debugFlags) {
+REXPORT SEXP pir_compile(SEXP what, SEXP name, SEXP debugFlags) {
     if (debugFlags != R_NilValue &&
         (TYPEOF(debugFlags) != INTSXP || Rf_length(debugFlags) < 1))
         Rf_error("pir_compile expects an integer vector as second parameter");
-    return pirCompile(what, debugFlags == R_NilValue
-                                ? PirDebug
-                                : pir::DebugOptions(INTEGER(debugFlags)[0]));
+    std::string n;
+    if (TYPEOF(name) == SYMSXP)
+        n = CHAR(PRINTNAME(name));
+    return pirCompile(what, n,
+                      debugFlags == R_NilValue
+                          ? PirDebug
+                          : pir::DebugOptions(INTEGER(debugFlags)[0]));
 }
 
 REXPORT SEXP pir_tests() {
@@ -182,7 +181,7 @@ REXPORT SEXP pir_tests() {
 SEXP pirOpt(SEXP fun) {
     // PIR can only optimize closures, not expressions
     if (isValidClosureSEXP(fun) && DispatchTable::check(BODY(fun)))
-        return pirCompile(fun, PirDebug);
+        return pirCompile(fun, "", PirDebug);
     else
         return fun;
 }
@@ -198,7 +197,7 @@ bool startup() {
     } else if (pir && std::string(pir).compare("force_dryrun") == 0) {
         initializeRuntime(
             [](SEXP f, SEXP env) {
-                return pirCompile(rir_compile(f, env),
+                return pirCompile(rir_compile(f, env), "",
                                   PirDebug | pir::DebugFlag::DryRun);
             },
             [](SEXP f) { return f; });

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -10,7 +10,7 @@
 extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_eval(SEXP, SEXP);
-REXPORT SEXP pir_compile(SEXP, SEXP);
-SEXP pirCompile(SEXP, const rir::pir::DebugOptions);
+REXPORT SEXP pir_compile(SEXP, SEXP, SEXP);
+SEXP pirCompile(SEXP, const std::string&, const rir::pir::DebugOptions);
 
 #endif // API_H_

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -6,12 +6,6 @@
 namespace rir {
 namespace pir {
 
-#ifdef ENABLE_SLOWASSERT
-#define LOGGING(code) code
-#else
-#define LOGGING(code) /* nothing */
-#endif
-
 // !!!  This list of arguments *must* be exactly equal to the   !!!
 // !!!    one in pir.debugFlags in R/rir.R                      !!!
 

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -12,8 +12,6 @@ namespace pir {
 #define LOGGING(code) /* nothing */
 #endif
 
-const std::string WARNING_GUARD_STRING = "Guard ignored";
-
 // !!!  This list of arguments *must* be exactly equal to the   !!!
 // !!!    one in pir.debugFlags in R/rir.R                      !!!
 

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -4,13 +4,15 @@
 #include "../pir/pir.h"
 #include "debugging.h"
 
+#include <fstream>
 #include <functional>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <ostream>
 #include <sstream>
 #include <stack>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace rir {
 
@@ -19,41 +21,118 @@ class BC;
 
 namespace pir {
 
-class StreamLogger {
-    static uint64_t logId;
+class StreamLogger;
 
+class LogStream {
+  private:
+    LogStream(const LogStream&) = delete;
+    LogStream& operator=(const LogStream&) = delete;
+    const std::string id;
+    std::ostream& out;
+    DebugOptions options;
+    bool printedAnything = false;
+
+  public:
+    void pirOptimizationsFinished(Closure*);
+    void compilationEarlyPir(Closure*);
+    void pirOptimizations(Closure*, const std::string&, size_t);
+    void afterAllocator(Code*, std::function<void(std::ostream&)>);
+    void CSSA(Code*);
+    void finalPIR(Closure*);
+    void finalRIR(Function*);
+    void unsupportedBC(const std::string&, rir::BC);
+    void failed(const std::string& msg);
+    void warn(const std::string& msg);
+
+    void section(const std::string&);
+
+    void preparePrint() {
+        if (!printedAnything)
+            header();
+        printedAnything = true;
+    }
+
+    virtual void flush() {
+        if (printedAnything) {
+            footer();
+            out.flush();
+        }
+        printedAnything = false;
+    }
+    virtual ~LogStream() { assert(!printedAnything && "Forgot to flush"); }
+
+  protected:
+    virtual void highlightOn();
+    virtual void highlightOff();
+
+    void header();
+    void footer();
+
+    LogStream(const DebugOptions& options, const std::string& id,
+              std::ostream& stream = std::cout)
+        : id(id), out(stream), options(options) {}
+    friend class StreamLogger;
+};
+
+class FileLogStream : public LogStream {
+  public:
+    ~FileLogStream() override;
+
+  private:
+    std::ofstream fstream;
+
+  protected:
+    void highlightOn() override{};
+    void highlightOff() override{};
+
+    FileLogStream(const DebugOptions& options, const std::string& id,
+                  const std::string& fileName)
+        : LogStream(options, id, fstream), fstream(fileName) {}
+    friend class StreamLogger;
+};
+
+class BufferedLogStream : public LogStream {
+  public:
+    void flush() override {
+        LogStream::flush();
+        std::cout << sstream.str();
+        sstream.str("");
+        std::cout.flush();
+    }
+
+  private:
+    std::stringstream sstream;
+
+  protected:
+    BufferedLogStream(const DebugOptions& options, const std::string& id)
+        : LogStream(options, id, sstream) {}
+    friend class StreamLogger;
+};
+
+class StreamLogger {
   public:
     StreamLogger(DebugOptions options) : options(options) {}
     ~StreamLogger();
 
+    static uint64_t logId;
+
     StreamLogger(const StreamLogger&) = delete;
     StreamLogger& operator=(const StreamLogger&) = delete;
 
-    void compilationEarlyPir(Closure&);
-    void pirOptimizations(Closure&, const std::string&, size_t);
-    void pirOptimizationsFinished(Closure&);
-    void afterCSSA(Closure&, const Code*);
-    void afterAllocator(Closure&, std::function<void(std::ostream&)>);
-    void finalPIR(Closure&);
-    void rirFromPir(rir::Function*);
-    void warningBC(rir::Function*, std::string, rir::BC);
-    void failCompilingPir(rir::Function*);
-    void header(std::string, const rir::Function*, std::ostream&, bool);
-    void innerHeader(rir::Function*, std::string);
+    LogStream& begin(Closure* cls, const std::string& name);
+    LogStream& get(Closure* cls) {
+        assert(streams.count(cls) && "You need to call begin first");
+        return *streams.at(cls);
+    }
 
-    std::ostream& getLog(rir::Function* function) {
-        if (!streams.count(function))
-            startLogging(function);
-        return *streams.at(function);
-    };
+    void warn(const std::string& msg);
+
+    void flush();
+    void close(Closure* cls) { streams.erase(cls); }
 
   private:
-    std::map<rir::Function*, std::unique_ptr<std::stringstream>> streams;
-    const DebugOptions options;
-
-    void startLogging(rir::Function* function);
-    void compilationInit(rir::Function*);
-    void finish(const rir::Function*, std::ostream&);
+    std::unordered_map<Closure*, std::unique_ptr<LogStream>> streams;
+    DebugOptions options;
 };
 
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -660,10 +660,10 @@ class Pir2Rir {
 size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
     collapseSafepoints(code);
     toCSSA(code);
-    LOGGING(log.CSSA(code));
+    log.CSSA(code);
 
     SSAAllocator alloc(code);
-    LOGGING(log.afterAllocator(code, [&](std::ostream& o) { alloc.print(o); }));
+    log.afterAllocator(code, [&](std::ostream& o) { alloc.print(o); });
     alloc.verify();
 
     // create labels for all bbs
@@ -1143,12 +1143,12 @@ rir::Function* Pir2Rir::finalize() {
     size_t localsCnt = compileCode(ctx, cls);
     ctx.finalizeCode(localsCnt);
     function.finalize();
-    LOGGING(log.finalPIR(cls));
+    log.finalPIR(cls);
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(function.function()->container(),
                                        globalContext());
 #endif
-    LOGGING(log.finalRIR(function.function()));
+    log.finalRIR(function.function());
     return function.function();
 }
 

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -637,8 +637,10 @@ class Context {
 
 class Pir2Rir {
   public:
-    Pir2Rir(Pir2RirCompiler& cmp, Closure* cls, SEXP origin)
-        : compiler(cmp), cls(cls), originCls(origin) {}
+    Pir2Rir(Pir2RirCompiler& cmp, Closure* cls, SEXP origin, bool dryRun,
+            LogStream& log)
+        : compiler(cmp), cls(cls), originCls(origin), dryRun(dryRun), log(log) {
+    }
     size_t compileCode(Context& ctx, Code* code);
     size_t getPromiseIdx(Context& ctx, Promise* code);
     void toCSSA(Code* code);
@@ -651,16 +653,17 @@ class Pir2Rir {
     SEXP originCls;
     std::unordered_map<Promise*, BC::FunIdx> promises;
     std::unordered_map<Promise*, SEXP> argNames;
+    bool dryRun;
+    LogStream& log;
 };
 
 size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
     collapseSafepoints(code);
     toCSSA(code);
-    LOGGING(compiler.getLogger().afterCSSA(*cls, code));
+    LOGGING(log.CSSA(code));
 
     SSAAllocator alloc(code);
-    LOGGING(compiler.getLogger().afterAllocator(
-        *cls, [&](std::ostream& os) { alloc.print(os); }));
+    LOGGING(log.afterAllocator(code, [&](std::ostream& o) { alloc.print(o); }));
     alloc.verify();
 
     // create labels for all bbs
@@ -853,9 +856,10 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 auto dt = DispatchTable::unpack(mkfuncls->code);
 
                 if (dt->capacity() > 1 && !dt->available(1)) {
-                    Pir2Rir pir2rir(compiler, mkfuncls->fun, nullptr);
+                    Pir2Rir pir2rir(compiler, mkfuncls->fun, nullptr, dryRun,
+                                    compiler.logger.get(mkfuncls->fun));
                     auto rirFun = pir2rir.finalize();
-                    if (!compiler.debug.includes(DebugFlag::DryRun))
+                    if (!dryRun)
                         dt->put(1, rirFun);
                 }
                 cs << BC::push(mkfuncls->fml) << BC::push(mkfuncls->code)
@@ -949,7 +953,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
             case Tag::StaticCall: {
                 auto call = StaticCall::Cast(instr);
-                compiler.compile(call->cls(), call->origin());
+                compiler.compile(call->cls(), call->origin(), dryRun);
                 cs << BC::staticCall(call->nCallArgs(), Pool::get(call->srcIdx),
                                      call->origin());
                 break;
@@ -1139,18 +1143,18 @@ rir::Function* Pir2Rir::finalize() {
     size_t localsCnt = compileCode(ctx, cls);
     ctx.finalizeCode(localsCnt);
     function.finalize();
-    LOGGING(compiler.getLogger().finalPIR(*cls));
+    LOGGING(log.finalPIR(cls));
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(function.function()->container(),
                                        globalContext());
 #endif
-    LOGGING(compiler.getLogger().rirFromPir(function.function()));
+    LOGGING(log.finalRIR(function.function()));
     return function.function();
 }
 
 } // namespace
 
-void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
+void Pir2RirCompiler::compile(Closure* cls, SEXP origin, bool dryRun) {
     if (done.count(cls))
         return;
     // Avoid recursivly compiling the same closure
@@ -1160,10 +1164,11 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
     if (table->available(1))
         return;
 
-    Pir2Rir pir2rir(*this, cls, origin);
+    auto& log = logger.get(cls);
+    Pir2Rir pir2rir(*this, cls, origin, dryRun, logger.get(cls));
     auto fun = pir2rir.finalize();
 
-    if (debug.includes(DebugFlag::DryRun))
+    if (dryRun)
         return;
 
     Protect p(fun->container());
@@ -1175,6 +1180,8 @@ void Pir2RirCompiler::compile(Closure* cls, SEXP origin) {
     fun->signature = oldFun->signature;
 
     table->put(1, fun);
+
+    log.flush();
 }
 
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -14,16 +14,15 @@ namespace pir {
 
 class Pir2RirCompiler {
   public:
-    Pir2RirCompiler(const DebugOptions& debug, StreamLogger& logger)
-        : debug(debug), logger(logger) {}
+    Pir2RirCompiler(StreamLogger& logger) : logger(logger) {}
+    Pir2RirCompiler(const Pir2RirCompiler&) = delete;
+    Pir2RirCompiler& operator=(const Pir2RirCompiler&) = delete;
 
-    const DebugOptions debug;
+    void compile(Closure* cls, SEXP origin, bool dryRun);
 
-    void compile(Closure* cls, SEXP origin);
-    StreamLogger& getLogger() { return logger; }
+    StreamLogger& logger;
 
   private:
-    StreamLogger& logger;
     std::unordered_set<Closure*> done;
 };
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -14,8 +14,9 @@ struct RirStack;
 
 class Rir2Pir {
   public:
-    Rir2Pir(Rir2PirCompiler& cmp, rir::Function* srcFunction)
-        : compiler(cmp), srcFunction(srcFunction) {}
+    Rir2Pir(Rir2PirCompiler& cmp, rir::Function* srcFunction, LogStream& log,
+            const std::string& name)
+        : compiler(cmp), srcFunction(srcFunction), log(log), name(name) {}
 
     // Tries to compile the srcCode. Return value indicates failure. Builder
     // has to be discarded, if compilation fails!
@@ -32,7 +33,8 @@ class Rir2Pir {
   private:
     bool tryCompilePromise(rir::Code* prom, Builder& insert) const
         __attribute__((warn_unused_result)) {
-        return Rir2Pir(compiler, srcFunction).tryCompile(prom, insert);
+        return Rir2Pir(compiler, srcFunction, log, name)
+            .tryCompile(prom, insert);
     }
 
     template <typename T>
@@ -67,6 +69,8 @@ class Rir2Pir {
 
     Rir2PirCompiler& compiler;
     rir::Function* srcFunction;
+    LogStream& log;
+    std::string name;
 
     bool compileBC(BC bc, Opcode* pos, rir::Code* srcCode, RirStack&, Builder&,
                    std::unordered_map<Value*, CallFeedback>&,

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -85,10 +85,10 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
             Rir2Pir rir2pir(*this, srcFunction, log, name);
 
             if (rir2pir.tryCompile(srcFunction->body(), builder)) {
-                LOGGING(log.compilationEarlyPir(pirFunction));
+                log.compilationEarlyPir(pirFunction);
                 if (!Verify::apply(pirFunction)) {
                     failed = true;
-                    LOGGING(log.failed("rir2pir failed to verify"));
+                    log.failed("rir2pir failed to verify");
                     log.flush();
                     logger.close(pirFunction);
                     assert(false);
@@ -97,7 +97,7 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
                 log.flush();
                 return true;
             }
-            LOGGING(log.failed("rir2pir aborted"));
+            log.failed("rir2pir aborted");
             failed = true;
             log.flush();
             logger.close(pirFunction);
@@ -112,7 +112,7 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
 
 void Rir2PirCompiler::optimizeModule(StreamLogger& logger,
                                      bool preserveVersions) {
-    LOGGING(size_t passnr = 0);
+    size_t passnr = 0;
     for (auto& translation : translations) {
         module->eachPirFunction([&](Module::VersionedClosure& v) {
             auto f = v.current();
@@ -121,19 +121,17 @@ void Rir2PirCompiler::optimizeModule(StreamLogger& logger,
 
             auto& log = logger.get(f);
             translation->apply(f);
-            LOGGING(log.pirOptimizations(f, translation->getName(), passnr++));
+            log.pirOptimizations(f, translation->getName(), passnr++);
 
 #ifdef ENABLE_SLOWASSERT
             assert(Verify::apply(f));
 #endif
         });
     }
-#ifdef ENABLE_SLOWASSERT
     module->eachPirFunction([&](Module::VersionedClosure& v) {
         logger.get(v.current()).pirOptimizationsFinished(v.current());
         assert(Verify::apply(v.current()));
     });
-#endif
     logger.flush();
 }
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -19,63 +19,88 @@
 namespace rir {
 namespace pir {
 
-Rir2PirCompiler::Rir2PirCompiler(Module* module, const DebugOptions& debug)
-    : RirCompiler(module, debug), logger(debug) {
+Rir2PirCompiler::Rir2PirCompiler(Module* module, StreamLogger& logger)
+    : RirCompiler(module), logger(logger) {
     for (auto& optimization : pirConfigurations()->pirOptimizations()) {
         translations.push_back(optimization);
     }
 }
 
-void Rir2PirCompiler::compileClosure(SEXP closure, MaybeCls success,
-                                     Maybe fail) {
+void Rir2PirCompiler::compileClosure(SEXP closure, const std::string& name,
+                                     MaybeCls success, Maybe fail) {
     assert(isValidClosureSEXP(closure));
 
     DispatchTable* tbl = DispatchTable::unpack(BODY(closure));
 
-    if (tbl->available(1)) {
-        if (debug.includes(DebugFlag::ShowWarnings))
-            std::cerr << "Closure already compiled to PIR\n";
-    }
+    if (tbl->available(1))
+        logger.warn("Closure already compiled to PIR");
 
     FormalArgs formals(FORMALS(closure));
     rir::Function* srcFunction = tbl->first();
     auto env = module->getEnv(CLOENV(closure));
     assert(env != Env::notClosed());
-    compileClosure(srcFunction, formals, env, success, fail);
+    auto frame = RList(FRAME(CLOENV(closure)));
+
+    std::string closureName = name;
+    if (name.compare("") == 0) {
+        // Serach for name in environment
+        for (auto e = frame.begin(); e != frame.end(); ++e) {
+            if (*e == closure)
+                closureName = CHAR(PRINTNAME(e.tag()));
+        }
+    }
+    compileClosure(srcFunction, closureName, formals, env, success, fail);
 }
 
 void Rir2PirCompiler::compileFunction(rir::Function* srcFunction,
+                                      const std::string& name,
                                       FormalArgs const& formals,
                                       MaybeCls success, Maybe fail) {
-    compileClosure(srcFunction, formals, Env::notClosed(), success, fail);
+    compileClosure(srcFunction, name, formals, Env::notClosed(), success, fail);
 }
 
 void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
+                                     const std::string& name,
                                      FormalArgs const& formals, Env* closureEnv,
                                      MaybeCls success, Maybe fail) {
 
     // TODO: Support default arguments and dots
-    if (formals.hasDefaultArgs || formals.hasDots)
+    if (formals.hasDefaultArgs) {
+        logger.warn("no support for default args");
         return fail();
+    }
+    if (formals.hasDots) {
+        logger.warn("no support for ...");
+        return fail();
+    }
 
     bool failed = false;
+    // TODO: if compilation fails, we should remember that somehow. Otherwise
+    // we will continue on trying to compile the same function over and over
+    // again.
     module->createIfMissing(
         srcFunction, formals.names, closureEnv, [&](Closure* pirFunction) {
             Builder builder(pirFunction, closureEnv);
-            Rir2Pir rir2pir(*this, srcFunction);
+            auto& log = logger.begin(pirFunction, name);
+            Rir2Pir rir2pir(*this, srcFunction, log, name);
 
             if (rir2pir.tryCompile(srcFunction->body(), builder)) {
-                LOGGING(logger.compilationEarlyPir(*(builder.function)));
+                LOGGING(log.compilationEarlyPir(pirFunction));
                 if (!Verify::apply(pirFunction)) {
                     failed = true;
-                    LOGGING(logger.failCompilingPir(srcFunction));
+                    LOGGING(log.failed("rir2pir failed to verify"));
+                    log.flush();
+                    logger.close(pirFunction);
                     assert(false);
                     return false;
                 }
+                log.flush();
                 return true;
             }
-            LOGGING(logger.failCompilingPir(srcFunction));
+            LOGGING(log.failed("rir2pir aborted"));
             failed = true;
+            log.flush();
+            logger.close(pirFunction);
             return false;
         });
 
@@ -85,32 +110,31 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
         success(module->get(Module::FunctionAndEnv(srcFunction, closureEnv)));
 }
 
-void Rir2PirCompiler::optimizeModule() {
+void Rir2PirCompiler::optimizeModule(StreamLogger& logger,
+                                     bool preserveVersions) {
     LOGGING(size_t passnr = 0);
     for (auto& translation : translations) {
         module->eachPirFunction([&](Module::VersionedClosure& v) {
             auto f = v.current();
-            if (debug.includes(DebugFlag::PreserveVersions))
+            if (preserveVersions)
                 v.saveVersion();
 
+            auto& log = logger.get(f);
             translation->apply(f);
-            LOGGING(
-                logger.pirOptimizations(*f, translation->getName(), passnr++));
+            LOGGING(log.pirOptimizations(f, translation->getName(), passnr++));
 
 #ifdef ENABLE_SLOWASSERT
             assert(Verify::apply(f));
 #endif
         });
     }
-#ifndef ENABLE_SLOWASSERT
+#ifdef ENABLE_SLOWASSERT
     module->eachPirFunction([&](Module::VersionedClosure& v) {
+        logger.get(v.current()).pirOptimizationsFinished(v.current());
         assert(Verify::apply(v.current()));
     });
-#else
-    module->eachPirFunction([&](Module::VersionedClosure& v) {
-        LOGGING(logger.pirOptimizationsFinished(*(v.current())));
-    });
 #endif
+    logger.flush();
 }
 
 } // namespace pir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -11,21 +11,20 @@ namespace pir {
 
 class Rir2PirCompiler : public RirCompiler {
   public:
-    Rir2PirCompiler(Module* module, const DebugOptions& debug);
+    Rir2PirCompiler(Module* module, StreamLogger& logger);
 
-    void compileClosure(SEXP, MaybeCls success, Maybe fail) override;
-    void compileFunction(rir::Function*, FormalArgs const&, MaybeCls success,
-                         Maybe fail);
-    void optimizeModule();
-
-    StreamLogger& getLogger() { return logger; }
+    void compileClosure(SEXP, const std::string& name, MaybeCls success,
+                        Maybe fail);
+    void compileFunction(rir::Function*, const std::string& name,
+                         FormalArgs const&, MaybeCls success, Maybe fail);
+    void optimizeModule(StreamLogger& logger, bool preserveVersions = false);
 
   private:
-    void compileClosure(rir::Function*, FormalArgs const&, Env* closureEnv,
-                        MaybeCls success, Maybe fail);
+    StreamLogger& logger;
+    void compileClosure(rir::Function*, const std::string& name,
+                        FormalArgs const&, Env* closureEnv, MaybeCls success,
+                        Maybe fail);
     void applyOptimizations(Closure*, const std::string&);
-
-    StreamLogger logger;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -15,20 +15,12 @@ namespace pir {
 
 class RirCompiler {
   public:
-    RirCompiler(Module* module, const DebugOptions& debug)
-        : debug(debug), module(module) {}
+    RirCompiler(Module* module) : module(module) {}
     RirCompiler(const RirCompiler&) = delete;
     void operator=(const RirCompiler&) = delete;
 
     typedef std::function<void()> Maybe;
     typedef std::function<void(Closure*)> MaybeCls;
-
-    virtual void compileClosure(SEXP, MaybeCls, Maybe) = 0;
-    void compileClosure(SEXP cls, MaybeCls success) {
-        return compileClosure(cls, success, []() {});
-    }
-
-    const DebugOptions debug;
 
   protected:
     std::vector<const PirTranslator*> translations;

--- a/rir/src/runtime/Function.cpp
+++ b/rir/src/runtime/Function.cpp
@@ -1,0 +1,13 @@
+#include "Function.h"
+
+namespace rir {
+void Function::disassemble(std::ostream& out) {
+    body()->disassemble(out);
+    for (auto c : *this) {
+        if (c != body()) {
+            out << "\n [Prom (index " << c->index << ")]\n";
+            c->disassemble(out);
+        }
+    }
+}
+} // namespace rir

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -98,6 +98,8 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
         return 0;
     }
 
+    void disassemble(std::ostream&);
+
     FunctionSEXP origin() { return origin_; }
 
     void origin(Function* s) { setEntry(0, s->container()); }


### PR DESCRIPTION
* have a LogStream class that captures the stream of one particular
  function that we can pass around.
* use OO to distinguish between our 3 different logging modes.
* some best effort for keeping track of function names.
* print in 3 steps: 1. early pir, 2. optimizations, 3. final pir.
  this allows us to at least get some output if we crash
  in the middle.
* fix all the logging to stdout.
* don't create unnecessary stringstreams.