### PR TITLE
remove code->function pointer

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -34,7 +34,7 @@ REXPORT SEXP rir_disassemble(SEXP what, SEXP verbose) {
             continue;
         Function* f = t->at(entry);
         std::cout << "= vtable slot <" << entry << "> (" << f << ", invoked "
-                  << f->invocationCount << ") =\n";
+                  << f->invocationCount() << ") =\n";
         f->disassemble(std::cout);
     }
 
@@ -203,7 +203,7 @@ REXPORT SEXP rir_invocation_count(SEXP what) {
 
     SEXP res = Rf_allocVector(INTSXP, dt->capacity());
     for (size_t i = 0; i < dt->capacity(); ++i) {
-        INTEGER(res)[i] = dt->available(i) ? dt->at(i)->invocationCount : 0;
+        INTEGER(res)[i] = dt->available(i) ? dt->at(i)->invocationCount() : 0;
     }
 
     return res;

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -194,6 +194,7 @@ SEXP pirCompile(SEXP what, const std::string& name, pir::DebugOptions debug) {
     return what;
 }
 
+// Used in test infrastructure for counting invocation of different versions
 REXPORT SEXP rir_invocation_count(SEXP what) {
     if (!isValidClosureSEXP(what)) {
         Rf_error("not a compiled closure");
@@ -202,9 +203,8 @@ REXPORT SEXP rir_invocation_count(SEXP what) {
     assert(dt);
 
     SEXP res = Rf_allocVector(INTSXP, dt->capacity());
-    for (size_t i = 0; i < dt->capacity(); ++i) {
+    for (size_t i = 0; i < dt->capacity(); ++i)
         INTEGER(res)[i] = dt->available(i) ? dt->at(i)->invocationCount() : 0;
-    }
 
     return res;
 }

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -35,15 +35,6 @@ class TheVerifier {
                 return;
             }
         }
-        for (auto p : f->defaultArgs) {
-            if (p)
-                verify(p);
-            if (!ok) {
-                std::cerr << "Verification of argument failed\n";
-                p->print(std::cerr, true);
-                return;
-            }
-        }
     }
 
     void verify(BB* bb, const DominanceGraph& dom, const CFG& cfg) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -206,7 +206,6 @@ class TheCleanup {
         };
         renumberBBs(function);
         function->eachPromise(renumberBBs);
-        function->eachDefaultArg(renumberBBs);
     }
 };
 

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -26,8 +26,6 @@ Promise* Closure::createProm(unsigned srcPoolIdx) {
 Closure::~Closure() {
     for (auto p : promises)
         delete p;
-    for (auto p : defaultArgs)
-        delete p;
 }
 
 Closure* Closure::clone() {

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -57,9 +57,10 @@ class Closure : public Code {
     rir::Function* rirVersion() { return function; }
 
     std::vector<SEXP> argNames;
-    std::vector<Promise*> defaultArgs;
     std::vector<Promise*> promises;
     ProfiledValues runtimeFeedback;
+
+    size_t nargs() const { return argNames.size(); }
 
     void print(std::ostream& out, bool tty) const;
 
@@ -75,12 +76,6 @@ class Closure : public Code {
     ~Closure();
 
     typedef std::function<void(Promise*)> PromiseIterator;
-
-    void eachDefaultArg(PromiseIterator it) const {
-        for (auto p : defaultArgs)
-            if (p)
-                it(p);
-    }
 
     void eachPromise(PromiseIterator it) const {
         for (auto p : promises)

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -153,18 +153,17 @@ bool compileAndVerify(const std::string& input) {
 
 void insertTypeFeedbackForBinops(rir::Function* srcFunction,
                                  std::array<SEXP, 2> typeFeedback) {
-    for (auto function : *srcFunction) {
-        Opcode* end = function->endCode();
-        Opcode* finger = function->code();
-        while (finger != end) {
-            Opcode* prev = finger;
-            BC bc = BC::advance(&finger, function);
-            if (bc.bc == Opcode::record_binop_) {
-                prev++;
-                ObservedValues* feedback = (ObservedValues*)prev;
-                feedback[0].record(typeFeedback[0]);
-                feedback[1].record(typeFeedback[1]);
-            }
+    auto function = srcFunction->body();
+    Opcode* end = function->endCode();
+    Opcode* finger = function->code();
+    while (finger != end) {
+        Opcode* prev = finger;
+        BC bc = BC::advance(&finger, function);
+        if (bc.bc == Opcode::record_binop_) {
+            prev++;
+            ObservedValues* feedback = (ObservedValues*)prev;
+            feedback[0].record(typeFeedback[0]);
+            feedback[1].record(typeFeedback[1]);
         }
     }
 }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -241,7 +241,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
                 log.warn("Cannot compile call with explicit missing arguments");
                 return false;
             }
-            rir::Code* promiseCode = srcFunction->codeAt(argi);
+            rir::Code* promiseCode = srcCode->getPromise(argi);
             Promise* prom = insert.function->createProm(promiseCode->src);
             {
                 Builder promiseBuilder(insert.function, prom);
@@ -303,7 +303,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
 
     case Opcode::promise_: {
         unsigned promi = bc.immediate.i;
-        rir::Code* promiseCode = srcFunction->codeAt(promi);
+        rir::Code* promiseCode = srcCode->getPromise(promi);
         Value* val = pop();
         Promise* prom = insert.function->createProm(promiseCode->src);
         {
@@ -778,7 +778,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
                 }
             }
             inner << "@";
-            if (srcCode != srcCode->function()->body()) {
+            if (srcCode != srcFunction->body()) {
                 size_t i = 0;
                 for (auto c : insert.function->promises) {
                     if (c == insert.code) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -983,9 +983,6 @@ RIR_INLINE SEXP findRootPromise(SEXP p) {
     return p;
 }
 
-extern void printCode(Code* c);
-extern void printFunction(Function* f);
-
 extern SEXP Rf_deparse1(SEXP call, Rboolean abbrev, int opts);
 
 void debug(Code* c, Opcode* pc, const char* name, unsigned depth,

--- a/rir/src/interpreter/runtime.cpp
+++ b/rir/src/interpreter/runtime.cpp
@@ -26,49 +26,6 @@ Function* isValidClosureSEXP(SEXP closure) {
     return nullptr;
 }
 
-// for now, we will have to rewrite this when it goes to GNU-R proper
-
-void printFunction(Function* f, std::ostream& out) {
-    out << "Function object (" << static_cast<void*>(f) << "):\n";
-    out << std::left << std::setw(20) << "  Magic:" << std::hex << f->info.magic
-        << std::dec << " (hex)\n";
-    out << std::left << std::setw(20) << "  Size:" << f->size << "\n";
-    out << std::left << std::setw(20) << "  Origin:";
-    if (f->origin()) {
-        out << static_cast<void*>(f->origin()) << "\n";
-    } else {
-        out << "(nil) (unoptimized)\n";
-    }
-    out << std::left << std::setw(20) << "  Next:";
-    if (f->next()) {
-        out << f->next() << "\n";
-    } else {
-        out << "(nil)"
-            << "\n";
-    }
-    out << std::left << std::setw(20) << "  Code objects:" << f->codeLength
-        << "\n";
-    out << std::left << std::setw(20)
-        << "  Fun code addr:" << static_cast<void*>(f->body()) << "\n";
-    out << std::left << std::setw(20) << "  Invoked:" << f->invocationCount
-        << "\n";
-    out << std::left << std::setw(20) << "  Signature:";
-    if (f->signature) {
-        out << static_cast<void*>(f->signature) << "\n";
-        f->signature->print(out);
-    } else {
-        out << "(nil)"
-            << "\n";
-    }
-
-    if (f->info.magic != FUNCTION_MAGIC)
-        Rf_error("Wrong magic number -- not rir bytecode");
-
-    // print respective code objects
-    for (Code* c : *f)
-        c->print(out);
-}
-
 void initializeRuntime() {
     envSymbol = Rf_install("environment");
     callSymbol = Rf_install(".Call");

--- a/rir/src/interpreter/runtime.h
+++ b/rir/src/interpreter/runtime.h
@@ -17,8 +17,6 @@ typedef rir::DispatchTable DispatchTable;
 
 Function* isValidClosureSEXP(SEXP closure);
 
-void printFunction(Function* f, std::ostream& out = std::cout);
-
 void initializeRuntime();
 
 /** Returns the global context for the interpreter - important to get access to

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -213,6 +213,21 @@ class BC {
                bc == Opcode::push_code_;
     }
 
+    void addPromargsTo(std::vector<FunIdx>& proms) {
+        switch (bc) {
+        case Opcode::push_code_:
+        case Opcode::promise_:
+            proms.push_back(immediate.arg_idx);
+            break;
+        case Opcode::named_call_implicit_:
+        case Opcode::call_implicit_:
+            for (auto a : callExtra().immediateCallArguments)
+                proms.push_back(a);
+            break;
+        default: {}
+        }
+    }
+
     bool isCondJmp() const {
         return bc == Opcode::brtrue_ || bc == Opcode::brfalse_ ||
                bc == Opcode::brobj_ || bc == Opcode::beginloop_;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -213,7 +213,7 @@ class BC {
                bc == Opcode::push_code_;
     }
 
-    void addPromargsTo(std::vector<FunIdx>& proms) {
+    void addMyPromArgsTo(std::vector<FunIdx>& proms) {
         switch (bc) {
         case Opcode::push_code_:
         case Opcode::promise_:

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -92,7 +92,7 @@ void Code::disassemble(std::ostream& out, std::string prefix) const {
         }
 
         BC bc = BC::decode(pc, this);
-        bc.addPromargsTo(promises);
+        bc.addMyPromArgsTo(promises);
 
         const size_t OFFSET_WIDTH = 7;
         out << std::right << std::setw(OFFSET_WIDTH)

--- a/rir/src/runtime/Function.cpp
+++ b/rir/src/runtime/Function.cpp
@@ -3,11 +3,5 @@
 namespace rir {
 void Function::disassemble(std::ostream& out) {
     body()->disassemble(out);
-    for (auto c : *this) {
-        if (c != body()) {
-            out << "\n[Prom (index " << c->index << ")]\n";
-            c->disassemble(out);
-        }
-    }
 }
 } // namespace rir


### PR DESCRIPTION
this removes the pointer from code objects to their function. Thus
this prevents escaping promises from keeping functions live.

To that end we change the function format from

    Function
      Code* promises[]    // list of body, formal args and all (nexted) promises

    Code
      justBC

to:

    Function
      Code* defaultArgs[]
      Code* body

    Code
      Code* promises[]
      justBC

Note: this leads to nested promises. For example `function() a(b(c,d))` is:

    function -> a -> b --> c
                       \-> d