### PR TITLE
fix soundness issue in static analysis

### DIFF
--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -206,17 +206,15 @@ class StaticAnalysis {
                 }
 
                 if (bb->isExit()) {
-                    if (!Deopt::Cast(bb->last())) {
-                        if (DEBUG_LEVEL >= AnalysisDebugLevel::Exit) {
-                            log << "===== Exit state is\n";
-                            log(state);
-                        }
-                        if (reachedExit) {
-                            exitpoint.merge(state);
-                        } else {
-                            exitpoint = state;
-                            reachedExit = true;
-                        }
+                    if (DEBUG_LEVEL >= AnalysisDebugLevel::Exit) {
+                        log << "===== Exit state is\n";
+                        log(state);
+                    }
+                    if (reachedExit) {
+                        exitpoint.merge(state);
+                    } else {
+                        exitpoint = state;
+                        reachedExit = true;
                     }
                     return;
                 }

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -70,10 +70,13 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
         auto res = ret->arg<0>().val();
         lookup(state, res,
                [&](const AbstractPirValue& analysisRes) {
-                   state.result.merge(analysisRes);
+                   state.returnValue.merge(analysisRes);
                },
-               [&]() { state.result.merge(ValOrig(res, i)); });
+               [&]() { state.returnValue.merge(ValOrig(res, i)); });
         effect.update();
+    } else if (Deopt::Cast(i)) {
+        // who knows what the deopt target will return...
+        state.returnValue.taint();
     } else if (auto mk = MkEnv::Cast(i)) {
         Value* lexicalEnv = mk->lexicalEnv();
         // If we know the caller, we can fill in the parent env
@@ -146,7 +149,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
                                    depth + 1, log);
                 prom();
                 state.mergeCall(code, prom.result());
-                state.returnValues[i].merge(prom.result().result);
+                state.returnValues[i].merge(prom.result().returnValue);
                 handled = true;
                 effect.update();
                 effect.keepSnapshot = true;
@@ -177,7 +180,8 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
                                               state, depth + 1, log);
                         nextFun();
                         state.mergeCall(code, nextFun.result());
-                        state.returnValues[i].merge(nextFun.result().result);
+                        state.returnValues[i].merge(
+                            nextFun.result().returnValue);
                         handled = true;
                         effect.update();
                         effect.keepSnapshot = true;
@@ -194,7 +198,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
                                           state, depth + 1, log);
                     nextFun();
                     state.mergeCall(code, nextFun.result());
-                    state.returnValues[i].merge(nextFun.result().result);
+                    state.returnValues[i].merge(nextFun.result().returnValue);
                     handled = true;
                     effect.update();
                     effect.keepSnapshot = true;

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -21,7 +21,7 @@ namespace pir {
 class ScopeAnalysisState {
     AbstractREnvironmentHierarchy envs;
     std::unordered_map<Instruction*, AbstractPirValue> returnValues;
-    AbstractPirValue result;
+    AbstractPirValue returnValue;
     std::set<Instruction*> observedStores;
     std::set<Value*> allStoresObserved;
 
@@ -95,7 +95,7 @@ class ScopeAnalysisState {
             }
         }
         out << "== Result: ";
-        result.print(out, tty);
+        returnValue.print(out, tty);
         out << "\n";
         if (mayUseReflection)
             out << "* Reflection possible\n";


### PR DESCRIPTION
currently only return statements are merged into the exitstate in
the static analysis. while this might be correct for some analysis
it is certainly not correct in general.

for example the dead store optimization looks at result() of the
analysis to determine whether a load is visible. If the load would
be in the deopt branch we would not see it.

I looked at all the places where we currently use result() and it
seems to me, that including the deopt state is the correct choice.

thus let's always include the deopt state for now and we can still
make it more clever in the future.

Also, this revealed a case in the scope analysis, where we did not
consider that a deopt influences the return value of a function.