### PR TITLE
fix inliner

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -194,6 +194,21 @@ SEXP pirCompile(SEXP what, const std::string& name, pir::DebugOptions debug) {
     return what;
 }
 
+REXPORT SEXP rir_invocation_count(SEXP what) {
+    if (!isValidClosureSEXP(what)) {
+        Rf_error("not a compiled closure");
+    }
+    auto dt = DispatchTable::check(BODY(what));
+    assert(dt);
+
+    SEXP res = Rf_allocVector(INTSXP, dt->capacity());
+    for (size_t i = 0; i < dt->capacity(); ++i) {
+        INTEGER(res)[i] = dt->available(i) ? dt->at(i)->invocationCount : 0;
+    }
+
+    return res;
+}
+
 REXPORT SEXP pir_compile(SEXP what, SEXP name, SEXP debugFlags) {
     if (debugFlags != R_NilValue &&
         (TYPEOF(debugFlags) != INTSXP || Rf_length(debugFlags) < 1))

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -9,6 +9,7 @@
 
 extern int R_ENABLE_JIT;
 
+REXPORT SEXP rir_invocation_count(SEXP what);
 REXPORT SEXP rir_eval(SEXP exp, SEXP env);
 REXPORT SEXP pir_compile(SEXP closure, SEXP name, SEXP sebugFlags);
 REXPORT SEXP rir_compile(SEXP what, SEXP env);

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -79,7 +79,8 @@ class TheScopeResolution {
                         if (src.origin->bb()->owner != function)
                             onlyLocalVals = false;
                     });
-                    if (aval.isUnknown() &&
+                    if (!ldfun && // for ldfun more thinking is required...
+                        aval.isUnknown() &&
                         aload.env != AbstractREnvironment::UnknownParent) {
                         // We have no clue what we load, but we know from where
                         ld->env(aload.env);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -419,7 +419,7 @@ class VarLenInstructionWithEnvSlot
         Super::pushArg(env, RType::env);
     }
 
-    void pushArg(Value* a, PirType t) override {
+    void pushArg(Value* a, PirType t) override final {
         assert(a);
         assert(args_.size() > 0);
         assert(args_.back().type() == RType::env);
@@ -427,7 +427,7 @@ class VarLenInstructionWithEnvSlot
         args_.push_back(args_.back());
         args_[args_.size() - 2] = InstrArg(a, t);
     }
-    void popArg() override {
+    void popArg() override final {
         assert(args_.size() > 1);
         assert(args_.back().type() == RType::env);
         args_[args_.size() - 2] = args_[args_.size() - 1];

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1134,6 +1134,8 @@ class VLIE(Safepoint, Effect::Any, EnvAccess::Leak) {
         }
     }
 
+    Value* tos() { return arg(stackSize - 1).val(); }
+
     void printArgs(std::ostream& out, bool tty) override;
     void printEnv(std::ostream& out, bool tty) override final{};
 };

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -854,16 +854,6 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
             case Tag::MkFunCls: {
                 auto mkfuncls = MkFunCls::Cast(instr);
-
-                auto dt = DispatchTable::unpack(mkfuncls->code);
-
-                if (dt->capacity() > 1 && !dt->available(1)) {
-                    Pir2Rir pir2rir(compiler, mkfuncls->fun, nullptr, dryRun,
-                                    compiler.logger.get(mkfuncls->fun));
-                    auto rirFun = pir2rir.finalize();
-                    if (!dryRun)
-                        dt->put(1, rirFun);
-                }
                 cs << BC::push(mkfuncls->fml) << BC::push(mkfuncls->code)
                    << BC::push(mkfuncls->src) << BC::close();
                 break;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -7,7 +7,6 @@
 #include "ir/RuntimeFeedback_inl.h"
 #include "runtime.h"
 
-#include <alloca.h>
 #include <assert.h>
 #include <deque>
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1,6 +1,3 @@
-#include <alloca.h>
-#include <assert.h>
-
 #include "R/Funtab.h"
 #include "R/Symbols.h"
 #include "R/r.h"
@@ -9,6 +6,10 @@
 #include "ir/Deoptimization.h"
 #include "ir/RuntimeFeedback_inl.h"
 #include "runtime.h"
+
+#include <alloca.h>
+#include <assert.h>
+#include <deque>
 
 #define NOT_IMPLEMENTED assert(false)
 
@@ -1097,7 +1098,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
     };
 #endif
 
-    std::vector<FrameInfo*> synthesizeFrames;
+    std::deque<FrameInfo*> synthesizeFrames;
     assert(c->info.magic == CODE_MAGIC);
 
     Locals locals(c->localsCount);
@@ -2440,6 +2441,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
             FrameInfo& f = m->frames[0];
             pc = f.pc;
             c = f.code;
+            c->function()->registerInvocation();
             assert(c->code() <= pc && pc < c->endCode());
             SEXP e = ostack_pop(ctx);
             assert(TYPEOF(e) == ENVSXP);
@@ -2699,13 +2701,14 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
 
 eval_done:
     while (!synthesizeFrames.empty()) {
-        FrameInfo* f = synthesizeFrames.back();
-        synthesizeFrames.pop_back();
+        FrameInfo* f = synthesizeFrames.front();
+        synthesizeFrames.pop_front();
         SEXP res = ostack_pop(ctx);
         SEXP e = ostack_pop(ctx);
         assert(TYPEOF(e) == ENVSXP);
         *env = e;
         ostack_push(ctx, res);
+        f->code->function()->registerInvocation();
         res = evalRirCode(f->code, ctx, env, callCtxt, f->pc);
         ostack_push(ctx, res);
     }

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -54,3 +54,30 @@ rir.compile(function(){
     f <- pir.compile(f);
     f(structure(1, class="foo"))
 })()
+
+
+# inlined safepoints:
+f <- rir.compile(function(x) g(x))
+g <- rir.compile(function(x) h(x))
+h <- rir.compile(function(x) 1+i(x))
+i <- rir.compile(function(x) 40-x)
+
+stopifnot(f(-1) == 42)
+
+hc1 = .Call("rir_invocation_count", h)
+ic1 = .Call("rir_invocation_count", i)
+g <- pir.compile(g)
+stopifnot(f(-1) == 42)
+
+## Assert we are really inlined (ie. h and i are not called)
+hc2 = .Call("rir_invocation_count", h)
+ic2 = .Call("rir_invocation_count", i)
+stopifnot(hc1 == hc2)
+stopifnot(ic1 == ic2)
+
+## Assert we deopt (ie. base version of h and i are invoked)
+stopifnot(f(structure(-1, class="asdf")) == 42)
+hc3 = .Call("rir_invocation_count", h)
+ic3 = .Call("rir_invocation_count", i)
+stopifnot(hc3 == hc2+c(1,0))
+stopifnot(ic3 == ic2+c(1,0))


### PR DESCRIPTION
this code was broken. we would never find the safepoint after the call,
since we would start searching at the (side-effecting) call instruction
itself. for now let's be less clever. we need a better story for sp
anyway.