### PR TITLE
add framestate to the call instructions

### DIFF
--- a/rir/src/compiler/opt/cleanup_framestate.cpp
+++ b/rir/src/compiler/opt/cleanup_framestate.cpp
@@ -9,6 +9,12 @@ namespace pir {
 
 void CleanupFrameState::apply(Closure* function) const {
     auto apply = [](Code* code) {
+        Visitor::run(code->entry, [&](Instruction* i) {
+            if (auto call = CallInstruction::CastCall(i)) {
+                call->clearFrameState();
+            }
+        });
+
         Visitor::run(code->entry, [&](BB* bb) {
             auto it = bb->begin();
             while (it != bb->end()) {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -385,6 +385,10 @@ void MkFunCls::printArgs(std::ostream& out, bool tty) {
 void StaticCall::printArgs(std::ostream& out, bool tty) {
     out << *cls_;
     printCallArgs(out, this);
+    if (frameState()) {
+        frameState()->printRef(out);
+        out << ", ";
+    }
 }
 
 CallInstruction* CallInstruction::CastCall(Value* v) {
@@ -421,6 +425,10 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
 void Call::printArgs(std::ostream& out, bool tty) {
     cls()->printRef(out);
     printCallArgs(out, this);
+    if (frameState()) {
+        frameState()->printRef(out);
+        out << ", ";
+    }
 }
 
 void NamedCall::printArgs(std::ostream& out, bool tty) {

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -43,6 +43,15 @@ class Missing : public SingletonValue<Missing> {
     friend class SingletonValue;
     Missing() : SingletonValue(PirType::missing(), Tag::Missing) {}
 };
+
+class Tombstone : public SingletonValue<Tombstone> {
+  public:
+    void printRef(std::ostream& out) { out << "~"; }
+
+  private:
+    friend class SingletonValue;
+    Tombstone() : SingletonValue(PirType::voyd(), Tag::Tombstone) {}
+};
 }
 }
 

--- a/rir/src/compiler/pir/value_list.h
+++ b/rir/src/compiler/pir/value_list.h
@@ -2,6 +2,7 @@
 #define COMPILER_VALUE_LIST_H
 
 #define COMPILER_VALUES(V)                                                     \
+    V(Tombstone)                                                               \
     V(Missing)                                                                 \
     V(Env)                                                                     \
     V(Nil)

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -715,6 +715,9 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
                 auto loadArg = [&](BB::Instrs::iterator it, Instruction* instr,
                                    Value* what) {
+                    if (what == Tombstone::instance()) {
+                        return;
+                    }
                     if (what == Missing::instance()) {
                         // if missing flows into instructions with more than one
                         // arg we will need stack shuffling here
@@ -1031,6 +1034,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 break;
             }
             // values, not instructions
+            case Tag::Tombstone:
             case Tag::Missing:
             case Tag::Env:
             case Tag::Nil:
@@ -1188,9 +1192,9 @@ rir::Function* Pir2Rir::finalize() {
 
     ctx.push(R_NilValue);
     size_t localsCnt = compileCode(ctx, cls);
+    log.finalPIR(cls);
     auto body = ctx.finalizeCode(localsCnt);
     function.finalize(body);
-    log.finalPIR(cls);
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(function.function()->container(),
                                        globalContext());

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -130,7 +130,7 @@ std::unordered_set<Opcode*> findMergepoints(rir::Code* srcCode) {
 namespace rir {
 namespace pir {
 
-bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
+bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos, rir::Code* srcCode,
                         RirStack& stack, Builder& insert) const {
     Value* env = insert.env;
 
@@ -272,12 +272,14 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
 
         auto ast = bc.immediate.callFixedArgs.ast;
         auto insertGenericCall = [&]() {
-            if (bc.bc == Opcode::named_call_implicit_)
+            if (bc.bc == Opcode::named_call_implicit_) {
                 push(insert(new NamedCall(insert.env, pop(), args,
                                           bc.callExtra().callArgumentNames,
                                           ast)));
-            else
-                push(insert(new Call(insert.env, pop(), args, ast)));
+            } else {
+                auto fs = insert.registerFrameState(srcCode, nextPos, stack);
+                push(insert(new Call(insert.env, pop(), args, fs, ast)));
+            }
         };
         if (monomorphic && isValidClosureSEXP(monomorphic)) {
             std::string name = "";
@@ -291,8 +293,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
 
                     insert.conditionalDeopt(t, srcCode, pos, stack, true);
                     pop();
+                    auto fs = insert.registerFrameState(srcCode, nextPos, stack);
                     push(insert(
-                        new StaticCall(insert.env, f, args, monomorphic, ast)));
+                        new StaticCall(insert.env, f, args, monomorphic, fs, ast)));
                 },
                 insertGenericCall);
         } else {
@@ -325,13 +328,15 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
             args[n - i - 1] = pop();
 
         auto target = pop();
-        if (bc.bc == Opcode::named_call_)
+        if (bc.bc == Opcode::named_call_) {
             push(insert(new NamedCall(env, target, args,
                                       bc.callExtra().callArgumentNames,
                                       bc.immediate.callFixedArgs.ast)));
-        else
+        } else {
+            auto fs = insert.registerFrameState(srcCode, nextPos, stack);
             push(insert(
-                new Call(env, target, args, bc.immediate.callFixedArgs.ast)));
+                new Call(env, target, args, fs, bc.immediate.callFixedArgs.ast)));
+        }
         break;
     }
 
@@ -361,7 +366,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode,
             compiler.compileClosure(
                 target, "",
                 [&](Closure* f) {
-                    push(insert(new StaticCall(env, f, args, target, ast)));
+                    auto fs = insert.registerFrameState(srcCode, nextPos, stack);
+                    push(insert(new StaticCall(env, f, args, target, fs, ast)));
                 },
                 [&]() { failed = true; });
             if (failed) {
@@ -809,7 +815,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
 
         if (!skip) {
             int size = cur.stack.size();
-            if (!compileBC(bc, pos, srcCode, cur.stack, insert)) {
+            if (!compileBC(bc, pos, nextPos, srcCode, cur.stack, insert)) {
                 log.failed("Abort r2p due to unsupported bc");
                 return nullptr;
             }
@@ -822,9 +828,6 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
                           << size << " to " << cur.stack.size() << "\n";
                 assert(false);
                 return nullptr;
-            }
-            if (bc.isCall()) {
-                insert.registerFrameState(srcCode, nextPos, cur.stack);
             }
         }
     }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -42,7 +42,7 @@ class Rir2Pir {
     LogStream& log;
     std::string name;
 
-    bool compileBC(const BC& bc, Opcode* pos, rir::Code* srcCode, RirStack&,
+    bool compileBC(const BC& bc, Opcode* pos, Opcode* nextPos, rir::Code* srcCode, RirStack&,
                    Builder&) const;
     virtual bool inPromise() const { return false; }
 };


### PR DESCRIPTION
for inlining we need a framestate that corresponds to the call instruction.
we used to just put a framestate after the call and then let the inliner
linearly search for it. This commit places the framestate right before
the call (which is more correct) and adds it as an argument to the call
instruction. thanks to that it is always unambiguous which framestate belongs
to the call.