### PR TITLE
move instructions out of edge-split nodes

### DIFF
--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -129,15 +129,11 @@ class TheCleanup {
         CFG cfg(function);
         std::unordered_map<BB*, BB*> toDel;
         Visitor::run(function->entry, [&](BB* bb) {
-            // Remove unnecessary splits
-            if (bb->isJmp() && cfg.hasSinglePred(bb->next0) &&
-                /* this condition keeps graph in split-edge: */
-                cfg.hasSinglePred(bb) &&
-                cfg.immediatePredecessors(bb)[0]->isJmp()) {
+            // If bb is a jump to non-merge block, we merge it with the next
+            if (bb->isJmp() && cfg.hasSinglePred(bb->next0)) {
                 BB* d = bb->next0;
-                while (!d->isEmpty()) {
+                while (!d->isEmpty())
                     d->moveToEnd(d->begin(), bb);
-                }
                 bb->next0 = d->next0;
                 bb->next1 = d->next1;
                 d->next0 = nullptr;


### PR DESCRIPTION
We keep our pir cfg in edge-split format. What this means is that
every BB can be a merge block, or a split block, but never both.
This avoids pathological graphs like:

       a     b
     /  \  /
    c    d

Where instructions from d cannot be hoisted without being captured by
an unrelated path and instructions from a cannot be pushed down,
without being captured by an unrelated path.

Our cleanup respects this condition. But if a BB is only there to
guarantee edge-split form, we should move all instructions to the
next BB. Many optimizations are BB local, thus it's not a good idea
to have a BB split over two.