### PR TITLE
don't convert named calls to static calls

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -258,10 +258,14 @@ bool Rir2Pir::compileBC(
 
         Value* callee = top();
         SEXP monomorphic = nullptr;
-        if (callFeedback.count(callee)) {
-            auto& feedback = callFeedback.at(callee);
-            if (feedback.numTargets == 1)
-                monomorphic = feedback.targets[0];
+
+        // TODO: static named argument matching
+        if (bc.bc != Opcode::named_call_implicit_) {
+            if (callFeedback.count(callee)) {
+                auto& feedback = callFeedback.at(callee);
+                if (feedback.numTargets == 1)
+                    monomorphic = feedback.targets[0];
+            }
         }
 
         auto ast = bc.immediate.callFixedArgs.ast;


### PR DESCRIPTION
Before we can convert named_call_implicit to static call, we need the
static version of arg position matching.

This case was introduced by accident