### PR TITLE
Refactoring

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -180,7 +180,14 @@ SEXP pirCompile(SEXP what, const std::string& name, pir::DebugOptions debug) {
 
                            // compile back to rir
                            pir::Pir2RirCompiler p2r(logger);
-                           p2r.compile(c, what, dryRun);
+                           auto fun = p2r.compile(c, what, dryRun);
+
+                           // Install
+                           if (dryRun)
+                               return;
+
+                           Protect p(fun->container());
+                           DispatchTable::unpack(BODY(what))->insert(fun);
                        },
                        [&]() {
                            if (debug.includes(pir::DebugFlag::ShowWarnings))

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -1233,7 +1233,7 @@ void Pir2Rir::lower(Code* code) {
             it = next;
         }
     });
-} // namespace
+}
 
 void Pir2Rir::toCSSA(Code* code) {
     // For each Phi, insert copies

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -999,7 +999,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 // staticCall that dispatches to that slot.
 
                 // Avoid recursivly compiling the same closure
-                if (!compiler.alreadyCompiled(cls)) {
+                if (!compiler.alreadyCompiled(call->cls)) {
                     auto fun =
                         compiler.compile(call->cls(), call->origin(), dryRun);
                     Protect p(fun->container());

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -997,7 +997,14 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 // waste that work and actually compile the optimized version,
                 // we need to put it in a specific slot and then have a
                 // staticCall that dispatches to that slot.
-                compiler.compile(call->cls(), call->origin(), dryRun);
+
+                // Avoid recursivly compiling the same closure
+                if (!compiler.alreadyCompiled(cls)) {
+                    auto fun =
+                        compiler.compile(call->cls(), call->origin(), dryRun);
+                    Protect p(fun->container());
+                    DispatchTable::unpack(BODY(call->origin()))->insert(fun);
+                }
                 cs << BC::staticCall(call->nCallArgs(), Pool::get(call->srcIdx),
                                      call->origin());
                 break;
@@ -1141,62 +1148,60 @@ static bool coinFlip() {
 };
 
 void Pir2Rir::lower(Code* code) {
-    Visitor::runPostChange(
-        code->entry, [&](BB* bb) {
-            auto it = bb->begin();
-            while (it != bb->end()) {
-                auto next = it + 1;
-                if (auto call = CallInstruction::CastCall(*it))
-                    call->clearFrameState();
-                if (auto ldfun = LdFun::Cast(*it)) {
-                    // the guessed binding in ldfun is just used as a temporary
-                    // store. If we did not manage to resolve ldfun by now, we
-                    // have to remove the guess again, since apparently we
-                    // where not sure it is correct.
-                    if (ldfun->guessedBinding())
-                        ldfun->clearGuessedBinding();
-                } else if (auto deopt = Deopt::Cast(*it)) {
-                    // Lower Deopt instructions + their FrameStates to a
-                    // ScheduledDeopt.
-                    auto newDeopt = new ScheduledDeopt();
-                    newDeopt->consumeFrameStates(deopt);
-                    bb->replace(it, newDeopt);
-                } else if (auto expect = Assume::Cast(*it)) {
-                    auto condition = expect->condition();
-                    if (DEOPT_CHAOS && coinFlip()) {
-                        condition = expect->assumeTrue
-                                        ? (Value*)False::instance()
-                                        : (Value*)True::instance();
-                    }
-                    BBTransform::lowerExpect(
-                        code, bb, it, condition, expect->assumeTrue,
-                        expect->checkpoint()->bb()->falseBranch());
-                    // lowerExpect splits the bb from current position. There
-                    // remains nothing to process. Breaking seems more robust
-                    // than trusting the modified iterator.
-                    break;
-                } else if (auto call = Call::Cast(*it)) {
-                    // Lower calls to call implicit
-                    std::vector<Promise*> args;
-                    if (allLazy(call, args))
-                        call->replaceUsesAndSwapWith(
-                            new CallImplicit(call->callerEnv(), call->cls(),
-                                             std::move(args), {}, call->srcIdx),
-                            it);
-                } else if (auto call = NamedCall::Cast(*it)) {
-                    // Lower named calls to call implicit
-                    std::vector<Promise*> args;
-                    if (allLazy(call, args))
-                        call->replaceUsesAndSwapWith(
-                            new CallImplicit(call->callerEnv(), call->cls(),
-                                             std::move(args), call->names,
-                                             call->srcIdx),
-                            it);
+    Visitor::runPostChange(code->entry, [&](BB* bb) {
+        auto it = bb->begin();
+        while (it != bb->end()) {
+            auto next = it + 1;
+            if (auto call = CallInstruction::CastCall(*it))
+                call->clearFrameState();
+            if (auto ldfun = LdFun::Cast(*it)) {
+                // the guessed binding in ldfun is just used as a temporary
+                // store. If we did not manage to resolve ldfun by now, we
+                // have to remove the guess again, since apparently we
+                // where not sure it is correct.
+                if (ldfun->guessedBinding())
+                    ldfun->clearGuessedBinding();
+            } else if (auto deopt = Deopt::Cast(*it)) {
+                // Lower Deopt instructions + their FrameStates to a
+                // ScheduledDeopt.
+                auto newDeopt = new ScheduledDeopt();
+                newDeopt->consumeFrameStates(deopt);
+                bb->replace(it, newDeopt);
+            } else if (auto expect = Assume::Cast(*it)) {
+                auto condition = expect->condition();
+                if (DEOPT_CHAOS && coinFlip()) {
+                    condition = expect->assumeTrue ? (Value*)False::instance()
+                                                   : (Value*)True::instance();
                 }
-
-                it = next;
+                BBTransform::lowerExpect(
+                    code, bb, it, condition, expect->assumeTrue,
+                    expect->checkpoint()->bb()->falseBranch());
+                // lowerExpect splits the bb from current position. There
+                // remains nothing to process. Breaking seems more robust
+                // than trusting the modified iterator.
+                break;
+            } else if (auto call = Call::Cast(*it)) {
+                // Lower calls to call implicit
+                std::vector<Promise*> args;
+                if (allLazy(call, args))
+                    call->replaceUsesAndSwapWith(
+                        new CallImplicit(call->callerEnv(), call->cls(),
+                                         std::move(args), {}, call->srcIdx),
+                        it);
+            } else if (auto call = NamedCall::Cast(*it)) {
+                // Lower named calls to call implicit
+                std::vector<Promise*> args;
+                if (allLazy(call, args))
+                    call->replaceUsesAndSwapWith(
+                        new CallImplicit(call->callerEnv(), call->cls(),
+                                         std::move(args), call->names,
+                                         call->srcIdx),
+                        it);
             }
-        });
+
+            it = next;
+        }
+    });
 
     Visitor::run(code->entry, [&](BB* bb) {
         auto it = bb->begin();
@@ -1285,31 +1290,14 @@ rir::Function* Pir2Rir::finalize() {
 
 } // namespace
 
-void Pir2RirCompiler::compile(Closure* cls, SEXP origin, bool dryRun) {
-    if (done.count(cls))
-        return;
-    // Avoid recursivly compiling the same closure
-    done.insert(cls);
-
-    auto table = DispatchTable::unpack(BODY(origin));
-    if (table->contains(cls->assumptions))
-        return;
-
+rir::Function* Pir2RirCompiler::compile(Closure* cls, SEXP origin,
+                                        bool dryRun) {
     auto& log = logger.get(cls);
-    Pir2Rir pir2rir(*this, cls, origin, dryRun, logger.get(cls));
+    done.insert(cls);
+    Pir2Rir pir2rir(*this, cls, origin, dryRun, log);
     auto fun = pir2rir.finalize();
-
-    if (dryRun)
-        return;
-
-    Protect p(fun->container());
-
-    auto oldFun = table->baseline();
-    fun->body()->funInvocationCount = oldFun->body()->funInvocationCount;
-
-    table->insert(fun);
-
     log.flush();
+    return fun;
 }
 
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -999,7 +999,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 // staticCall that dispatches to that slot.
 
                 // Avoid recursivly compiling the same closure
-                if (!compiler.alreadyCompiled(call->cls)) {
+                if (!compiler.alreadyCompiled(call->cls())) {
                     auto fun =
                         compiler.compile(call->cls(), call->origin(), dryRun);
                     Protect p(fun->container());

--- a/rir/src/compiler/translations/pir_2_rir.h
+++ b/rir/src/compiler/translations/pir_2_rir.h
@@ -18,9 +18,11 @@ class Pir2RirCompiler {
     Pir2RirCompiler(const Pir2RirCompiler&) = delete;
     Pir2RirCompiler& operator=(const Pir2RirCompiler&) = delete;
 
-    void compile(Closure* cls, SEXP origin, bool dryRun);
+    rir::Function* compile(Closure* cls, SEXP origin, bool dryRun);
 
     StreamLogger& logger;
+
+    bool alreadyCompiled(Closure* cls) { return done.count(cls); }
 
   private:
     std::unordered_set<Closure*> done;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -372,8 +372,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                                       bc.immediate.callFixedArgs.ast)));
         } else {
             auto fs = insert.registerFrameState(srcCode, nextPos, stack);
-            push(insert(
-                new Call(env, target, args, fs, bc.immediate.callFixedArgs.ast)));
+            push(insert(new Call(env, target, args, fs,
+                                 bc.immediate.callFixedArgs.ast)));
         }
         break;
     }
@@ -400,7 +400,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             compiler.compileClosure(
                 target, "", asmpt,
                 [&](Closure* f) {
-                    auto fs = insert.registerFrameState(srcCode, nextPos, stack);
+                    auto fs =
+                        insert.registerFrameState(srcCode, nextPos, stack);
                     push(insert(new StaticCall(env, f, args, target, fs, ast)));
                 },
                 [&]() { failed = true; });

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -236,12 +236,6 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, ::Context* ctx) {
     assert(f->size <= XLENGTH(sexp) and
            "Reported size must be smaller than the size of the vector");
 
-    if (f->origin()) {
-        assert(TYPEOF(f->origin()) == EXTERNALSXP and "Invalid origin type");
-        assert(Function::unpack(f->origin())->info.magic == FUNCTION_MAGIC and
-               "Origin does not seem to be function bytecode");
-    }
-
     // check that the call instruction has proper arguments and number of
     // instructions is valid
     bool sawReturnOrBackjump = false;

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -39,7 +39,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     friend class FunctionCodeIterator;
     friend class ConstFunctionCodeIterator;
 
-    static constexpr size_t NUM_PTRS = 3;
+    static constexpr size_t NUM_PTRS = 1;
 
     Function(size_t functionSize, SEXP body_,
              const std::vector<SEXP>& defaultArgs,
@@ -50,19 +50,15 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
               NUM_PTRS + defaultArgs.size()),
           size(functionSize), deopt(false), markOpt(false),
           numArgs(defaultArgs.size()), signature_(signature) {
-        next(nullptr);
         for (size_t i = 0; i < numArgs; ++i)
             setEntry(NUM_PTRS + i, defaultArgs[i]);
         body(body_);
     }
 
-    Code* body() { return Code::unpack(getEntry(2)); }
-    void body(SEXP body) { setEntry(2, body); }
+    Code* body() { return Code::unpack(getEntry(0)); }
+    void body(SEXP body) { setEntry(0, body); }
 
     void disassemble(std::ostream&);
-
-    FunctionSEXP next() { return getEntry(1); }
-    void next(FunctionSEXP s) { setEntry(1, s); }
 
     Code* defaultArg(size_t i) const {
         assert(i < numArgs);

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -50,7 +50,6 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
               NUM_PTRS + defaultArgs.size()),
           size(functionSize), deopt(false), markOpt(false),
           numArgs(defaultArgs.size()), signature_(signature) {
-        origin(nullptr);
         next(nullptr);
         for (size_t i = 0; i < numArgs; ++i)
             setEntry(NUM_PTRS + i, defaultArgs[i]);
@@ -61,9 +60,6 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     void body(SEXP body) { setEntry(2, body); }
 
     void disassemble(std::ostream&);
-
-    FunctionSEXP origin() { return getEntry(0); }
-    void origin(FunctionSEXP s) { setEntry(0, s); }
 
     FunctionSEXP next() { return getEntry(1); }
     void next(FunctionSEXP s) { setEntry(1, s); }
@@ -97,6 +93,6 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     CodeSEXP defaultArg_[];
 };
 #pragma pack(pop)
-}
+} // namespace rir
 
 #endif


### PR DESCRIPTION
This refactoring just changes the `pir2rir` compiler so that it does not have anymore the responsibility of installing the resulting optimized function in the corresponding place. It now just returns the function and it is the responsibility of the client to decide what to do. It also removes the `origin` and `next` fields from RIR functions which was created for managing different optimizations levels of the same function but it is actually not used. For managing the different optimization levels we resort to the different slots of the dispatch table.