### PR TITLE
fix BBTransform::clone copies instructions without copying promises

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -27,8 +27,14 @@ class TheVerifier {
         }
 
         for (auto p : f->promises) {
-            if (p)
+            if (p) {
+                if (p != f->promises[p->id]) {
+                    std::cerr << "Promise with id " << p->id
+                              << " is in the wrong slot\n";
+                    ok = false;
+                }
                 verify(p);
+            }
             if (!ok) {
                 std::cerr << "Verification of promise failed\n";
                 p->print(std::cerr, true);
@@ -120,6 +126,17 @@ class TheVerifier {
             std::cerr << "' is supposed to point to BB " << bb
                       << " but points to " << i->bb() << "\n";
             ok = false;
+        }
+
+        if (auto mk = MkArg::Cast(i)) {
+            auto p = mk->prom();
+            assert(p->fun->promises[p->id] == p);
+            if (p->fun != f) {
+                mk->printRef(std::cerr);
+                std::cerr << " is referencing a promise from another function "
+                          << p->fun->name << "\n";
+                ok = false;
+            }
         }
 
         if (i->branchOrExit())

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -255,7 +255,7 @@ void ForceDominance::apply(RirCompiler&, Closure* cls, LogStream& log) const {
                                 BB* split = BBTransform::split(code->nextBBId++,
                                                                bb, ip, code);
                                 BB* prom_copy =
-                                    BBTransform::clone(prom->entry, code);
+                                    BBTransform::clone(prom->entry, code, cls);
                                 bb->overrideNext(prom_copy);
 
                                 // For now we assume every promise starts with a
@@ -337,7 +337,6 @@ void ForceDominance::apply(RirCompiler&, Closure* cls, LogStream& log) const {
         }
     };
     apply(cls);
-    cls->eachPromise([&](Promise* p) { apply(p); });
 }
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -93,7 +93,8 @@ class TheInliner {
                     [&](Value* v) { arguments.push_back(v); });
 
                 // Clone the function
-                BB* copy = BBTransform::clone(inlinee->entry, function);
+                BB* copy =
+                    BBTransform::clone(inlinee->entry, function, function);
 
                 bool needsEnvPatching = inlinee->closureEnv() != staticEnv;
 
@@ -202,9 +203,9 @@ class TheInliner {
                                         function->promises.at(newPromId[id]));
                                 } else {
                                     Promise* clone = function->createProm(
-                                        mk->prom()->srcPoolIdx);
+                                        mk->prom()->srcPoolIdx());
                                     BB* promCopy = BBTransform::clone(
-                                        mk->prom()->entry, clone);
+                                        mk->prom()->entry, clone, function);
                                     clone->entry = promCopy;
                                     newPromId[id] = clone->id;
                                     copiedPromise[id] = true;

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -40,16 +40,16 @@ Closure* Closure::clone() {
     Closure* c = new Closure(name, argNames, env, function);
 
     // clone code
-    c->entry = BBTransform::clone(entry, c);
+    c->entry = BBTransform::clone(entry, c, c);
 
     // clone promises
     std::unordered_map<Promise*, Promise*> promMap;
     for (auto p : promises) {
         if (!p)
             continue;
-        Promise* clonedP = new Promise(c, c->promises.size(), p->srcPoolIdx);
+        Promise* clonedP = new Promise(c, c->promises.size(), p->srcPoolIdx());
         c->promises.push_back(clonedP);
-        clonedP->entry = BBTransform::clone(p->entry, clonedP);
+        clonedP->entry = BBTransform::clone(p->entry, clonedP, c);
         promMap[p] = clonedP;
     }
 

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -481,6 +481,20 @@ void NamedCall::printArgs(std::ostream& out, bool tty) {
     out << ") ";
 }
 
+CallImplicit::CallImplicit(Value* callerEnv, Value* fun,
+                           const std::vector<Promise*>& args,
+                           const std::vector<SEXP>& names_, unsigned srcIdx)
+    : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
+                                     {{PirType::closure()}}, {{fun}}, callerEnv,
+                                     srcIdx),
+      promises(args), names(names_) {}
+
+void CallImplicit::eachArg(const std::function<void(Promise*)>& action) const {
+    for (auto prom : promises) {
+        action(prom);
+    }
+}
+
 void CallImplicit::printArgs(std::ostream& out, bool tty) {
     cls()->printRef(out);
     out << "(";

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1090,19 +1090,17 @@ class VLIE(NamedCall, Effect::Any, EnvAccess::Leak), public CallInstruction {
 };
 
 class FLIE(CallImplicit, 2, Effect::Any, EnvAccess::Leak) {
+    const std::vector<Promise*> promises;
+
   public:
-    std::vector<Promise*> promises;
-    std::vector<SEXP> names;
+    void eachArg(const std::function<void(Promise*)>&) const;
+    const std::vector<SEXP> names;
 
     Value* cls() { return arg(0).val(); }
 
     CallImplicit(Value* callerEnv, Value* fun,
                  const std::vector<Promise*>& args,
-                 const std::vector<SEXP>& names_, unsigned srcIdx)
-        : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
-                                         {{PirType::closure()}}, {{fun}},
-                                         callerEnv, srcIdx),
-          promises(args), names(names_) {}
+                 const std::vector<SEXP>& names_, unsigned srcIdx);
 
     Value* callerEnv() { return env(); }
     void printArgs(std::ostream& out, bool tty) override;

--- a/rir/src/compiler/pir/promise.cpp
+++ b/rir/src/compiler/pir/promise.cpp
@@ -1,0 +1,14 @@
+#include "promise.h"
+#include "interpreter/runtime.h"
+
+namespace rir {
+namespace pir {
+
+Promise::Promise(Closure* fun, unsigned id, unsigned src)
+    : id(id), fun(fun), srcPoolIdx_(src) {
+    assert(src_pool_at(globalContext(), srcPoolIdx_));
+}
+
+unsigned Promise::srcPoolIdx() const { return srcPoolIdx_; }
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -8,9 +8,8 @@ namespace pir {
 
 class Promise : public Code {
   public:
-    unsigned id;
+    const unsigned id;
     Closure* fun;
-    unsigned srcPoolIdx;
 
     void print(std::ostream& out, bool tty) const {
         out << "Prom " << id << ":\n";
@@ -22,10 +21,12 @@ class Promise : public Code {
         return out;
     }
 
+    unsigned srcPoolIdx() const;
+
   private:
+    const unsigned srcPoolIdx_;
     friend class Closure;
-    Promise(Closure* fun, unsigned id, unsigned src)
-        : id(id), fun(fun), srcPoolIdx(src) {}
+    Promise(Closure* fun, unsigned id, unsigned src);
 };
 
 } // namespace pir

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -11,7 +11,7 @@ namespace pir {
 class FrameState;
 class BBTransform {
   public:
-    static BB* clone(BB* src, Code* target);
+    static BB* clone(BB* src, Code* target, Closure* targetClosure);
     static BB* split(size_t next_id, BB* src, BB::Instrs::iterator,
                      Code* target);
     static Value* forInline(BB* inlinee, BB* cont);

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -1,6 +1,7 @@
 #ifndef interpreter_context_h
 #define interpreter_context_h
 
+#include "R/r.h"
 #include "interp_data.h"
 #include "ir/BC_inc.h"
 
@@ -229,7 +230,14 @@ RIR_INLINE size_t src_pool_add(Context* c, SEXP v) {
     return result;
 }
 
-#define cp_pool_at(c, index) (VECTOR_ELT((c)->cp.list, (index)))
-#define src_pool_at(c, value) (VECTOR_ELT((c)->src.list, (value)))
+RIR_INLINE SEXP cp_pool_at(Context* c, unsigned index) {
+    SLOWASSERT(c->cp.capacity > index);
+    return VECTOR_ELT(c->cp.list, index);
+}
+
+RIR_INLINE SEXP src_pool_at(Context* c, unsigned index) {
+    SLOWASSERT(c->src.capacity > index);
+    return VECTOR_ELT(c->src.list, index);
+}
 
 #endif // interpreter_context_h


### PR DESCRIPTION
when copying instructions from one function to another, we would not
copy promises, that where used in MkArgs. This would cause pointers
across different closures and ultimatively to segv, if the old function
is deleted (or the promise in the old function).