### PR TITLE
don't output terminal control characters to non-terminals

### DIFF
--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -24,6 +24,7 @@ StreamLogger::~StreamLogger() {
 FileLogStream::~FileLogStream() { fstream.close(); }
 
 bool LogStream::tty() { return ConsoleColor::isTTY(out); }
+bool BufferedLogStream::tty() { return ConsoleColor::isTTY(actualOut); }
 
 LogStream& StreamLogger::begin(Closure* cls, const std::string& name) {
     assert(!streams.count(cls) && "You already started this function");
@@ -31,7 +32,7 @@ LogStream& StreamLogger::begin(Closure* cls, const std::string& name) {
     id << name;
     if (name.empty())
         id << "?";
-    id << "_" << cls->rirVersion();
+    id << "_" << *cls;
 
     if (options.includes(DebugFlag::PrintIntoFiles)) {
         std::stringstream filename;
@@ -201,21 +202,25 @@ void StreamLogger::title(const std::string& msg) {
     if (!options.includes(DebugFlag::PrintIntoFiles) &&
         (options.intersects(PrintDebugPasses) ||
          options.includes(DebugFlag::ShowWarnings))) {
-        ConsoleColor::blue(std::cout);
+        if (ConsoleColor::isTTY(std::cout))
+            ConsoleColor::blue(std::cout);
         int l = 36 - (int)msg.length() / 2;
         int r = l - msg.length() % 2;
         std::cout << "\n╞";
         for (int i = 0; i < l; ++i)
             std::cout << "═";
         std::cout << "╡  ";
-        ConsoleColor::clear(std::cout);
+        if (ConsoleColor::isTTY(std::cout))
+            ConsoleColor::clear(std::cout);
         std::cout << msg;
-        ConsoleColor::blue(std::cout);
+        if (ConsoleColor::isTTY(std::cout))
+            ConsoleColor::blue(std::cout);
         std::cout << "  ╞";
         for (int i = 0; i < r; ++i)
             std::cout << "═";
         std::cout << "╡\n";
-        ConsoleColor::clear(std::cout);
+        if (ConsoleColor::isTTY(std::cout))
+            ConsoleColor::clear(std::cout);
     }
 }
 

--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -26,25 +26,20 @@ FileLogStream::~FileLogStream() { fstream.close(); }
 bool LogStream::tty() { return ConsoleColor::isTTY(out); }
 bool BufferedLogStream::tty() { return ConsoleColor::isTTY(actualOut); }
 
-LogStream& StreamLogger::begin(Closure* cls, const std::string& name) {
+LogStream& StreamLogger::begin(Closure* cls) {
     assert(!streams.count(cls) && "You already started this function");
-    std::stringstream id;
-    id << name;
-    if (name.empty())
-        id << "?";
-    id << "_" << *cls;
 
     if (options.includes(DebugFlag::PrintIntoFiles)) {
         std::stringstream filename;
         filename << "pir-function-" << std::setfill('0') << std::setw(5)
-                 << logId++ << "-" << id.str() << ".log";
+                 << logId++ << "-" << cls->name << ".log";
         streams.emplace(cls,
-                        new FileLogStream(options, id.str(), filename.str()));
+                        new FileLogStream(options, cls->name, filename.str()));
     } else {
         if (options.includes(DebugFlag::PrintIntoStdout))
-            streams.emplace(cls, new LogStream(options, id.str()));
+            streams.emplace(cls, new LogStream(options, cls->name));
         else
-            streams.emplace(cls, new BufferedLogStream(options, id.str()));
+            streams.emplace(cls, new BufferedLogStream(options, cls->name));
     }
 
     auto& logger = get(cls);

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -125,7 +125,7 @@ class StreamLogger {
     StreamLogger(const StreamLogger&) = delete;
     StreamLogger& operator=(const StreamLogger&) = delete;
 
-    LogStream& begin(Closure* cls, const std::string& name);
+    LogStream& begin(Closure* cls);
     LogStream& get(Closure* cls) {
         assert(streams.count(cls) && "You need to call begin first");
         return *streams.at(cls);

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -97,19 +97,21 @@ class BufferedLogStream : public LogStream {
   public:
     void flush() override {
         LogStream::flush();
-        std::cout << sstream.str();
+        actualOut << sstream.str();
         sstream.str("");
-        std::cout.flush();
+        actualOut.flush();
     }
 
   private:
     std::stringstream sstream;
+    std::ostream& actualOut;
 
   protected:
-    bool tty() override { return true; }
+    bool tty() override;
 
-    BufferedLogStream(const DebugOptions& options, const std::string& id)
-        : LogStream(options, id, sstream) {}
+    BufferedLogStream(const DebugOptions& options, const std::string& id,
+                      std::ostream& actualOut = std::cout)
+        : LogStream(options, id, sstream), actualOut(actualOut) {}
     friend class StreamLogger;
 };
 

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -9,7 +9,7 @@ namespace rir {
 namespace pir {
 
 void Closure::print(std::ostream& out, bool tty) const {
-    out << "Closure " << this << "(" << function << ")\n";
+    out << *this << "\n";
     printCode(out, tty);
     for (auto p : promises) {
         if (p)
@@ -31,7 +31,7 @@ Closure::~Closure() {
 }
 
 Closure* Closure::clone() {
-    Closure* c = new Closure(argNames, env, function);
+    Closure* c = new Closure(name, argNames, env, function);
 
     // clone code
     c->entry = BBTransform::clone(entry, c);

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -5,6 +5,7 @@
 #include "code.h"
 #include "pir.h"
 #include <functional>
+#include <sstream>
 
 namespace rir {
 namespace pir {
@@ -20,15 +21,27 @@ namespace pir {
 class Closure : public Code {
   private:
     friend class Module;
-    Closure(std::initializer_list<SEXP> a, Env* env, rir::Function* function)
-        : env(env), function(function), argNames(a) {}
-    Closure(const std::vector<SEXP>& a, Env* env, rir::Function* function)
-        : env(env), function(function), argNames(a) {}
+    static std::string uniqueName(const Closure* c, const std::string& name) {
+        std::stringstream id;
+        id << name << "[" << c << "]";
+        return id.str();
+    }
+
+    Closure(const std::string& name, std::initializer_list<SEXP> a, Env* env,
+            rir::Function* function)
+        : env(env), function(function), name(uniqueName(this, name)),
+          argNames(a) {}
+    Closure(const std::string& name, const std::vector<SEXP>& a, Env* env,
+            rir::Function* function)
+        : env(env), function(function), name(uniqueName(this, name)),
+          argNames(a) {}
 
     Env* env;
     rir::Function* function;
 
   public:
+    const std::string name;
+
     Env* closureEnv() const { return env; }
     rir::Function* rirVersion() { return function; }
 
@@ -42,7 +55,7 @@ class Closure : public Code {
     Promise* createProm(unsigned srcPoolIdx);
 
     friend std::ostream& operator<<(std::ostream& out, const Closure& e) {
-        out << "Func(" << (void*)&e << ")";
+        out << e.name;
         return out;
     }
 

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -371,7 +371,6 @@ MkFunCls::MkFunCls(Closure* fun, Value* lexicalEnv, SEXP fml, SEXP code,
 
 void MkFunCls::printArgs(std::ostream& out, bool tty) {
     out << *fun;
-    out << ", ";
     Instruction::printArgs(out, tty);
 }
 

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -23,14 +23,15 @@ void Module::printEachVersion(std::ostream& out, bool tty) {
     }
 }
 
-void Module::createIfMissing(rir::Function* f, const std::vector<SEXP>& a,
-                             Env* env, MaybeCreate create) {
+void Module::createIfMissing(const std::string& name, rir::Function* f,
+                             const std::vector<SEXP>& a, Env* env,
+                             MaybeCreate create) {
     auto idx = FunctionAndEnv(f, env);
     if (functionMap.count(idx)) {
         return;
     }
     assert(functionMap.count(idx) == 0);
-    auto* cls = new pir::Closure(a, env, f);
+    auto* cls = new pir::Closure(name, a, env, f);
     auto functionsIdx = functions.size();
     functions.push_back(VersionedClosure(cls));
     functionMap.emplace(idx, functionsIdx);

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -53,7 +53,8 @@ class Module {
     }
 
     typedef std::function<bool(Closure* f)> MaybeCreate;
-    void createIfMissing(rir::Function* f, const std::vector<SEXP>& a, Env* env,
+    void createIfMissing(const std::string& name, rir::Function* f,
+                         const std::vector<SEXP>& a, Env* env,
                          MaybeCreate create);
 
     typedef std::function<void(VersionedClosure&)> PirClosureVersionIterator;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -78,31 +78,31 @@ void Rir2PirCompiler::compileClosure(rir::Function* srcFunction,
     // TODO: if compilation fails, we should remember that somehow. Otherwise
     // we will continue on trying to compile the same function over and over
     // again.
-    module->createIfMissing(
-        srcFunction, formals.names, closureEnv, [&](Closure* pirFunction) {
-            Builder builder(pirFunction, closureEnv);
-            auto& log = logger.begin(pirFunction, name);
-            Rir2Pir rir2pir(*this, srcFunction, log, name);
+    module->createIfMissing(name, srcFunction, formals.names, closureEnv,
+                            [&](Closure* pirFunction) {
+                                Builder builder(pirFunction, closureEnv);
+                                auto& log = logger.begin(pirFunction);
+                                Rir2Pir rir2pir(*this, srcFunction, log, name);
 
-            if (rir2pir.tryCompile(builder)) {
-                log.compilationEarlyPir(pirFunction);
-                if (!Verify::apply(pirFunction)) {
-                    failed = true;
-                    log.failed("rir2pir failed to verify");
-                    log.flush();
-                    logger.close(pirFunction);
-                    assert(false);
-                    return false;
-                }
-                log.flush();
-                return true;
-            }
-            log.failed("rir2pir aborted");
-            failed = true;
-            log.flush();
-            logger.close(pirFunction);
-            return false;
-        });
+                                if (rir2pir.tryCompile(builder)) {
+                                    log.compilationEarlyPir(pirFunction);
+                                    if (!Verify::apply(pirFunction)) {
+                                        failed = true;
+                                        log.failed("rir2pir failed to verify");
+                                        log.flush();
+                                        logger.close(pirFunction);
+                                        assert(false);
+                                        return false;
+                                    }
+                                    log.flush();
+                                    return true;
+                                }
+                                log.failed("rir2pir aborted");
+                                failed = true;
+                                log.flush();
+                                logger.close(pirFunction);
+                                return false;
+                            });
 
     if (failed)
         fail();


### PR DESCRIPTION
This PR fixes the following issues:
1. the buffered log stream would print terminal escape chars to non terminals
2. closures would be named differently in the logger header and in call instructions. To be able to
    show the closure name, for example in the disassembly of `StaticCall`, I had to move the name
    from the logstream into the actual closure. 