### PR TITLE
Smaller type feedback struct

### DIFF
--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -158,7 +158,7 @@ void insertTypeFeedbackForBinops(rir::Function* srcFunction,
         Opcode* finger = function->code();
         while (finger != end) {
             Opcode* prev = finger;
-            BC bc = BC::advance(&finger);
+            BC bc = BC::advance(&finger, function);
             if (bc.bc == Opcode::record_binop_) {
                 prev++;
                 TypeFeedback* feedback = (TypeFeedback*)prev;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -100,7 +100,7 @@ std::unordered_set<Opcode*> findMergepoints(rir::Code* srcCode) {
     std::unordered_map<Opcode*, std::vector<Opcode*>> incom;
     // Mark incoming jmps
     for (auto pc = srcCode->code(); pc != srcCode->endCode();) {
-        BC bc = BC::decode_shallow(pc);
+        BC bc = BC::decodeShallow(pc);
         if (bc.isJmp()) {
             incom[bc.jmpTarget(pc)].push_back(pc);
         }
@@ -108,7 +108,7 @@ std::unordered_set<Opcode*> findMergepoints(rir::Code* srcCode) {
     }
     // Mark falltrough to label
     for (auto pc = srcCode->code(); pc != srcCode->endCode();) {
-        BC bc = BC::decode_shallow(pc);
+        BC bc = BC::decodeShallow(pc);
         if (!bc.isUncondJmp() && !bc.isExit()) {
             Opcode* next = BC::next(pc);
             if (incom.count(next))
@@ -782,7 +782,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
                 for (int i = 0; i < 2 && n < end; ++i, n = BC::next(n))
                     ;
                 if (n < end) {
-                    auto nextbc = BC::decode(n, srcCode);
+                    auto nextbc = BC::decodeShallow(n);
                     if (nextbc.bc == Opcode::stvar_)
                         inner << ">"
                               << CHAR(PRINTNAME(nextbc.immediateConst()));

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -43,7 +43,7 @@ class Rir2Pir {
     std::string name;
 
     bool compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode, RirStack&,
-                   Builder&, std::unordered_map<Value*, CallFeedback>&,
+                   Builder&, std::unordered_map<Value*, std::vector<SEXP>>&,
                    std::unordered_map<Value*, TypeFeedback>&) const;
     virtual bool inPromise() const { return false; }
 };

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -263,7 +263,6 @@ BC BC::callImplicit(const std::vector<FunIdx>& args, SEXP ast) {
     im.callFixedArgs.nargs = args.size();
     im.callFixedArgs.ast = Pool::insert(ast);
     BC cur(Opcode::call_implicit_, im);
-    cur.allocExtraInformation();
     cur.callExtra().immediateCallArguments = args;
     return cur;
 }
@@ -276,7 +275,6 @@ BC BC::callImplicit(const std::vector<FunIdx>& args,
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
     BC cur(Opcode::named_call_implicit_, im);
-    cur.allocExtraInformation();
     cur.callExtra().immediateCallArguments = args;
     cur.callExtra().callArgumentNames = nameIdxs;
     return cur;
@@ -295,7 +293,6 @@ BC BC::call(size_t nargs, const std::vector<SEXP>& names, SEXP ast) {
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
     BC cur(Opcode::named_call_, im);
-    cur.allocExtraInformation();
     cur.callExtra().callArgumentNames = nameIdxs;
     return cur;
 }

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -262,7 +262,10 @@ BC BC::callImplicit(const std::vector<FunIdx>& args, SEXP ast) {
     ImmediateArguments im;
     im.callFixedArgs.nargs = args.size();
     im.callFixedArgs.ast = Pool::insert(ast);
-    return BC(Opcode::call_implicit_, im, args, {});
+    BC cur(Opcode::call_implicit_, im);
+    cur.allocExtraInformation();
+    cur.callExtra().immediateCallArguments = args;
+    return cur;
 }
 BC BC::callImplicit(const std::vector<FunIdx>& args,
                     const std::vector<SEXP>& names, SEXP ast) {
@@ -272,7 +275,11 @@ BC BC::callImplicit(const std::vector<FunIdx>& args,
     std::vector<PoolIdx> nameIdxs;
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
-    return BC(Opcode::named_call_implicit_, im, args, std::move(nameIdxs));
+    BC cur(Opcode::named_call_implicit_, im);
+    cur.allocExtraInformation();
+    cur.callExtra().immediateCallArguments = args;
+    cur.callExtra().callArgumentNames = nameIdxs;
+    return cur;
 }
 BC BC::call(size_t nargs, SEXP ast) {
     ImmediateArguments im;
@@ -287,7 +294,10 @@ BC BC::call(size_t nargs, const std::vector<SEXP>& names, SEXP ast) {
     std::vector<PoolIdx> nameIdxs;
     for (auto n : names)
         nameIdxs.push_back(Pool::insert(n));
-    return BC(Opcode::named_call_, im, {}, std::move(nameIdxs));
+    BC cur(Opcode::named_call_, im);
+    cur.allocExtraInformation();
+    cur.callExtra().callArgumentNames = nameIdxs;
+    return cur;
 }
 BC BC::staticCall(size_t nargs, SEXP ast, SEXP target) {
     ImmediateArguments im;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -196,7 +196,7 @@ class BC {
     SEXP immediateConst() const;
 
     inline static Opcode* jmpTarget(Opcode* pos) {
-        BC bc = BC::decodeShallow(pos);
+        BC bc = decodeShallow(pos);
         assert(bc.isJmp());
         return (Opcode*)((uintptr_t)pos + bc.size() + bc.immediate.offset);
     }

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -113,7 +113,7 @@ class CodeStream {
 
 #define INS(pc_) (reinterpret_cast<Opcode*>(&(*code)[(pc_)]))
 
-        unsigned bcSize = BC::decode_shallow(INS(pc)).size();
+        unsigned bcSize = BC::decodeShallow(INS(pc)).size();
 
         for (unsigned i = 0; i < bcSize; ++i) {
             *INS(pc + i) = Opcode::nop_;

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -113,7 +113,7 @@ class CodeStream {
 
 #define INS(pc_) (reinterpret_cast<Opcode*>(&(*code)[(pc_)]))
 
-        unsigned bcSize = BC::decode(INS(pc)).size();
+        unsigned bcSize = BC::decode_shallow(INS(pc)).size();
 
         for (unsigned i = 0; i < bcSize; ++i) {
             *INS(pc + i) = Opcode::nop_;

--- a/rir/src/ir/RuntimeFeedback.cpp
+++ b/rir/src/ir/RuntimeFeedback.cpp
@@ -9,7 +9,7 @@ RecordedType::RecordedType(SEXP s)
     : sexptype((uint8_t)TYPEOF(s)), scalar(IS_SCALAR(s, TYPEOF(s))),
       object(OBJECT(s)), attribs(ATTRIB(s) != R_NilValue) {}
 
-SEXP CallFeedback::getTarget(const Code* code, size_t pos) {
+SEXP CallFeedback::getTarget(const Code* code, size_t pos) const {
     assert(pos < numTargets);
     return code->getExtraPoolEntry(targets[pos]);
 }

--- a/rir/src/ir/RuntimeFeedback.cpp
+++ b/rir/src/ir/RuntimeFeedback.cpp
@@ -9,9 +9,9 @@ RecordedType::RecordedType(SEXP s)
     : sexptype((uint8_t)TYPEOF(s)), scalar(IS_SCALAR(s, TYPEOF(s))),
       object(OBJECT(s)), attribs(ATTRIB(s) != R_NilValue) {}
 
-SEXP CallFeedback::getTarget(size_t pos) {
+SEXP CallFeedback::getTarget(const Code* code, size_t pos) {
     assert(pos < numTargets);
-    return targets[pos];
+    return code->getExtraPoolEntry(targets[pos]);
 }
 
 } // namespace rir

--- a/rir/src/ir/RuntimeFeedback.h
+++ b/rir/src/ir/RuntimeFeedback.h
@@ -28,7 +28,7 @@ struct CallFeedback {
     uint32_t taken : CounterBits;
 
     RIR_INLINE void record(Code* caller, SEXP callee);
-    SEXP getTarget(const Code* code, size_t pos);
+    SEXP getTarget(const Code* code, size_t pos) const;
 
     std::array<unsigned, MaxTargets> targets;
 };

--- a/rir/src/ir/RuntimeFeedback.h
+++ b/rir/src/ir/RuntimeFeedback.h
@@ -28,9 +28,9 @@ struct CallFeedback {
     uint32_t taken : CounterBits;
 
     RIR_INLINE void record(Code* caller, SEXP callee);
-    SEXP getTarget(size_t pos);
+    SEXP getTarget(const Code* code, size_t pos);
 
-    std::array<SEXP, MaxTargets> targets;
+    std::array<unsigned, MaxTargets> targets;
 };
 
 struct RecordedType {
@@ -46,7 +46,7 @@ struct RecordedType {
 
     bool isObj() const { return object; }
 };
-static_assert(sizeof(CallFeedback) == 7 * sizeof(uint32_t),
+static_assert(sizeof(CallFeedback) == 4 * sizeof(uint32_t),
               "Size needs to fit inside a record_ bc immediate args");
 
 struct TypeFeedback {

--- a/rir/src/ir/RuntimeFeedback_inl.h
+++ b/rir/src/ir/RuntimeFeedback_inl.h
@@ -12,11 +12,11 @@ void CallFeedback::record(Code* caller, SEXP callee) {
     if (numTargets < MaxTargets) {
         int i = 0;
         for (; i < numTargets; ++i)
-            if (targets[i] == callee)
+            if (caller->getEntry(targets[i]) == callee)
                 break;
         if (i == numTargets) {
-            caller->addExtraPoolEntry(callee);
-            targets[numTargets++] = callee;
+            auto idx = caller->addExtraPoolEntry(callee);
+            targets[numTargets++] = idx;
         }
     }
 }

--- a/rir/src/ir/RuntimeFeedback_inl.h
+++ b/rir/src/ir/RuntimeFeedback_inl.h
@@ -12,7 +12,7 @@ void CallFeedback::record(Code* caller, SEXP callee) {
     if (numTargets < MaxTargets) {
         int i = 0;
         for (; i < numTargets; ++i)
-            if (caller->getEntry(targets[i]) == callee)
+            if (caller->getExtraPoolEntry(targets[i]) == callee)
                 break;
         if (i == numTargets) {
             auto idx = caller->addExtraPoolEntry(callee);

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -446,7 +446,7 @@ DEF_INSTR(deopt_, 1, -1, 0, 0)
  * They keep a struct from RuntimeFeedback.h inline, that's why they are quite
  * heavy in size.
  */
-DEF_INSTR(record_call_, 7, 1, 1, 0)
+DEF_INSTR(record_call_, 4, 1, 1, 0)
 DEF_INSTR(record_binop_, 2, 2, 2, 0)
 
 #undef DEF_INSTR

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -69,7 +69,7 @@ void Code::disassemble(std::ostream& out) const {
     std::map<Opcode*, size_t> targets;
     targets[pc] = label++;
     while (pc < endCode()) {
-        if (BC::decode_shallow(pc).isJmp()) {
+        if (BC::decodeShallow(pc).isJmp()) {
             auto t = BC::jmpTarget(pc);
             if (!targets.count(t))
                 targets[t] = label++;

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -69,7 +69,7 @@ void Code::disassemble(std::ostream& out) const {
     std::map<Opcode*, size_t> targets;
     targets[pc] = label++;
     while (pc < endCode()) {
-        if (BC::decode(pc).isJmp()) {
+        if (BC::decode_shallow(pc).isJmp()) {
             auto t = BC::jmpTarget(pc);
             if (!targets.count(t))
                 targets[t] = label++;
@@ -91,7 +91,7 @@ void Code::disassemble(std::ostream& out) const {
             out << ":\n";
         }
 
-        BC bc = BC::decode(pc);
+        BC bc = BC::decode(pc, this);
 
         const size_t OFFSET_WIDTH = 5;
         out << std::setw(OFFSET_WIDTH) << ((uintptr_t)pc - (uintptr_t)code());

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -119,7 +119,7 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     // 2. is added at runtime
     // Those elements can be added to the extra pool.
     unsigned addExtraPoolEntry(SEXP v);
-    SEXP getExtraPoolEntry(unsigned i) {
+    SEXP getExtraPoolEntry(unsigned i) const {
         assert(i < extraPoolSize);
         return VECTOR_ELT(getEntry(1), i);
     }

--- a/rir/src/runtime/RirRuntimeObject.h
+++ b/rir/src/runtime/RirRuntimeObject.h
@@ -42,11 +42,11 @@ struct RirRuntimeObject {
         EXTERNALSXP_SET_ENTRY(this->container(), pos, v);
     }
 
-    SEXP getEntry(size_t pos) {
+    SEXP getEntry(size_t pos) const {
         return EXTERNALSXP_ENTRY(this->container(), pos);
     }
 
-    SEXP container() {
+    SEXP container() const {
         // cppcheck-suppress thisSubtraction
         SEXP result = (SEXP)((uintptr_t)this - sizeof(VECTOR_SEXPREC));
         assert(TYPEOF(result) == EXTERNALSXP &&

--- a/rir/src/runtime/RirRuntimeObject.h
+++ b/rir/src/runtime/RirRuntimeObject.h
@@ -38,14 +38,6 @@ template <typename BASE, uint32_t MAGIC>
 struct RirRuntimeObject {
     rir_header info;
 
-    void setEntry(size_t pos, SEXP v) {
-        EXTERNALSXP_SET_ENTRY(this->container(), pos, v);
-    }
-
-    SEXP getEntry(size_t pos) const {
-        return EXTERNALSXP_ENTRY(this->container(), pos);
-    }
-
     SEXP container() const {
         // cppcheck-suppress thisSubtraction
         SEXP result = (SEXP)((uintptr_t)this - sizeof(VECTOR_SEXPREC));
@@ -71,6 +63,14 @@ struct RirRuntimeObject {
     }
 
   protected:
+    void setEntry(size_t pos, SEXP v) {
+        EXTERNALSXP_SET_ENTRY(this->container(), pos, v);
+    }
+
+    SEXP getEntry(size_t pos) const {
+        return EXTERNALSXP_ENTRY(this->container(), pos);
+    }
+
     RirRuntimeObject(uint32_t gc_area_start, uint32_t gc_area_length)
         : info{gc_area_start, gc_area_length, MAGIC} {
         uint8_t* start = (uint8_t*)this + gc_area_start;


### PR DESCRIPTION
after many iterations I think this PR finally strikes a balance between fast decoding of bytecodes and still having the option for bytecodes to refer to external data.

The high level idea is, that you do `BC::decode(pc)` and this will create a BC object, that captures all the required information of a BC, and that also lets you dump that bc to a `CodeStream` again.

This nice idea breaks down, if the BC refers to external data, or gets painfully slow if the BC it is variable length.

So in a recent PR i removed all the external dependencies and made BC contain everything necessary. But now I wanted to move the recorded call targets of the `record_call_` bytecode into the code object constant pool. This means that decoding a BC also needs to access the code object (to read out the actual targets).

The solution in this PR is twofold:

1. there are two decodes now: `decode_shallow` only reads local and fixed lenght information. This is enough get most of the bc and for example know its lenght and so on.
2. the full `decode` allocates (only if needed, ie. currently for `call_implicit`, `call_named` and `record_call`) an additional `ExtraInformation` struct, that contains all the variable length, or external data. This is needed if you want to print the BC in full, or write it again to a code stream.

As a concrete usecase this allows us to store the recorded call targets in the code object extra pool. When decoding a `record_call_`, we just read the targets from the extra pool and store them in a `RecordCallExtraInformation` struct that is associated with the BC object.

By moving the extra information into a heap allocated object, we shave the old `callArgumentNames` and `implicitCallArguments` from all the BC objects that don't need them. This should roughtly halve the size of most BC objects..