### PR TITLE
new pass schedule

### DIFF
--- a/examples/mandelbrot_mini.R
+++ b/examples/mandelbrot_mini.R
@@ -9,4 +9,5 @@ mandelbrot_mini <- function() {
 f <- rir.compile(function() mandelbrot_mini())
 
 f()
+f()
 pir.compile(mandelbrot_mini, debugFlags=pir.debugFlags(PrintPirAfterOpt=TRUE, ShowWarnings=TRUE))

--- a/examples/mandelbrot_mini.R
+++ b/examples/mandelbrot_mini.R
@@ -8,6 +8,7 @@ mandelbrot_mini <- function() {
 
 f <- rir.compile(function() mandelbrot_mini())
 
+# Run twice to get realistic type feedback
 f()
 f()
 pir.compile(mandelbrot_mini, debugFlags=pir.debugFlags(PrintPirAfterOpt=TRUE, ShowWarnings=TRUE))

--- a/examples/tree_mini.r
+++ b/examples/tree_mini.r
@@ -24,4 +24,5 @@ test <- function() {
 f <- rir.compile(function() test())
 
 f()
+f()
 pir.compile(test, debugFlags=pir.debugFlags(PrintPirAfterOpt=TRUE, ShowWarnings=TRUE))

--- a/examples/tree_mini.r
+++ b/examples/tree_mini.r
@@ -23,6 +23,7 @@ test <- function() {
 
 f <- rir.compile(function() test())
 
+# Run twice to get realistic type feedback
 f()
 f()
 pir.compile(test, debugFlags=pir.debugFlags(PrintPirAfterOpt=TRUE, ShowWarnings=TRUE))

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -19,8 +19,8 @@ class TheInliner {
     Closure* function;
     explicit TheInliner(Closure* function) : function(function) {}
 
-    static constexpr size_t MAX_SIZE = 1024;
-    static constexpr size_t MAX_INLINEE_SIZE = 128;
+    static constexpr size_t MAX_SIZE = 10000;
+    static constexpr size_t MAX_INLINEE_SIZE = 200;
     static constexpr size_t MAX_FUEL = 5;
 
     void operator()() {

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -19,12 +19,12 @@ class TheInliner {
     Closure* function;
     explicit TheInliner(Closure* function) : function(function) {}
 
-    static constexpr size_t MAX_SIZE = 10000;
-    static constexpr size_t MAX_INLINEE_SIZE = 200;
-    static constexpr size_t MAX_FUEL = 5;
+    static const size_t MAX_SIZE;
+    static const size_t MAX_INLINEE_SIZE;
+    static const size_t INITIAL_FUEL;
 
     void operator()() {
-        size_t fuel = MAX_FUEL;
+        size_t fuel = INITIAL_FUEL;
 
         if (function->size() > MAX_SIZE)
             return;
@@ -228,6 +228,21 @@ class TheInliner {
         });
     }
 };
+
+// TODO: maybe implement something more resonable to pass in those constants.
+// For now it seems a simple env variable is just fine.
+const size_t TheInliner::MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
+                                        ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
+                                        : 10000;
+const size_t TheInliner::MAX_INLINEE_SIZE =
+    getenv("PIR_INLINER_MAX_INLINEE_SIZE")
+        ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
+        : 200;
+const size_t TheInliner::INITIAL_FUEL =
+    getenv("PIR_INLINER_INITIAL_FUEL")
+        ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
+        : 5;
+
 } // namespace
 
 namespace rir {


### PR DESCRIPTION
1. fix the examples: if we compile after only one execution, we
accidentially think that the inner function has a monomorphic target
closure. (which is not true, since it gets recreated for every
invocation)
2. increase inliner limits a bit
3. a new pass schedule, that is still completely arbitrary, but at least
has some justification for the parts :)