### PR TITLE
Miscellaneous printing fixes

### DIFF
--- a/rir/src/R/Sexp.cpp
+++ b/rir/src/R/Sexp.cpp
@@ -4,10 +4,8 @@
 namespace rir {
 
 void MatchStatement::fallThroughFail() {
-    std::stringstream s;
-    s << line;
-    std::cout << Rf_type2char(TYPEOF(subject)) << " not handled in Match "
-              << file << ":" << s.str() << "\n";
+    std::cerr << Rf_type2char(TYPEOF(subject)) << " not handled in Match "
+              << file << ":" << line << "\n";
     assert(false);
 }
 }

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -135,8 +135,7 @@ void TheScopeAnalysis::print(std::ostream& out) {
                 for (auto& entry : e) {
                     auto ptr = entry.first;
                     auto env = entry.second;
-                    std::cout << "Env(" << ptr << "), leaked " << env.leaked
-                              << ":\n";
+                    out << "Env(" << ptr << "), leaked " << env.leaked << ":\n";
                     env.print(out);
                 }
             }
@@ -147,7 +146,7 @@ void TheScopeAnalysis::print(std::ostream& out) {
     for (auto& entry : result()) {
         auto ptr = entry.first;
         auto env = entry.second;
-        std::cout << "Env(" << ptr << "), leaked " << env.leaked << ":\n";
+        out << "Env(" << ptr << "), leaked " << env.leaked << ":\n";
         env.print(out);
     }
     out << "-------------------------------------\n";
@@ -161,7 +160,7 @@ ScopeAnalysis::ScopeAnalysis(Closure* function) {
     TheScopeAnalysis analysis(function, function->argNames);
     analysis();
     if (false)
-        analysis.print();
+        analysis.print(std::cout);
 
     // Collect all abstract values of all loads
     analysis.foreach<PositioningStyle::BeforeInstruction>(

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -286,12 +286,12 @@ static void printCallArgs(std::ostream& out, CallInstruction* call) {
 }
 
 void CallBuiltin::printArgs(std::ostream& out, bool tty) {
-    std::cout << getBuiltinName(builtinId);
+    out << getBuiltinName(builtinId);
     printCallArgs(out, this);
 }
 
 void CallSafeBuiltin::printArgs(std::ostream& out, bool tty) {
-    std::cout << getBuiltinName(builtinId);
+    out << getBuiltinName(builtinId);
     printCallArgs(out, this);
 }
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -6,7 +6,7 @@ extern "C" Rboolean(Rf_isObject)(SEXP s);
 namespace rir {
 namespace pir {
 
-void PirType::print() { std::cout << *this << "\n"; }
+void PirType::print(std::ostream& out) { out << *this << "\n"; }
 
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     switch (TYPEOF(e)) {

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -246,7 +246,7 @@ struct PirType {
         return t_.r.includes(o.t_.r);
     }
 
-    void print();
+    void print(std::ostream& out = std::cout);
 };
 
 inline std::ostream& operator<<(std::ostream& out, NativeType t) {

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -17,8 +17,7 @@ typedef rir::DispatchTable DispatchTable;
 
 Function* isValidClosureSEXP(SEXP closure);
 
-void printFunction(Function* f);
-void printFunctionFancy(SEXP f);
+void printFunction(Function* f, std::ostream& out = std::cout);
 
 void initializeRuntime();
 

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -134,12 +134,17 @@ void Code::disassemble(std::ostream& out) const {
 
 void Code::print(std::ostream& out) const {
     out << "Code object (" << this << " index " << index << ")\n";
-    out << "   Source: " << src << " index to src pool\n";
-    out << "   Magic: " << std::hex << info.magic << std::dec << "(hex)\n";
-    out << "   Stack (o): " << stackLength << "\n";
-    out << "   Code size: " << codeSize << "[B]\n";
+    out << std::left << std::setw(20) << "   Source: " << src
+        << " (index into src pool)\n";
+    out << std::left << std::setw(20) << "   Magic: " << std::hex << info.magic
+        << std::dec << " (hex)\n";
+    out << std::left << std::setw(20) << "   Stack (o): " << stackLength
+        << "\n";
+    out << std::left << std::setw(20) << "   Code size: " << codeSize
+        << "[B]\n";
+    out << std::left << std::setw(20) << "   Default arg? "
+        << (isDefaultArgument ? "yes" : "no") << "\n";
 
-    out << "   Default arg? " << (isDefaultArgument ? "yes\n" : "no") << "\n";
     if (info.magic != CODE_MAGIC) {
         out << "Wrong magic number -- corrupted IR bytecode";
         Rf_error("Wrong magic number -- corrupted IR bytecode");

--- a/rir/src/runtime/FunctionSignature.h
+++ b/rir/src/runtime/FunctionSignature.h
@@ -2,6 +2,10 @@
 
 #include "R/r.h"
 
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
 namespace rir {
 
 struct FunctionSignature {
@@ -30,9 +34,11 @@ struct FunctionSignature {
                    length == other.length;
         }
 
-        void print() const {
-            Rprintf("                   isEvaluated=%s, type=%u, length=%d\n",
-                    isEvaluated ? "true" : "false", type, length);
+        void print(std::ostream& out = std::cout) const {
+            out << std::setw(22) << " "
+                << "isEvaluated=" << (isEvaluated ? "true" : "false")
+                << ", type=" << Rf_type2char(type) << ", length=" << length
+                << "\n";
         }
     };
 
@@ -56,14 +62,16 @@ struct FunctionSignature {
         return true;
     }
 
-    void print() const {
-        Rprintf("    environment?   %s\n",
-                createEnvironment ? "true" : "false");
-        Rprintf("    on stack?      %s\n", argsOnStack ? "true" : "false");
-        Rprintf("    args (%u):\n", arguments.size());
+    void print(std::ostream& out = std::cout) const {
+        out << std::left << std::setw(20) << "    environment?"
+            << (createEnvironment ? "true" : "false") << "\n";
+        out << std::left << std::setw(20) << "    on stack?"
+            << (argsOnStack ? "true" : "false") << "\n";
+        out << std::left << std::setw(20) << "    args"
+            << "size=" << arguments.size() << "\n";
         for (auto arg : arguments)
-            arg.print();
-        Rprintf("\n");
+            arg.print(out);
+        out << "\n";
     }
 
     FunctionSignature() = default;


### PR DESCRIPTION
Print to ostream parameter, not std::cout.

Also other miscellaneous fixes (see second commit).

---

Before, we would get something like:

```
╞══════════════════════════╡  Compiling bitwShiftL  ╞══════════════════════════╡
bitwiseShiftL
┌──────────────────────────────────────────────────────────────────────────────┐
│ bitwShiftL_0x2a6ecc8                                                         │
├────── Final PIR Version
Closure 0x2792ad0(0x2a6ecc8)
BB0
  val^    %0.0  = LdArg            0
  val^    %0.1  = LdArg            1
  env     e0.2  = MkEnv            a=%0.0, n=%0.1, parent=<environment: namespace:base>
  val     %0.3  = Force            %0.0, e0.2
  val^?   %0.4  = LdVar            n, e0.2
  val     %0.5  = Force            %0.4, e0.2
  val^    %0.6  = CallBuiltin      (%0.3, %0.5) e0.2
  val     %0.7  = Force            %0.6, e0.2
  void            Return           %0.7
```

Note the stray `bitwiseShiftL` at the top, and how `CallBuiltin` is calling some unnamed function.

The correct output is:

```
╞══════════════════════════╡  Compiling bitwShiftL  ╞══════════════════════════╡
┌──────────────────────────────────────────────────────────────────────────────┐
│ bitwShiftL_0x2a6ecc8                                                         │
├────── Final PIR Version
Closure 0x2792ad0(0x2a6ecc8)
BB0
  val^    %0.0  = LdArg            0
  val^    %0.1  = LdArg            1
  env     e0.2  = MkEnv            a=%0.0, n=%0.1, parent=<environment: namespace:base>
  val     %0.3  = Force            %0.0, e0.2
  val^?   %0.4  = LdVar            n, e0.2
  val     %0.5  = Force            %0.4, e0.2
  val^    %0.6  = CallBuiltin      bitwiseShiftL(%0.3, %0.5) e0.2
  val     %0.7  = Force            %0.6, e0.2
  void            Return           %0.7
```
