### PR TITLE
avoid deopts when encountering lazy loading stubs

### DIFF
--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1043,7 +1043,7 @@ class VLIE(Call, Effect::Any, EnvAccess::Leak), public CallInstruction {
     Value* cls() { return arg(1).val(); }
 
     Call(Value * callerEnv, Value * fun, const std::vector<Value*>& args,
-         FrameState* fs, unsigned srcIdx)
+         Value* fs, unsigned srcIdx)
         : VarLenInstructionWithEnvSlot(PirType::valOrLazy(), callerEnv,
                                        srcIdx) {
         assert(fs);

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -17,7 +17,8 @@ class BBTransform {
     static Value* forInline(BB* inlinee, BB* cont);
     static BB* lowerExpect(Code* closure, BB* src,
                            BB::Instrs::iterator position, Value* condition,
-                           bool expected, BB* deoptBlock);
+                           bool expected, BB* deoptBlock,
+                           const std::string& debugMesage);
     static void removeBBs(Code* code, const std::unordered_set<BB*>& toDelete);
 };
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -916,7 +916,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
         cs << BC::Factory();                                                   \
         break;                                                                 \
     }
-                SIMPLE(Identical, identical);
+                SIMPLE(Identical, identicalNoforce);
                 SIMPLE(LOr, lglOr);
                 SIMPLE(LAnd, lglAnd);
                 SIMPLE(Inc, inc);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -510,7 +510,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         BINOP(Neq, ne_);
 #undef BINOP
 
-    case Opcode::identical_: {
+    case Opcode::identical_noforce_: {
         auto rhs = pop();
         auto lhs = pop();
         push(insert(new Identical(lhs, rhs)));

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1896,11 +1896,11 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
             NEXT();
         }
 
-        INSTRUCTION(identical_) {
+        INSTRUCTION(identical_noforce_) {
             SEXP rhs = ostack_pop(ctx);
             SEXP lhs = ostack_pop(ctx);
             // This instruction does not force, but we should still compare
-            // the actual promise value if it is already forces.
+            // the actual promise value if it is already forced.
             // Especially important since all the inlined functions are probably
             // behind lazy loading stub promises.
             if (TYPEOF(rhs) == PROMSXP && PRVALUE(rhs) != R_UnboundValue)

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1899,6 +1899,14 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
         INSTRUCTION(identical_) {
             SEXP rhs = ostack_pop(ctx);
             SEXP lhs = ostack_pop(ctx);
+            // This instruction does not force, but we should still compare
+            // the actual promise value if it is already forces.
+            // Especially important since all the inlined functions are probably
+            // behind lazy loading stub promises.
+            if (TYPEOF(rhs) == PROMSXP && PRVALUE(rhs) != R_UnboundValue)
+                rhs = PRVALUE(rhs);
+            if (TYPEOF(lhs) == PROMSXP && PRVALUE(lhs) != R_UnboundValue)
+                lhs = PRVALUE(lhs);
             ostack_push(ctx, rhs == lhs ? R_TrueValue : R_FalseValue);
             NEXT();
         }

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -155,7 +155,7 @@ void BC::write(CodeStream& cs) const {
     case Opcode::le_:
     case Opcode::ge_:
     case Opcode::eq_:
-    case Opcode::identical_:
+    case Opcode::identical_noforce_:
     case Opcode::ne_:
     case Opcode::seq_:
     case Opcode::colon_:
@@ -369,7 +369,7 @@ void BC::print(std::ostream& out) const {
     case Opcode::le_:
     case Opcode::ge_:
     case Opcode::eq_:
-    case Opcode::identical_:
+    case Opcode::identical_noforce_:
     case Opcode::ne_:
     case Opcode::return_:
     case Opcode::isfun_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -222,7 +222,7 @@ BC BC::gt() { return BC(Opcode::gt_); }
 BC BC::le() { return BC(Opcode::le_); }
 BC BC::ge() { return BC(Opcode::ge_); }
 BC BC::eq() { return BC(Opcode::eq_); }
-BC BC::identical() { return BC(Opcode::identical_); }
+BC BC::identicalNoforce() { return BC(Opcode::identical_noforce_); }
 BC BC::ne() { return BC(Opcode::ne_); }
 BC BC::invisible() { return BC(Opcode::invisible_); }
 BC BC::visible() { return BC(Opcode::visible_); }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -350,7 +350,7 @@ class BC {
     inline static BC le();
     inline static BC ge();
     inline static BC eq();
-    inline static BC identical();
+    inline static BC identicalNoforce();
     inline static BC ne();
     inline static BC seq();
     inline static BC colon();
@@ -682,7 +682,7 @@ class BC {
         case Opcode::le_:
         case Opcode::ge_:
         case Opcode::eq_:
-        case Opcode::identical_:
+        case Opcode::identical_noforce_:
         case Opcode::ne_:
         case Opcode::return_:
         case Opcode::isfun_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -100,7 +100,7 @@ static Sources hasSources(Opcode bc) {
         return Sources::Required;
 
     case Opcode::inc_:
-    case Opcode::identical_:
+    case Opcode::identical_noforce_:
     case Opcode::push_:
     case Opcode::ldfun_:
     case Opcode::ldddvar_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -245,7 +245,7 @@ DEF_INSTR(ge_, 0, 2, 1, 0)
 DEF_INSTR(eq_, 0, 2, 1, 0)
 DEF_INSTR(ne_, 0, 2, 1, 0)
 
-DEF_INSTR(identical_, 0, 2, 1, 0)
+DEF_INSTR(identical_noforce_, 0, 2, 1, 0)
 
 /**
  * not_:: unary negation operator !


### PR DESCRIPTION
our guards would fail constantly, because we where comparing the guarded
functions against their lazyloading stub. The reason is that ldvar would
return the stub, without forcing it. Even though the promise is already
long forced. The solution here is a bit hacky, but for now let's just
make identical check if either argument is an already evaluated promise.

Additionally this commit introduces the PIR_DEBUG_DEOPTS env variable
that allows us to print diagnostic information when deopts happen.