### PR TITLE
eagerly force arguments to builtin functions

### DIFF
--- a/rir/src/R/Funtab.h
+++ b/rir/src/R/Funtab.h
@@ -115,6 +115,7 @@ static inline CCODE getBuiltin(SEXP f) {
 }
 static inline int getBuiltinNr(SEXP f) { return ((sexprec_rjit*)f)->u.i; }
 static inline const char* getBuiltinName(int i) { return R_FunTab[i].name; }
+static inline int getBuiltinArity(SEXP f) { return R_FunTab[getBuiltinNr(f)].arity; }
 static inline int getFlag(SEXP f) {
     int i = ((sexprec_rjit*)f)->u.i;
     return (((R_FunTab[i].eval) / 100) % 10);

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -45,8 +45,10 @@ void ElideEnv::apply(RirCompiler&, Closure* function, LogStream&) const {
                             if (v != i->env())
                                 args.push_back(v);
                         });
-                        bb->replace(
-                            ip, new CallSafeBuiltin(b->blt, args, b->srcIdx));
+                        auto safe =
+                            new CallSafeBuiltin(b->blt, args, b->srcIdx);
+                        b->replaceUsesWith(safe);
+                        bb->replace(ip, safe);
                         envIsNeeded = false;
                     }
                 }

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -241,16 +241,16 @@ void ForceDominance::apply(RirCompiler&, Closure* cls, LogStream& log) const {
             while (ip != bb->end()) {
                 auto next = ip + 1;
                 if (auto f = Force::Cast(*ip)) {
-                    if (result.isDominatingForce(f)) {
+                    if (result.isDominatingForce(f))
                         f->strict = true;
-                        if (auto mkarg =
-                                MkArg::Cast(f->followCastsAndForce())) {
-                            Value* strict = mkarg->eagerArg();
-                            if (strict != Missing::instance()) {
-                                f->replaceUsesWith(strict);
-                                next = bb->remove(ip);
-                                inlinedPromise[f] = strict;
-                            } else if (result.isSafeToInline(mkarg)) {
+
+                    if (auto mkarg = MkArg::Cast(f->followCastsAndForce())) {
+                        Value* eager = mkarg->eagerArg();
+                        if (eager != Missing::instance()) {
+                            f->replaceUsesWith(eager);
+                            next = bb->remove(ip);
+                        } else if (result.isDominatingForce(f)) {
+                            if (result.isSafeToInline(mkarg)) {
                                 Promise* prom = mkarg->prom();
                                 BB* split = BBTransform::split(code->nextBBId++,
                                                                bb, ip, code);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -447,7 +447,7 @@ StaticCall::StaticCall(Value* callerEnv, Closure* cls,
     assert(fs);
     pushArg(fs, NativeType::frameState);
     for (unsigned i = 0; i < args.size(); ++i)
-        pushArg(args[i], PirType::val());
+        pushArg(args[i], RType::prom);
 }
 
 CallInstruction* CallInstruction::CastCall(Value* v) {
@@ -474,7 +474,7 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     assert(names_.size() == args.size());
     pushArg(fun, RType::closure);
     for (unsigned i = 0; i < args.size(); ++i) {
-        pushArg(args[i], PirType::val());
+        pushArg(args[i], RType::prom);
         auto name = Pool::get(names_[i]);
         assert(TYPEOF(name) == SYMSXP || name == R_NilValue);
         names.push_back(name);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -311,9 +311,8 @@ CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
 
 CallBuiltin::CallBuiltin(Value* env, SEXP builtin,
                          const std::vector<Value*>& args, unsigned srcIdx)
-    : VarLenInstructionWithEnvSlot(PirType::valOrLazy(), env, srcIdx),
-      blt(builtin), builtin(getBuiltin(builtin)),
-      builtinId(getBuiltinNr(builtin)) {
+    : VarLenInstructionWithEnvSlot(PirType::val(), env, srcIdx), blt(builtin),
+      builtin(getBuiltin(builtin)), builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
         this->pushArg(args[i], PirType::val());
 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1050,7 +1050,7 @@ class VLIE(Call, Effect::Any, EnvAccess::Leak), public CallInstruction {
         pushArg(fs, NativeType::frameState);
         pushArg(fun, RType::closure);
         for (unsigned i = 0; i < args.size(); ++i)
-            pushArg(args[i], PirType::val());
+            pushArg(args[i], RType::prom);
     }
 
     Closure* tryGetCls() override final {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -302,12 +302,18 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                 }
             }
             Value* val = Missing::instance();
-            if (Query::pure(prom))
+            if (monomorphicBuiltin || Query::pure(prom))
                 if (auto inlineProm = tryTranslate(promiseCode, insert))
                     val = inlineProm;
-            Value* res = insert(new MkArg(prom, val, env));
+            Value* res = nullptr;
+            // TODO: this fails on some builtins, need to investigate why
+            // if (monomorphicBuiltin && val != Missing::instance()) {
+            //     res = val;
+            // } else {
+            res = insert(new MkArg(prom, val, env));
             if (monomorphicBuiltin)
                 res = insert(new Force(res, env));
+            // }
             args.push_back(res);
         }
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -32,6 +32,8 @@ class Rir2Pir {
 
     Value* tryTranslate(rir::Code* srcCode, Builder& insert) const
         __attribute__((warn_unused_result));
+    Value* tryTranslatePromise(rir::Code* srcCode, Builder& insert) const
+        __attribute__((warn_unused_result));
 
     void finalize(Value*, Builder& insert);
 
@@ -47,7 +49,13 @@ class Rir2Pir {
     bool compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                    rir::Code* srcCode, RirStack&, Builder&,
                    CallTargetFeedback&) const;
-    virtual bool inPromise() const { return false; }
+    virtual bool inPromise() const { return inPromise_; }
+
+    Checkpoint* addCheckpoint(rir::Code* srcCode, Opcode* pos,
+                              const RirStack& stack, Builder& insert) const;
+
+  private:
+    bool inPromise_ = false;
 };
 
 class PromiseRir2Pir : public Rir2Pir {

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -65,8 +65,8 @@ FrameState* Builder::registerFrameState(rir::Code* srcCode, Opcode* pos,
     return sp;
 };
 
-Checkpoint* Builder::addCheckpoint(rir::Code* srcCode, Opcode* pos,
-                                   const RirStack& stack) {
+Checkpoint* Builder::emitCheckpoint(rir::Code* srcCode, Opcode* pos,
+                                    const RirStack& stack) {
     auto cp = new Checkpoint();
     add(cp);
     auto cont = createBB();

--- a/rir/src/compiler/util/builder.h
+++ b/rir/src/compiler/util/builder.h
@@ -45,8 +45,8 @@ class Builder {
 
     FrameState* registerFrameState(rir::Code* srcCode, Opcode* pos,
                                    const RirStack& stack);
-    Checkpoint* addCheckpoint(rir::Code* srcCode, Opcode* pos,
-                              const RirStack& stack);
+    Checkpoint* emitCheckpoint(rir::Code* srcCode, Opcode* pos,
+                               const RirStack& stack);
 
     // Use with care, let the builder keep track of BB. Prefer the highlevel
     // api above.

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -75,6 +75,7 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         return true;
 
     static int safeBuiltins[] = {
+        findBuiltin("c"),
         findBuiltin("["),
         findBuiltin("[["),
         findBuiltin("+"),


### PR DESCRIPTION
see individual commit msgs.


We missed this in the past, so we would actually pass unevaluated promises. (in short this means that speculating on builtins was mostly broken :) )

but, for that reason I had to move the guard before the evaluation of the promises, because of course if we force an argument, then find out that we are actually not calling a builtin after all, then the forcing would have been wrong.