### PR TITLE
Inline prom call

### DIFF
--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -15,16 +15,6 @@ bool Query::noEnv(Code* c) {
                           [](Instruction* i) { return !MkEnv::Cast(i); });
 }
 
-bool Query::envOnlyBeforeDeopt(Code* c) {
-    return Visitor::check(c->entry, [&](BB* bb) -> bool {
-        for (auto& i : *bb) {
-            if (MkEnv::Cast(i))
-                return Deopt::Cast(bb->last());
-        }
-        return true;
-    });
-}
-
 bool Query::pure(Code* c) {
     return Visitor::check(c->entry, [](Instruction* i) {
         return !i->hasEffect() && !i->changesEnv();

--- a/rir/src/compiler/analysis/query.h
+++ b/rir/src/compiler/analysis/query.h
@@ -16,7 +16,6 @@ class Query {
   public:
     static bool pure(Code* c);
     static bool noEnv(Code* c);
-    static bool envOnlyBeforeDeopt(Code* c);
     static bool noDeopt(Code* c);
     static std::unordered_set<Value*> returned(Code* c);
 };

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -67,8 +67,13 @@ class TheCleanup {
                             usedBB[curBB].insert(phi);
                     }
                 } else if (auto arg = MkArg::Cast(i)) {
-                    used_p.insert(arg->prom()->id);
-                    todo.push_back(arg->prom());
+                    if (arg->unused()) {
+                        removed = true;
+                        next = bb->remove(ip);
+                    } else {
+                        used_p.insert(arg->prom()->id);
+                        todo.push_back(arg->prom());
+                    }
                 } else if (auto shared = SetShared::Cast(i)) {
                     if (i->unused()) {
                         removed = true;

--- a/rir/src/compiler/opt/cleanup_checkpoints.cpp
+++ b/rir/src/compiler/opt/cleanup_checkpoints.cpp
@@ -1,0 +1,35 @@
+#include "../pir/pir_impl.h"
+#include "../transform/bb.h"
+#include "../transform/replace.h"
+#include "../util/cfg.h"
+#include "../util/visitor.h"
+#include "pass_definitions.h"
+
+namespace rir {
+namespace pir {
+
+void CleanupCheckpoints::apply(RirCompiler&, Closure* function) const {
+    auto apply = [](Code* code) {
+        std::unordered_set<BB*> toDelete;
+        Visitor::run(code->entry, [&](BB* bb) {
+            if (bb->isEmpty())
+                return;
+            if (auto cp = Checkpoint::Cast(bb->last())) {
+                if (cp->unused()) {
+                    bb->remove(bb->end() - 1);
+                    toDelete.insert(bb->next1);
+                    assert(bb->next1->isExit() &&
+                           "deopt blocks should be just one BB");
+                    bb->next1 = nullptr;
+                }
+            }
+        });
+        BBTransform::removeBBs(code, toDelete);
+    };
+    apply(function);
+    for (auto& p : function->promises)
+        if (p)
+            apply(p);
+}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/cleanup_framestate.cpp
+++ b/rir/src/compiler/opt/cleanup_framestate.cpp
@@ -7,7 +7,7 @@
 namespace rir {
 namespace pir {
 
-void CleanupFrameState::apply(Closure* function) const {
+void CleanupFrameState::apply(RirCompiler&, Closure* function) const {
     auto apply = [](Code* code) {
         Visitor::run(code->entry, [&](Instruction* i) {
             if (auto call = CallInstruction::CastCall(i)) {

--- a/rir/src/compiler/opt/cleanup_framestate.cpp
+++ b/rir/src/compiler/opt/cleanup_framestate.cpp
@@ -1,4 +1,5 @@
 #include "../pir/pir_impl.h"
+#include "../transform/bb.h"
 #include "../transform/replace.h"
 #include "../util/cfg.h"
 #include "../util/visitor.h"
@@ -7,23 +8,11 @@
 namespace rir {
 namespace pir {
 
-void CleanupFrameState::apply(RirCompiler&, Closure* function) const {
+void CleanupFramestate::apply(RirCompiler&, Closure* function) const {
     auto apply = [](Code* code) {
         Visitor::run(code->entry, [&](Instruction* i) {
             if (auto call = CallInstruction::CastCall(i)) {
                 call->clearFrameState();
-            }
-        });
-
-        Visitor::run(code->entry, [&](BB* bb) {
-            auto it = bb->begin();
-            while (it != bb->end()) {
-                auto next = it + 1;
-                if (auto sp = FrameState::Cast(*it)) {
-                    if (sp->unused())
-                        next = bb->remove(it);
-                }
-                it = next;
             }
         });
     };

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -1,0 +1,145 @@
+#include "../pir/pir_impl.h"
+#include "../transform/replace.h"
+#include "../translations/rir_compiler.h"
+#include "../util/cfg.h"
+#include "../util/visitor.h"
+#include "R/Symbols.h"
+#include "pass_definitions.h"
+
+#include <unordered_set>
+
+namespace {
+
+using namespace rir::pir;
+
+static LdConst* isConst(Value* instr) {
+    if (auto shared = SetShared::Cast(instr)) {
+        instr = shared->arg<0>().val();
+    }
+    if (auto cst = LdConst::Cast(instr)) {
+        return cst;
+    }
+    return nullptr;
+}
+
+#define FOLD(Instruction, Operation)                                           \
+    do {                                                                       \
+        if (auto instr = Instruction::Cast(i)) {                               \
+            if (auto lhs = isConst(instr->arg<0>().val())) {                   \
+                if (auto rhs = isConst(instr->arg<1>().val())) {               \
+                    auto res = Rf_eval(Rf_lang3(Operation, lhs->c, rhs->c),    \
+                                       R_BaseEnv);                             \
+                    cmp.preserve(res);                                         \
+                    auto resi = new LdConst(res);                              \
+                    instr->replaceUsesWith(resi);                              \
+                    bb->replace(ip, resi);                                     \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+    } while (false)
+
+#define FOLD2(__i__, Instruction, Operation)                                   \
+    do {                                                                       \
+        if (auto instr = Instruction::Cast(__i__)) {                           \
+            if (auto lhs = isConst(instr->arg<0>().val())) {                   \
+                if (auto rhs = isConst(instr->arg<1>().val())) {               \
+                    Operation(lhs->c, rhs->c);                                 \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+    } while (false)
+
+} // namespace
+
+namespace rir {
+namespace pir {
+
+void Constantfold::apply(RirCompiler& cmp, Closure* function) const {
+    std::unordered_map<BB*, bool> branchRemoval;
+    DominanceGraph dom(function);
+
+    Visitor::run(function->entry, [&](BB* bb) {
+        if (bb->isEmpty())
+          return;
+        for (auto ip = bb->begin(); ip != bb->end(); ++ip) {
+            auto i = *ip;
+
+            // Constantfolding of some common operations
+            FOLD(Add, symbol::Add);
+            FOLD(Sub, symbol::Sub);
+            FOLD(Mul, symbol::Mul);
+            FOLD(Div, symbol::Div);
+            FOLD(IDiv, symbol::Idiv);
+            FOLD(Lt, symbol::Lt);
+            FOLD(Gt, symbol::Gt);
+            FOLD(Lte, symbol::Le);
+            FOLD(Gte, symbol::Ge);
+            FOLD(Eq, symbol::Eq);
+            FOLD(Neq, symbol::Ne);
+            FOLD(Pow, symbol::Pow);
+        }
+
+        if (auto branch = Branch::Cast(bb->last())) {
+            if (auto tst = AsTest::Cast(branch->arg<0>().val())) {
+                // Try to detect constant branch conditions and mark such
+                // branches for removal
+                auto cnst = isConst(tst->arg<0>().val());
+                if (!cnst)
+                    if (auto lgl = AsLogical::Cast(tst->arg<0>().val()))
+                        cnst = isConst(lgl->arg<0>().val());
+                if (cnst) {
+                    SEXP c = cnst->c;
+                    // Non length 1 condition throws warning
+                    if (Rf_length(c) == 1) {
+                        auto cond = Rf_asLogical(c);
+                        // NA throws an error
+                        if (cond != NA_LOGICAL) {
+                            branchRemoval.emplace(bb, cond);
+                        }
+                    }
+                }
+
+                // If the `Identical` instruction can be resolved statically,
+                // use it for branch removal as well.
+                FOLD2(tst->arg<0>().val(), Identical, [&](SEXP a, SEXP b) {
+                    branchRemoval.emplace(bb, a == b);
+                });
+            }
+        }
+    });
+
+    std::vector<BB*> deleted;
+    // Find all dead basic blocks
+    for (auto e : branchRemoval) {
+        auto branch = e.first;
+        auto dead = e.second ? branch->next1 : branch->next0;
+        Visitor::run(dead, [&](BB* child) {
+            if (dead != branch && dom.dominates(child, dead))
+                deleted.push_back(child);
+        });
+        deleted.push_back(dead);
+    }
+    // Dead code can still appear as phi inputs in live blocks
+    Visitor::run(function->entry, [&](Instruction* i) {
+        if (auto phi = Phi::Cast(i)) {
+            phi->removeInputs(deleted);
+        }
+    });
+    // Remove the actual branch instruction
+    for (auto e : branchRemoval) {
+        auto branch = e.first;
+        auto condition = e.second;
+        branch->remove(branch->end() - 1);
+        if (condition) {
+            branch->next1 = nullptr;
+        } else {
+            branch->next0 = branch->next1;
+            branch->next1 = nullptr;
+        }
+    }
+    // Delete dead blocks
+    for (auto bb : deleted)
+        delete bb;
+}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -9,7 +9,7 @@
 namespace rir {
 namespace pir {
 
-void DelayEnv::apply(Closure* function) const {
+void DelayEnv::apply(RirCompiler&, Closure* function) const {
     Visitor::run(function->entry, [&](BB* bb) {
         std::unordered_set<MkEnv*> done;
         MkEnv* envInstr;

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -6,7 +6,7 @@
 namespace rir {
 namespace pir {
 
-void DelayInstr::apply(Closure* function) const {
+void DelayInstr::apply(RirCompiler&, Closure* function) const {
     std::vector<MkEnv*> envs;
 
     Visitor::run(function->entry, [&](BB* bb) {

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -9,7 +9,7 @@
 namespace rir {
 namespace pir {
 
-void ElideEnv::apply(Closure* function) const {
+void ElideEnv::apply(RirCompiler&, Closure* function) const {
     std::unordered_set<Value*> envNeeded;
     std::unordered_map<Value*, Value*> envDependency;
 

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -10,7 +10,7 @@
 namespace rir {
 namespace pir {
 
-void ElideEnvSpec::apply(Closure* function) const {
+void ElideEnvSpec::apply(RirCompiler&, Closure* function) const {
 
     // Elide environments of binary operators in which both operators are
     // primitive values

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -215,7 +215,7 @@ class TheInliner {
 namespace rir {
 namespace pir {
 
-void Inline::apply(Closure* function) const {
+void Inline::apply(RirCompiler&, Closure* function) const {
     TheInliner s(function);
     s();
 }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -61,6 +61,9 @@ class TheInliner {
                     continue;
                 }
 
+                if (inlinee == function && fuel < 5)
+                    continue;
+
                 fuel--;
 
                 BB* split =

--- a/rir/src/compiler/opt/insert_checkpoints.cpp
+++ b/rir/src/compiler/opt/insert_checkpoints.cpp
@@ -10,8 +10,7 @@
 namespace rir {
 namespace pir {
 
-void insertCheckpoints::apply(Closure* function) const {
-
+void insertCheckpoints::apply(RirCompiler&, Closure* function) const {
     Visitor::run(function->entry, [&](BB* bb) {
         if (bb->isEmpty())
             return;

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -14,7 +14,7 @@ class Closure;
     PirTranslator {                                                            \
       public:                                                                  \
         name() : PirTranslator(desc){};                                        \
-        void apply(Closure* function) const final override;                    \
+        void apply(RirCompiler&, Closure* function) const final override;      \
     };
 
 /*
@@ -91,11 +91,14 @@ class PASS(
  * incompatible input appears at run time.
  */
 class PASS(ElideEnvSpec, "Speculate on values to elide environments");
+class PASS(Constantfold, "Constant folding");
 
 class PASS(Cleanup, "Cleanup redundant operations");
 class PASS(CleanupFrameState, "Cleanup targeted only to frameStates");
 
 } // namespace pir
 } // namespace rir
+
+#undef PASS
 
 #endif

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -24,7 +24,7 @@ class Closure;
  * environment, to pir SSA variables.
  *
  */
-class PASS(ScopeResolution, "Dead store elimination");
+class PASS(ScopeResolution, "Scope resolution");
 
 /*
  * ElideEnv removes envrionments which are not needed. It looks at all uses of
@@ -44,13 +44,13 @@ class PASS(ElideEnv, "Elide environments not needed");
  * dominating force, and replaces all subsequent forces with its result.
  *
  */
-class PASS(ForceDominance, "Eliminate redundant force instructions");
+class PASS(ForceDominance, "Inline Promises");
 
 /*
  * DelayInstr tries to schedule instructions right before they are needed.
  *
  */
-class PASS(DelayInstr, "Eliminate redundant force instructions");
+class PASS(DelayInstr, "Delay instructions");
 
 /*
  * The DelayEnv pass tries to delay the scheduling of `MkEnv` instructions as
@@ -91,10 +91,31 @@ class PASS(
  * incompatible input appears at run time.
  */
 class PASS(ElideEnvSpec, "Speculate on values to elide environments");
+
+/*
+ * Constantfolding and dead branch removal.
+ */
 class PASS(Constantfold, "Constant folding");
 
+/*
+ * Generic instruction and controlflow cleanup pass.
+ */
 class PASS(Cleanup, "Cleanup redundant operations");
-class PASS(CleanupFrameState, "Cleanup targeted only to frameStates");
+
+/*
+ * Checkpoints keep values alive. Thus it makes sense to remove them if they
+ * are unused after a while.
+ */
+class PASS(CleanupCheckpoints, "Cleanup unused checkpoints");
+
+/*
+ * Unused framestate instructions usually get removed automatically. Except
+ * some call instructions consume framestates, but just for the case where we
+ * want to inline. This pass removes those framestates from the calls, such
+ * that they can be removed later, if they are not actually used by any
+ * checkpoint/deopt.
+ */
+class PASS(CleanupFramestate, "Cleanup framestates unused by checkpoints");
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -159,7 +159,7 @@ class TheScopeResolution {
 namespace rir {
 namespace pir {
 
-void ScopeResolution::apply(Closure* function) const {
+void ScopeResolution::apply(RirCompiler&, Closure* function) const {
     TheScopeResolution s(function);
     s();
 }

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -37,7 +37,13 @@ class TheScopeResolution {
                 else if (ldfun)
                     ld = ldfun;
 
-                if (sld) {
+                if (ldfun && ldfun->guessedBinding() &&
+                    ldfun->guessedBinding()->type.isA(PirType::closure())) {
+                    // If we inferred that a guessd ldfun binding is a closure
+                    // for sure, then we can replace the ldfun with the guess.
+                    ldfun->replaceUsesWith(ldfun->guessedBinding());
+                    next = bb->remove(ip);
+                } else if (sld) {
                     // LdVarSuper where the parent environment is known and
                     // local, can be replaced by a simple LdVar
                     auto e = Env::parentEnv(sld->env());
@@ -87,19 +93,17 @@ class TheScopeResolution {
                     } else if (onlyLocalVals) {
                         auto replaceLdFun = [&](Value* val) {
                             if (val->type.isA(PirType::closure())) {
-                                next = bb->remove(ip);
                                 ld->replaceUsesWith(val);
+                                next = bb->remove(ip);
                                 return;
                             }
-                            // TODO: for now, turn this off if the value may
-                            // need forcing
-                            //       (because we need a way to get the
-                            //       environment where the ldfun would be
-                            //       executed)
-                            if (!val->type.maybeLazy()) {
-                                auto ch = new ChkClosure(val);
-                                bb->replace(ip, ch);
-                                ld->replaceUsesWith(ch);
+                            // Add the binding as a guess. If we later infer
+                            // that the guess is a closure, we can promote it.
+                            if (!ldfun->guessedBinding()) {
+                                ip = bb->insert(ip,
+                                                new Force(val, ldfun->env()));
+                                ldfun->guessedBinding(*ip);
+                                next = ip + 2;
                             }
                         };
                         // This load can be resolved to a unique value

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -203,6 +203,11 @@ void LdVar::printArgs(std::ostream& out, bool tty) {
 
 void LdFun::printArgs(std::ostream& out, bool tty) {
     out << CHAR(PRINTNAME(varName)) << ", ";
+    if (guessedBinding()) {
+        out << "<";
+        guessedBinding()->printRef(out);
+        out << ">, ";
+    }
 }
 
 void LdArg::printArgs(std::ostream& out, bool tty) { out << id; }

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -44,13 +44,28 @@ class Missing : public SingletonValue<Missing> {
     Missing() : SingletonValue(PirType::missing(), Tag::Missing) {}
 };
 
-class Tombstone : public SingletonValue<Tombstone> {
+class Tombstone : public Value {
   public:
-    void printRef(std::ostream& out) { out << "~"; }
+    void printRef(std::ostream& out) {
+        out << "~";
+        if (this == closure())
+            out << "cls";
+        else if (this == framestate())
+            out << "fs";
+        else
+            assert(false);
+    }
+    static Tombstone* closure() {
+        static Tombstone cls(RType::closure);
+        return &cls;
+    }
+    static Tombstone* framestate() {
+        static Tombstone cls(NativeType::frameState);
+        return &cls;
+    }
 
   private:
-    friend class SingletonValue;
-    Tombstone() : SingletonValue(PirType::voyd(), Tag::Tombstone) {}
+    Tombstone(PirType t) : Value(t, Tag::Tombstone) {}
 };
 }
 }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -170,6 +170,9 @@ struct PirType {
     RIR_INLINE bool isRType() const {
         return flags_.includes(TypeFlags::rtype);
     }
+    RIR_INLINE bool maybe(RType type) const {
+        return isRType() && t_.r.includes(type);
+    }
 
     RIR_INLINE PirType scalar() const {
         assert(isRType());

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -317,7 +317,7 @@ bool checkPir2Rir(SEXP expected, SEXP result) {
 
 bool testPir2Rir(const std::string& name, const std::string& fun,
                  const std::string& args, bool useSame = false,
-                 bool verbose = false) {
+                 bool verbose = true) {
     Protect p;
 
     std::string wrapper =
@@ -540,6 +540,27 @@ static Test tests[] = {
                                 "  sum\n"
                                 "}",
                                 "4");
+         }),
+    Test(
+        "Elide ldfun through promise",
+        []() { return test42("{f <- function() 42L; (function(x) x())(f)}"); }),
+    Test("Constantfolding1", []() { return test42("{if (1<2) 42L}"); }),
+    Test("Constantfolding2",
+         []() {
+             return test42("{a<- 41L; b<- 1L; f <- function(x,y) x+y; f(a,b)}");
+         }),
+    Test("Inlining promises and closures with Constantfolding",
+         []() {
+             return test42("{a<- function() 41L; b<- function() 1L; f <- "
+                           "function(x,y) x()+y; f(a,b())}");
+         }),
+    Test("more cf",
+         []() {
+             return test42("{x <- function() 42;"
+                           " y <- function() 41;"
+                           " z <- 1;"
+                           " f <- function(a,b,c) if (a() == (b+c)) 42L;"
+                           " f(x,y(),z)}");
          }),
 };
 } // namespace

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -3,6 +3,9 @@
 
 #include "../pir/bb.h"
 #include "../pir/pir.h"
+#include "../util/cfg.h"
+
+#include <unordered_set>
 
 namespace rir {
 namespace pir {
@@ -19,6 +22,9 @@ class BBTransform {
                            BB* deoptBlock);
     static BB* addCheckpoint(Code* closure, BB* src,
                              BB::Instrs::iterator position);
+    static void removeBBsWithChildren(DominanceGraph& dom, Code* code,
+                                      const std::unordered_set<BB*>& toDelete);
+    static void removeBBs(Code* code, const std::unordered_set<BB*>& toDelete);
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -715,7 +715,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
                 auto loadArg = [&](BB::Instrs::iterator it, Instruction* instr,
                                    Value* what) {
-                    if (what == Tombstone::instance()) {
+                    if (what->tag == Tag::Tombstone) {
                         return;
                     }
                     if (what == Missing::instance()) {
@@ -1087,7 +1087,16 @@ void Pir2Rir::lower(Code* code) {
             auto it = bb->begin();
             while (it != bb->end()) {
                 auto next = it + 1;
-                if (auto deopt = Deopt::Cast(*it)) {
+                if (auto call = CallInstruction::CastCall(*it))
+                    call->clearFrameState();
+                if (auto ldfun = LdFun::Cast(*it)) {
+                    // the guessed binding in ldfun is just used as a temporary
+                    // store. If we did not manage to resolve ldfun by now, we
+                    // have to remove the guess again, since apparently we
+                    // where not sure it is correct.
+                    if (ldfun->guessedBinding())
+                        ldfun->clearGuessedBinding();
+                } else if (auto deopt = Deopt::Cast(*it)) {
                     // Lower Deopt instructions + their FrameStates to a
                     // ScheduledDeopt.
                     auto newDeopt = new ScheduledDeopt();

--- a/rir/src/compiler/translations/pir_translator.h
+++ b/rir/src/compiler/translations/pir_translator.h
@@ -12,7 +12,7 @@ class PirTranslator {
   public:
     PirTranslator(const std::string& name) : name(name) {}
 
-    virtual void apply(Closure* function) const = 0;
+    virtual void apply(RirCompiler&, Closure* function) const = 0;
     std::string getName() const { return this->name; }
     virtual ~PirTranslator() {}
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -114,7 +114,7 @@ void Rir2PirCompiler::optimizeModule(bool preserveVersions) {
                 v.saveVersion();
 
             auto& log = logger.get(f);
-            translation->apply(f);
+            translation->apply(*this, f);
             log.pirOptimizations(f, translation->getName(), passnr++);
 
 #ifdef ENABLE_SLOWASSERT

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -6,6 +6,7 @@
 #include "../pir/module.h"
 #include "../pir/pir.h"
 #include "../pir/value.h"
+#include "R/Preserve.h"
 #include "pir_translator.h"
 #include "runtime/Function.h"
 #include <vector>
@@ -22,9 +23,12 @@ class RirCompiler {
     typedef std::function<void()> Maybe;
     typedef std::function<void(Closure*)> MaybeCls;
 
+    void preserve(SEXP c) { preserve_(c); }
+
   protected:
     std::vector<const PirTranslator*> translations;
     Module* module;
+    Preserve preserve_;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -42,6 +42,7 @@ void Configurations::defaultOptimizations() {
     auto addDefaultOpt = [&]() {
         optimizations.push_back(new pir::ForceDominance());
         optimizations.push_back(new pir::ScopeResolution());
+        optimizations.push_back(new pir::Constantfold());
         optimizations.push_back(new pir::Cleanup());
         optimizations.push_back(new pir::DelayInstr());
         optimizations.push_back(new pir::ElideEnvSpec());


### PR DESCRIPTION

inlining promised calls

there was an issue with inlining functions such as `a` in:

    a <- function() 42
    f <- function(x) x()
    f(a)

after inlining `f`. The reason was that after inlining `f` we get
`ldfun x`. Even if we manage to trace this through the promise
`ldvar a`, we do not inline the promise, because there is no force
instruction. The reason is that `ldfun` itself forces, because of
the strange 'skip-non-closure-bindings'. Also, due to those semantics
we can only replace `ldfun` if we are sure that the thing we load
is a closure, which we can only after inlining the promise. A
chicken-egg problem.

This is resolved in this commit, by adding a "guessed binding" input
to the `ldfun` instruction, where we can add the most inner binding
that matches the ldfun, try to infer its type over time and finally
if we succeed to prove that it has type closure, replace the `ldfun`
with it (or discard it if not).

Additionally this commit removes unused checkpoints (such that they
do not block optimizations) and marks framestates as non-effectful (such
that they get removed automatically).

(also adds some tests for this and constantfolding)

a60e0ba 