### PR TITLE
move loop context setjmp/longjmp out of the interpreter loop

### DIFF
--- a/rir/src/R/r.h
+++ b/rir/src/R/r.h
@@ -1,6 +1,8 @@
 #ifndef RIR_R_H
 #define RIR_R_H
 
+#include "common.h"
+
 #include <R.h>
 #define USE_RINTERNALS
 #include <Rinternals.h>
@@ -20,5 +22,54 @@ extern SEXP R_TrueValue;
 extern SEXP R_FalseValue;
 extern SEXP R_LogicalNAValue;
 };
+
+// Performance critical stuff copied from Rinlinedfun.h
+
+#ifdef ENABLE_SLOWASSERT
+RIR_INLINE void CHKVEC(SEXP x) {
+    switch (TYPEOF(x)) {
+    case CHARSXP:
+    case LGLSXP:
+    case INTSXP:
+    case REALSXP:
+    case CPLXSXP:
+    case STRSXP:
+    case VECSXP:
+    case EXPRSXP:
+    case RAWSXP:
+    case WEAKREFSXP:
+    case EXTERNALSXP: // added by RIR
+        break;
+    default:
+        assert(false);
+    }
+}
+#else
+#define CHKVEC(x)                                                              \
+    do {                                                                       \
+    } while (0)
+#endif
+
+RIR_INLINE void* DATAPTR(SEXP x) {
+    CHKVEC(x);
+    if (ALTREP(x))
+        return ALTVEC_DATAPTR(x);
+#ifdef CATCH_ZERO_LENGTH_ACCESS
+    /* Attempts to read or write elements of a zero length vector will
+       result in a segfault, rather than read and write random memory.
+       Returning NULL would be more natural, but Matrix seems to assume
+       that even zero-length vectors have non-NULL data pointers, so
+       return (void *) 1 instead. Zero-length CHARSXP objects still
+       have a trailing zero byte so they are not handled. */
+    else if (STDVEC_LENGTH(x) == 0 && TYPEOF(x) != CHARSXP)
+        return (void*)1;
+#endif
+    else
+        return STDVEC_DATAPTR(x);
+}
+
+RIR_INLINE R_xlen_t XLENGTH_EX(SEXP x) {
+    return ALTREP(x) ? ALTREP_LENGTH(x) : STDVEC_LENGTH(x);
+}
 
 #endif

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -590,7 +590,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     case Opcode::asast_:
     case Opcode::missing_:
     case Opcode::beginloop_:
-    case Opcode::endcontext_:
+    case Opcode::endloop_:
     case Opcode::ldddvar_:
         log.unsupportedBC("Unsupported BC", bc);
         return false;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1128,8 +1128,16 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
     std::deque<FrameInfo*> synthesizeFrames;
     assert(c->info.magic == CODE_MAGIC);
 
-    if (!localsBase)
+    if (!localsBase) {
+#ifdef TYPED_STACK
+        // Zero the region of the locals to avoid keeping stuff alive and to
+        // zero all the type tags. Note: this trick does not work with the stack
+        // in general, since there intermediate callees might set the type tags
+        // to something else.
+        memset(R_BCNodeStackTop, 0, sizeof(*R_BCNodeStackTop) * c->localsCount);
+#endif
         localsBase = R_BCNodeStackTop;
+    }
     Locals locals(localsBase, c->localsCount);
 
     BindingCache bindingCache[BINDING_CACHE_SIZE];

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -129,7 +129,7 @@ RIR_INLINE SEXP getSrcForCall(Code* c, Opcode* pc, Context* ctx) {
 #endif
 
 // bytecode accesses
-#define advanceOpcode() (*pc++)
+#define advanceOpcode() (*(pc++))
 #define readImmediate() (*(Immediate*)pc)
 #define readSignedImmediate() (*(SignedImmediate*)pc)
 #define readJumpOffset() (*(JumpOffset*)(pc))
@@ -370,6 +370,33 @@ SEXP rirCallTrampoline(const CallContext& call, Function* fun, SEXP arglist,
 SEXP rirCallTrampoline(const CallContext& call, Function* fun, SEXP env,
                        SEXP arglist, Context* ctx) {
     return rirCallTrampoline(call, fun, env, arglist, nullptr, ctx);
+}
+
+const static SEXP loopTrampolineMarker = (SEXP)0x7007;
+SEXP evalRirCode(Code*, Context*, SEXP*, const CallContext*, Opcode*,
+                 R_bcstack_t*);
+static void loopTrampoline(Code* c, Context* ctx, SEXP* env,
+                           const CallContext* callCtxt, Opcode* pc,
+                           R_bcstack_t* localsBase) {
+    assert(*env);
+
+    RCNTXT cntxt;
+    Rf_begincontext(&cntxt, CTXT_LOOP, R_NilValue, *env, R_BaseEnv, R_NilValue,
+                    R_NilValue);
+
+    if (int s = SETJMP(cntxt.cjmpbuf)) {
+        // incoming non-local break/continue:
+        if (s == CTXT_BREAK) {
+            Rf_endcontext(&cntxt);
+            return;
+        }
+        // continue case: fall through to do another iteration
+    }
+
+    // execute the loop body
+    SEXP res = evalRirCode(c, ctx, env, callCtxt, pc, localsBase);
+    assert(res == loopTrampolineMarker);
+    Rf_endcontext(&cntxt);
 }
 
 void warnSpecial(SEXP callee, SEXP call) {
@@ -1085,7 +1112,7 @@ static void cachedSetVar(SEXP val, SEXP env, Immediate idx, Context* ctx,
 #pragma GCC diagnostic ignored "-Wcast-align"
 
 SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
-                 Opcode* initialPC) {
+                 Opcode* initialPC, R_bcstack_t* localsBase = nullptr) {
     assert(*env || (callCtxt != nullptr));
 
     extern int R_PPStackTop;
@@ -1101,7 +1128,9 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
     std::deque<FrameInfo*> synthesizeFrames;
     assert(c->info.magic == CODE_MAGIC);
 
-    Locals locals(c->localsCount);
+    if (!localsBase)
+        localsBase = R_BCNodeStackTop;
+    Locals locals(localsBase, c->localsCount);
 
     BindingCache bindingCache[BINDING_CACHE_SIZE];
     memset(&bindingCache, 0, sizeof(bindingCache));
@@ -2634,56 +2663,17 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
         }
 
         INSTRUCTION(beginloop_) {
-            // Allocate a RCNTXT on the stack
-            SEXP val = Rf_allocVector(RAWSXP, sizeof(RCNTXT) + sizeof(pc));
-            ostack_push(ctx, val);
-
-            RCNTXT* cntxt = (RCNTXT*)RAW(val);
-
-            {
-                // (ab)use the same buffer to store the current pc
-                Opcode** oldPc = (Opcode**)(cntxt + 1);
-                *oldPc = pc;
-            }
-
-            Rf_begincontext(cntxt, CTXT_LOOP, R_NilValue, getenv(), R_BaseEnv,
-                            R_NilValue, R_NilValue);
-            // (ab)use the unused cenddata field to store sp
-            cntxt->cenddata = (void*)ostack_length(ctx);
-
+            SLOWASSERT(*env);
+            int offset = readJumpOffset();
             advanceJump();
-
-            int s;
-            if ((s = SETJMP(cntxt->cjmpbuf))) {
-                // incoming non-local break/continue:
-                // restore our stack state
-
-                // get the RCNTXT from the stack
-                val = ostack_top(ctx);
-                assert(TYPEOF(val) == RAWSXP && "stack botched");
-                RCNTXT* cntxt = (RCNTXT*)RAW(val);
-                assert(cntxt == R_GlobalContext && "stack botched");
-                Opcode** oldPc = (Opcode**)(cntxt + 1);
-                pc = *oldPc;
-
-                int offset = readJumpOffset();
-                advanceJump();
-
-                if (s == CTXT_BREAK)
-                    pc += offset;
-                PC_BOUNDSCHECK(pc, c);
-            }
+            loopTrampoline(c, ctx, env, callCtxt, pc, localsBase);
+            pc += offset;
+            assert(*pc == Opcode::endloop_);
+            advanceOpcode();
             NEXT();
         }
 
-        INSTRUCTION(endcontext_) {
-            SEXP val = ostack_top(ctx);
-            assert(TYPEOF(val) == RAWSXP);
-            RCNTXT* cntxt = (RCNTXT*)RAW(val);
-            Rf_endcontext(cntxt);
-            ostack_pop(ctx); // Context
-            NEXT();
-        }
+        INSTRUCTION(endloop_) { return loopTrampolineMarker; }
 
         INSTRUCTION(return_) {
             res = ostack_top(ctx);

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -199,7 +199,7 @@ class Locals final {
                    "Attempt to store invalid local variable.");
 #ifdef TYPED_STACK
         (base + offset)->u.sxpval = val;
-        (base + offset)->tag = 0;
+        SLOWASSERT((base + offset)->tag == 0);
 #else
         base[offset] = val;
 #endif

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -185,8 +185,8 @@ class Locals final {
     ~Locals() { R_BCNodeStackTop -= localsCount; }
 
     SEXP load(unsigned offset) {
-        assert(offset < localsCount &&
-               "Attempt to load invalid local variable.");
+        SLOWASSERT(offset < localsCount &&
+                   "Attempt to load invalid local variable.");
 #ifdef TYPED_STACK
         return (base + offset)->u.sxpval;
 #else
@@ -195,8 +195,8 @@ class Locals final {
     }
 
     void store(unsigned offset, SEXP val) {
-        assert(offset < localsCount &&
-               "Attempt to store invalid local variable.");
+        SLOWASSERT(offset < localsCount &&
+                   "Attempt to store invalid local variable.");
 #ifdef TYPED_STACK
         (base + offset)->u.sxpval = val;
         (base + offset)->tag = 0;

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -177,8 +177,8 @@ class Locals final {
     unsigned localsCount;
 
   public:
-    explicit Locals(unsigned count)
-        : base(R_BCNodeStackTop), localsCount(count) {
+    explicit Locals(R_bcstack_t* base, unsigned count)
+        : base(base), localsCount(count) {
         R_BCNodeStackTop += localsCount;
     }
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -163,7 +163,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::isfun_:
     case Opcode::invisible_:
     case Opcode::visible_:
-    case Opcode::endcontext_:
+    case Opcode::endloop_:
     case Opcode::subassign1_:
     case Opcode::subassign2_:
     case Opcode::isobj_:
@@ -383,7 +383,7 @@ void BC::print(std::ostream& out) const {
     case Opcode::length_:
     case Opcode::names_:
     case Opcode::set_names_:
-    case Opcode::endcontext_:
+    case Opcode::endloop_:
     case Opcode::aslogical_:
     case Opcode::lgl_or_:
     case Opcode::lgl_and_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -201,7 +201,7 @@ BC BC::brfalse(Jmp j) {
     i.offset = j;
     return BC(Opcode::brfalse_, i);
 }
-BC BC::endcontext() { return BC(Opcode::endcontext_); }
+BC BC::endloop() { return BC(Opcode::endloop_); }
 BC BC::dup() { return BC(Opcode::dup_); }
 BC BC::inc() { return BC(Opcode::inc_); }
 BC BC::close() { return BC(Opcode::close_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -324,7 +324,7 @@ class BC {
     inline static BC alloc(int type);
     inline static BC asbool();
     inline static BC beginloop(Jmp);
-    inline static BC endcontext();
+    inline static BC endloop();
     inline static BC brtrue(Jmp);
     inline static BC brfalse(Jmp);
     inline static BC br(Jmp);
@@ -688,7 +688,7 @@ class BC {
         case Opcode::isfun_:
         case Opcode::invisible_:
         case Opcode::visible_:
-        case Opcode::endcontext_:
+        case Opcode::endloop_:
         case Opcode::subassign1_:
         case Opcode::subassign2_:
         case Opcode::length_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -156,7 +156,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::isfun_:
     case Opcode::invisible_:
     case Opcode::visible_:
-    case Opcode::endcontext_:
+    case Opcode::endloop_:
     case Opcode::isobj_:
     case Opcode::check_missing_:
     case Opcode::lgl_and_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -417,14 +417,13 @@ DEF_INSTR(make_unique_, 0, 1, 1, 1)
 /**
  * beginloop_:: begins loop context, break and continue target immediate (this is the target for break and next long jumps)
  */
-DEF_INSTR(beginloop_, 1, 0, 1, 1)
+DEF_INSTR(beginloop_, 1, 0, 0, 1)
 
 /**
- * endcontext_:: ends a context. Takes a context as input and removes it from the stack (the context to be removed does not have to be top one)
+ * endloop_:: end marker for a loop with context
 
-TODO black magic here
  */
-DEF_INSTR(endcontext_, 0, 1, 0, 0)
+DEF_INSTR(endloop_, 0, 0, 0, 0)
 
 /**
  * return_ :: return instruction. Non-local return instruction as opposed to ret_.

--- a/rir/src/utils/FunctionWriter.h
+++ b/rir/src/utils/FunctionWriter.h
@@ -68,7 +68,7 @@ class FunctionWriter {
         unsigned totalSize = Code::size(codeSize, sources.size());
 
         SEXP store = Rf_allocVector(EXTERNALSXP, totalSize);
-        void* payload = INTEGER(store);
+        void* payload = DATAPTR(store);
         Code* code = new (payload)
             Code(nullptr, ast, codeSize, sources.size(), localsCnt);
         preserve(store);


### PR DESCRIPTION
I had a theory that the setjmp/longjmp in the middle of the loop body deteriorates perf. So I experimented with moving it out into a loopTrampoline function. With this patch we are now using the same strategy as mainline R -- executing contextful loop bodies in their own function. Since most loops have no context it seems better to tank their performance.

Anyway, the theory was wrong, the patch does not improve much. Still putting it here, maybe we decide it's more readable?