### PR TITLE
fix unprotected promises before functions are finalized

### DIFF
--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1163,16 +1163,14 @@ rir::Function* Pir2Rir::finalize() {
     FunctionWriter function;
     Context ctx(function);
 
-    // PIR does not support default args currently. So we just pass an empty
-    // array, since functions are expected to have a slot reserved for every
-    // argument.
-    std::vector<SEXP> defaultArgs;
-    defaultArgs.resize(cls->nargs());
+    // PIR does not support default args currently.
+    for (size_t i = 0; i < cls->nargs(); ++i)
+        function.addArgWithoutDefault();
 
     ctx.push(R_NilValue);
     size_t localsCnt = compileCode(ctx, cls);
     auto body = ctx.finalizeCode(localsCnt);
-    function.finalize(body, defaultArgs);
+    function.finalize(body);
     log.finalPIR(cls);
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(function.function()->container(),

--- a/rir/src/ir/CodeStream.h
+++ b/rir/src/ir/CodeStream.h
@@ -26,6 +26,7 @@ class CodeStream {
     unsigned nops = 0;
 
     FunctionWriter& function;
+    Preserve preserve;
 
     SEXP ast;
 
@@ -51,6 +52,7 @@ class CodeStream {
     CodeStream& operator=(const CodeStream& other) = delete;
 
     size_t addPromise(Code* code) {
+        preserve(code->container());
         auto s = promises.size();
         promises.push_back(code);
         return s;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -908,15 +908,13 @@ SEXP Compiler::finalize() {
 
     FunctionSignature* signature = new FunctionSignature();
 
-    std::vector<SEXP> defaultArgs;
-
     // Compile formals (if any) and create signature
     for (auto arg = RList(formals).begin(); arg != RList::end(); ++arg) {
         if (*arg == R_MissingArg) {
-            defaultArgs.push_back(nullptr);
+            function.addArgWithoutDefault();
         } else {
             auto compiled = compilePromise(ctx, *arg);
-            defaultArgs.push_back(compiled->container());
+            function.addDefaultArg(compiled);
         }
         signature->pushDefaultArgument();
     }
@@ -925,7 +923,7 @@ SEXP Compiler::finalize() {
     compileExpr(ctx, exp);
     ctx.cs() << BC::ret();
     auto body = ctx.pop();
-    function.finalize(body, defaultArgs);
+    function.finalize(body);
 
     function.function()->signature = signature;
 

--- a/rir/src/utils/FunctionWriter.h
+++ b/rir/src/utils/FunctionWriter.h
@@ -18,11 +18,11 @@ namespace rir {
 class FunctionWriter {
   private:
     Function* function_;
+    std::vector<SEXP> defaultArgs;
+    Preserve preserve;
 
   public:
     typedef unsigned PcOffset;
-
-    Preserve preserve;
 
     FunctionWriter() : function_(nullptr) {}
 
@@ -33,7 +33,14 @@ class FunctionWriter {
         return function_;
     }
 
-    void finalize(Code* body, std::vector<SEXP>& defaultArgs) {
+    void addArgWithoutDefault() { defaultArgs.push_back(nullptr); }
+
+    void addDefaultArg(Code* code) {
+        preserve(code->container());
+        defaultArgs.push_back(code->container());
+    }
+
+    void finalize(Code* body) {
         assert(function_ == nullptr && "Trying to finalize a second time");
 
         size_t dataSize = defaultArgs.size() * sizeof(SEXP);


### PR DESCRIPTION
a GC could release the compiled promises, since they are only reachable
through the function.

thanks @JanJecmen for pointing this out