### PR TITLE
aslogical should not be confused with astest

### DIFF
--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -754,7 +754,7 @@ class FLI(AsLogical, 1, Effect::None, EnvAccess::None) {
 class FLI(AsTest, 1, Effect::Warn, EnvAccess::None) {
   public:
     explicit AsTest(Value* in)
-        : FixedLenInstruction(NativeType::test, {{RType::logical}}, {{in}}) {}
+        : FixedLenInstruction(NativeType::test, {{PirType::any()}}, {{in}}) {}
 };
 
 class FLIE(Subassign1_1D, 4, Effect::None, EnvAccess::Leak) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -174,6 +174,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
 
     case Opcode::asbool_:
+        push(insert(new AsTest(pop())));
+        break;
+
     case Opcode::aslogical_:
         push(insert(new AsLogical(pop(), srcIdx)));
         break;


### PR DESCRIPTION
we compiled RIR asbool_ to PIR AsLogical, which is wrong. As logical
will trim the result to a length 1 logical vector (it is used for ||
and && and such), but astest/asbool_ are used for branches and this
one will throw a warning if the size is not 1 and will throw an error
if the result is NA.