### PR TITLE
add some infrastructure to mark builtins safe

### DIFF
--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -1,6 +1,7 @@
 #include "instruction.h"
 #include "pir_impl.h"
 
+#include "../util/safe_builtins_list.h"
 #include "../util/visitor.h"
 #include "R/Funtab.h"
 #include "utils/Pool.h"
@@ -314,6 +315,15 @@ CallBuiltin::CallBuiltin(Value* env, SEXP builtin,
       builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
         this->pushArg(args[i], PirType::val());
+}
+
+Instruction* BuiltinCallFactory::New(Value* callerEnv, SEXP builtin,
+                                     const std::vector<Value*>& args,
+                                     unsigned srcIdx) {
+    if (SafeBuiltinsList::contains(builtin))
+        return new CallSafeBuiltin(builtin, args, srcIdx);
+    else
+        return new CallBuiltin(callerEnv, builtin, args, srcIdx);
 }
 
 static void printCallArgs(std::ostream& out, CallInstruction* call) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1154,9 +1154,6 @@ class VLIE(CallBuiltin, Effect::Any, EnvAccess::Leak), public CallInstruction {
     const CCODE builtin;
     int builtinId;
 
-    CallBuiltin(Value * callerEnv, SEXP builtin,
-                const std::vector<Value*>& args, unsigned srcIdx);
-
     size_t nCallArgs() override { return nargs() - 1; };
     void eachCallArg(Instruction::ArgumentValueIterator it) override {
         for (size_t i = 0; i < nCallArgs(); ++i)
@@ -1164,6 +1161,11 @@ class VLIE(CallBuiltin, Effect::Any, EnvAccess::Leak), public CallInstruction {
     }
     void printArgs(std::ostream & out, bool tty) override;
     Value* callerEnv() { return env(); }
+
+  private:
+    CallBuiltin(Value * callerEnv, SEXP builtin,
+                const std::vector<Value*>& args, unsigned srcIdx);
+    friend class BuiltinCallFactory;
 };
 
 class VLI(CallSafeBuiltin, Effect::None, EnvAccess::None),
@@ -1173,15 +1175,23 @@ class VLI(CallSafeBuiltin, Effect::None, EnvAccess::None),
     const CCODE builtin;
     int builtinId;
 
-    CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
-                    unsigned srcIdx);
-
     size_t nCallArgs() override { return nargs(); };
     void eachCallArg(Instruction::ArgumentValueIterator it) override {
         eachArg(it);
     }
 
     void printArgs(std::ostream & out, bool tty) override;
+
+  private:
+    CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
+                    unsigned srcIdx);
+    friend class BuiltinCallFactory;
+};
+
+class BuiltinCallFactory {
+  public:
+    static Instruction* New(Value* callerEnv, SEXP builtin,
+                            const std::vector<Value*>& args, unsigned srcIdx);
 };
 
 class VLIE(MkEnv, Effect::None, EnvAccess::Capture) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -366,13 +366,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             args[n - i - 1] = pop();
 
         if (TYPEOF(target) == BUILTINSXP) {
-            // TODO: compile a list of safe builtins
-            static int vector = findBuiltin("vector");
-
-            if (getBuiltinNr(target) == vector)
-                push(insert(new CallSafeBuiltin(target, args, ast)));
-            else
-                push(insert(new CallBuiltin(env, target, args, ast)));
+            push(insert(BuiltinCallFactory::New(env, target, args, ast)));
         } else {
             assert(TYPEOF(target) == CLOSXP);
             if (!isValidClosureSEXP(target)) {

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -1,0 +1,21 @@
+#include "safe_builtins_list.h"
+
+#include "R/Funtab.h"
+
+namespace rir {
+namespace pir {
+
+bool SafeBuiltinsList::contains(SEXP builtin) {
+    static int safeBuiltins[] = {
+        findBuiltin("vector"),
+        findBuiltin("c"),
+    };
+
+    for (auto i : safeBuiltins)
+        if (i == getBuiltinNr(builtin))
+            return true;
+    return false;
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/util/safe_builtins_list.h
+++ b/rir/src/compiler/util/safe_builtins_list.h
@@ -1,0 +1,17 @@
+#ifndef SAFE_BUILTINS_LIST_H
+#define SAFE_BUILTINS_LIST_H
+
+#include "R/r.h"
+
+namespace rir {
+namespace pir {
+
+class SafeBuiltinsList {
+  public:
+    static bool contains(SEXP builtin);
+};
+
+} // namespace pir
+} // namespace rir
+
+#endif


### PR DESCRIPTION
safe builtins are those who do not access the caller environment in
any way.

The list needs to be extended of course...

@charig I have this lying around from another PR that needs more thinking. I guess it's small, but still worth salvaging