### PR TITLE
fix framestate after static call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
         - CC_OVERRIDE=clang
         - BUILD=debug
         - CHECK=check
+        - RIR_WARMUP=2
       compiler: clang
 
     # linux gcc
@@ -47,6 +48,7 @@ matrix:
         - CHECK=check-recommended
         - BUILD=release
         - TEST_GCTORTURE=1
+        - RIR_WARMUP=4
 
 addons:
   apt:

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -374,7 +374,6 @@ MkFunCls::MkFunCls(Closure* fun, Value* lexicalEnv, SEXP fml, SEXP code,
                    SEXP src)
     : FixedLenInstructionWithEnvSlot(RType::closure, lexicalEnv), fun(fun),
       fml(fml), code(code), src(src) {
-    assert(fun->closureEnv() == Env::notClosed());
 }
 
 void MkFunCls::printArgs(std::ostream& out, bool tty) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -277,8 +277,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos, rir::Code* s
                                           bc.callExtra().callArgumentNames,
                                           ast)));
             } else {
+                auto callee = pop();
                 auto fs = insert.registerFrameState(srcCode, nextPos, stack);
-                push(insert(new Call(insert.env, pop(), args, fs, ast)));
+                push(insert(new Call(insert.env, callee, args, fs, ast)));
             }
         };
         if (monomorphic && isValidClosureSEXP(monomorphic)) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -570,6 +570,9 @@ SEXP rirCall(const CallContext& call, SEXP actuals, Context* ctx) {
     return result;
 }
 
+static unsigned RIR_WARMUP =
+    getenv("RIR_WARMUP") ? atoi(getenv("RIR_WARMUP")) : 3;
+
 // Call a RIR function. Arguments are still untouched.
 SEXP rirCall(const CallContext& call, Context* ctx) {
     SEXP body = BODY(call.callee);
@@ -582,7 +585,7 @@ SEXP rirCall(const CallContext& call, Context* ctx) {
     Function* fun = table->at(slot);
 
     fun->registerInvocation();
-    if (slot == 0 && fun->invocationCount() == 2) {
+    if (slot == 0 && fun->invocationCount() == RIR_WARMUP) {
         SEXP lhs = CAR(call.ast);
         SEXP name = R_NilValue;
         if (TYPEOF(lhs) == SYMSXP)


### PR DESCRIPTION
the framestate for the static call accidentially included the callee,
since the pop was after the insertion of the framestate.

this was only revealed when i started optimizing functions later.
thus this commit also introduces 3 different optimization trigger
values on travis, to get more coverage.