### PR TITLE
Clean up unnecessary jumps

### DIFF
--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -82,6 +82,22 @@ class CodeStream {
     }
 
     CodeStream& operator<<(BC::Label label) {
+
+        // get rid of unnecessary jumps
+        {
+            unsigned imm = pos - sizeof(BC::Jmp);
+            unsigned op = imm - sizeof(Opcode);
+            if (patchpoints.count(imm) && patchpoints[imm] == label) {
+                switch ((Opcode)(*code)[op]) {
+                case Opcode::br_:
+                    remove(op);
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
         labels[pos].push_back(label);
         return *this;
     }
@@ -144,6 +160,7 @@ class CodeStream {
         return res->index;
     }
 };
-}
+
+} // namespace rir
 
 #endif


### PR DESCRIPTION
Change this
```
   36   ...
   37   brfalse_ 2
   42   br_ 1
1:
   47   ...
   52   br_ 3
2:
   57   ...
   62   br_ 3
3:
   67   ...
```

to this
```
   36   ...
   37   brfalse_ 1
   42   ...
   47   br_ 2
1:
   52   ...
2:
   57   ...
```
