### PR TITLE
Named arguments for PIR Calls

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -93,9 +93,9 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
                 envs.merge(nextFun.result());
                 handled = true;
             }
-        } else {
-            assert(CallBuiltin::Cast(i) || CallSafeBuiltin::Cast(i));
         }
+        // Not handled:
+        // CallBuiltin, CallSafeBuiltin, CallImplicit, CallNamed
     }
 
     // Keep track of closures

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -93,9 +93,12 @@ void TheScopeAnalysis::apply(AS& envs, Instruction* i) const {
                 envs.merge(nextFun.result());
                 handled = true;
             }
+        } else {
+            // TODO: support for NamedCall
+            assert((CallBuiltin::Cast(i) || CallSafeBuiltin::Cast(i) ||
+                    NamedCall::Cast(i)) &&
+                   "New call instruction not handled?");
         }
-        // Not handled:
-        // CallBuiltin, CallSafeBuiltin, CallImplicit, CallNamed
     }
 
     // Keep track of closures

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -129,6 +129,12 @@ void Instruction::replaceUsesWith(Value* replace) {
     replaceUsesIn(replace, bb());
 }
 
+void Instruction::replaceUsesAndSwapWith(
+    Instruction* replace, std::vector<Instruction*>::iterator it) {
+    replaceUsesWith(replace);
+    bb()->replace(it, replace);
+}
+
 Value* Instruction::baseValue() {
     if (auto cast = CastType::Cast(this))
         return cast->arg<0>().val()->baseValue();
@@ -398,8 +404,8 @@ void NamedCall::printArgs(std::ostream& out) {
     size_t nargs = nCallArgs();
     out << "(";
     for (size_t i = 0; i < nargs; ++i) {
-        if (names.size() > i && names.at(i) != R_NilValue)
-            out << CHAR(PRINTNAME(names.at(i))) << "=";
+        if (names[i] != R_NilValue)
+            out << CHAR(PRINTNAME(names.at(i))) << " = ";
         arg(i).val()->printRef(out);
         if (i < nargs - 1)
             out << ", ";

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -4,6 +4,7 @@
 #include "R/r.h"
 #include "env.h"
 #include "instruction_list.h"
+#include "ir/BC_inc.h"
 #include "ir/Deoptimization.h"
 #include "pir.h"
 #include "singleton_values.h"
@@ -887,6 +888,28 @@ class VLIE(Call, Effect::Any, EnvAccess::Leak), public CallInstruction {
     }
 
     Value* callerEnv() { return env(); }
+
+    void printArgs(std::ostream&) override;
+};
+
+class VLIE(NamedCall, Effect::Any, EnvAccess::Leak), public CallInstruction {
+  public:
+    std::vector<SEXP> names;
+
+    Value* cls() { return arg(0).val(); }
+
+    NamedCall(Value * callerEnv, Value * fun, const std::vector<Value*>& args,
+              const std::vector<BC::PoolIdx>& names_, unsigned srcIdx);
+
+    size_t nCallArgs() override { return nargs() - 2; };
+    void eachCallArg(Instruction::ArgumentValueIterator it) override {
+        for (size_t i = 0; i < nCallArgs(); ++i)
+            it(arg(i + 1).val());
+    }
+
+    Value* callerEnv() { return env(); }
+
+    void printArgs(std::ostream&) override;
 };
 
 // Call instruction for lazy, but staticatlly resolved calls. Closure is

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -129,6 +129,8 @@ class Instruction : public Value {
 
     Instruction* hasSingleUse();
     void replaceUsesWith(Value* val);
+    void replaceUsesAndSwapWith(Instruction* val,
+                                std::vector<Instruction*>::iterator it);
     void replaceUsesIn(Value* val, BB* target);
     bool unused();
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -908,7 +908,25 @@ class VLIE(NamedCall, Effect::Any, EnvAccess::Leak), public CallInstruction {
     }
 
     Value* callerEnv() { return env(); }
+    void printArgs(std::ostream&) override;
+};
 
+class FLIE(CallImplicit, 2, Effect::Any, EnvAccess::Leak) {
+  public:
+    std::vector<Promise*> promises;
+    std::vector<SEXP> names;
+
+    Value* cls() { return arg(0).val(); }
+
+    CallImplicit(Value* callerEnv, Value* fun,
+                 const std::vector<Promise*>& args,
+                 const std::vector<SEXP>& names_, unsigned srcIdx)
+        : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
+                                         {{PirType::closure()}}, {{fun}},
+                                         callerEnv, srcIdx),
+          promises(args), names(names_) {}
+
+    Value* callerEnv() { return env(); }
     void printArgs(std::ostream&) override;
 };
 
@@ -937,6 +955,7 @@ class VLIE(StaticCall, Effect::Any, EnvAccess::Leak), public CallInstruction {
     }
 
     void printArgs(std::ostream&) override;
+    Value* callerEnv() { return env(); }
 };
 
 typedef SEXP (*CCODE)(SEXP, SEXP, SEXP, SEXP);
@@ -956,6 +975,7 @@ class VLIE(CallBuiltin, Effect::Any, EnvAccess::Leak), public CallInstruction {
             it(arg(i).val());
     }
     void printArgs(std::ostream & out) override;
+    Value* callerEnv() { return env(); }
 };
 
 class VLI(CallSafeBuiltin, Effect::None, EnvAccess::None),

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -24,6 +24,7 @@
     V(ChkMissing)                                                              \
     V(ChkClosure)                                                              \
     V(Call)                                                                    \
+    V(NamedCall)                                                               \
     V(StaticCall)                                                              \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -28,6 +28,7 @@
     V(StaticCall)                                                              \
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
+    V(CallImplicit)                                                            \
     V(MkEnv)                                                                   \
     V(LdFunctionEnv)                                                           \
     V(Lte)                                                                     \

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -951,6 +951,12 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 cs << BC::call(call->nCallArgs(), Pool::get(call->srcIdx));
                 break;
             }
+            case Tag::NamedCall: {
+                auto call = NamedCall::Cast(instr);
+                cs << BC::call(call->nCallArgs(), call->names,
+                               Pool::get(call->srcIdx));
+                break;
+            }
             case Tag::StaticCall: {
                 auto call = StaticCall::Cast(instr);
                 compiler.compile(call->cls(), call->origin(), dryRun);

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -46,7 +46,15 @@ void Builder::createNextBB() {
 }
 
 void Builder::add(Instruction* i) {
-    assert(i->tag != Tag::_UNUSED_);
+    switch (i->tag) {
+    case Tag::_UNUSED_:
+        assert(false && "Invalid instruction");
+    case Tag::PirCopy:
+    case Tag::CallImplicit:
+    case Tag::ScheduledDeopt:
+        assert(false && "This instruction is only allowed during lowering");
+    default: {}
+    }
     bb->append(i);
 }
 

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -272,7 +272,7 @@ BC BC::callImplicit(const std::vector<FunIdx>& args,
     std::vector<PoolIdx> nameIdxs;
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
-    return BC(Opcode::named_call_implicit_, im, args, nameIdxs);
+    return BC(Opcode::named_call_implicit_, im, args, std::move(nameIdxs));
 }
 BC BC::call(size_t nargs, SEXP ast) {
     ImmediateArguments im;

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -287,7 +287,7 @@ BC BC::call(size_t nargs, const std::vector<SEXP>& names, SEXP ast) {
     std::vector<PoolIdx> nameIdxs;
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
-    return BC(Opcode::named_call_, im, {}, nameIdxs);
+    return BC(Opcode::named_call_, im, {}, std::move(nameIdxs));
 }
 BC BC::staticCall(size_t nargs, SEXP ast, SEXP target) {
     ImmediateArguments im;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -178,7 +178,7 @@ class BC {
     inline size_t popCount() {
         // return also is a leave
         assert(bc != Opcode::return_);
-        if (bc == Opcode::call_)
+        if (bc == Opcode::call_ || bc == Opcode::named_call_)
             return immediate.callFixedArgs.nargs + 1;
         if (bc == Opcode::static_call_)
             return immediate.staticCallFixedArgs.nargs;
@@ -383,10 +383,10 @@ class BC {
         bc = *pc;
         pc++;
         immediate = decodeImmediateArguments(bc, pc);
+        pc += sizeof(CallFixedArgs);
         // Read implicit promise argument offsets
         if (bc == Opcode::call_implicit_ ||
             bc == Opcode::named_call_implicit_) {
-            pc += sizeof(CallFixedArgs);
             for (size_t i = 0; i < immediate.callFixedArgs.nargs; ++i)
                 immediateCallArguments.push_back(readImmediate(&pc));
         }

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -330,7 +330,7 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
                 }
             }
             if (*cptr == Opcode::named_call_) {
-                uint32_t nargs = *reinterpret_cast<Immediate*>(cptr + 5);
+                uint32_t nargs = *reinterpret_cast<Immediate*>(cptr + 1);
                 for (size_t i = 0, e = nargs; i != e; ++i) {
                     uint32_t offset = cur.callArgumentNames[i];
                     if (offset) {


### PR DESCRIPTION
Introduce a new NamedCall PIR instruction that supports named
arguments. Currently this named call instruction is a completely
separate instruction. Therefore for existing optimizations and
analysis, this new instruction is completely opaque.

What we gain from this commit is that named calls can be compiled
to pir and back to rir.