### PR TITLE
fix elide_env issue

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -148,6 +148,12 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     auto top = [&stack]() { return stack.at(0); };
     auto set = [&stack](unsigned i, Value* v) { stack.at(i) = v; };
 
+    auto forceIfLazy = [&](unsigned i) {
+        if (stack.at(i)->type.maybeLazy()) {
+            stack.at(i) = insert(new Force(at(i), env));
+        }
+    };
+
     switch (bc.bc) {
 
     case Opcode::push_:
@@ -426,6 +432,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
 
     case Opcode::extract1_1_: {
+        forceIfLazy(1); // <- ensure forced version are captured in framestate
+        forceIfLazy(0);
         insert.addCheckpoint(srcCode, pos, stack);
         Value* idx = pop();
         Value* vec = pop();
@@ -434,6 +442,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::extract2_1_: {
+        forceIfLazy(1); // <- ensure forced version are captured in framestate
+        forceIfLazy(0);
         insert.addCheckpoint(srcCode, pos, stack);
         Value* idx = pop();
         Value* vec = pop();
@@ -442,7 +452,15 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::extract1_2_: {
-        insert.addCheckpoint(srcCode, pos, stack);
+        // TODO: checkpoint here is broken. What we should do here is insert a
+        // checkpoint between every force, and then deopt between forcing. E.g.
+        // if in a[b,c] b turns out to be an object, we need a deopt exit that
+        // captures the forced a, forced b and unforced c. So we cannot have
+        // deopt like now right in front of the Extract2_2D, but instead we need
+        // 3 different deopts after every force.
+        // For that we need to fix elide_env_spec to insert the assumes in the
+        // right place (ie, after the force and not before the Extract)
+        // insert.addCheckpoint(srcCode, pos, stack);
         Value* idx2 = pop();
         Value* idx1 = pop();
         Value* vec = pop();
@@ -451,7 +469,15 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::extract2_2_: {
-        insert.addCheckpoint(srcCode, pos, stack);
+        // TODO: checkpoint here is broken. What we should do here is insert a
+        // checkpoint between every force, and then deopt between forcing. E.g.
+        // if in a[b,c] b turns out to be an object, we need a deopt exit that
+        // captures the forced a, forced b and unforced c. So we cannot have
+        // deopt like now right in front of the Extract2_2D, but instead we need
+        // 3 different deopts after every force.
+        // For that we need to fix elide_env_spec to insert the assumes in the
+        // right place (ie, after the force and not before the Extract)
+        // insert.addCheckpoint(srcCode, pos, stack);
         Value* idx2 = pop();
         Value* idx1 = pop();
         Value* vec = pop();
@@ -460,7 +486,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::subassign1_: {
-        insert.addCheckpoint(srcCode, pos, stack);
         Value* idx = pop();
         Value* vec = pop();
         Value* val = pop();
@@ -469,7 +494,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::subassign2_: {
-        insert.addCheckpoint(srcCode, pos, stack);
         Value* idx = pop();
         Value* vec = pop();
         Value* val = pop();
@@ -488,10 +512,18 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         BINOP_NOENV(LAnd, lgl_and_);
 #undef BINOP_NOENV
 
+        // Explicit force below to ensure that framestate contains the forced
+        // version
+        // Forcing of both args is ok here, even if lhs is an object, because
+        // binop dispatch in R always forces both arguments before deciding on
+        // a dispatch strategy.
+
 #define BINOP(Name, Op)                                                        \
     case Opcode::Op: {                                                         \
-        auto rhs = at(0);                                                      \
+        forceIfLazy(1);                                                        \
+        forceIfLazy(0);                                                        \
         auto lhs = at(1);                                                      \
+        auto rhs = at(0);                                                      \
         insert.addCheckpoint(srcCode, pos, stack);                             \
         pop();                                                                 \
         pop();                                                                 \

--- a/rir/tests/pir_regression_splines.R
+++ b/rir/tests/pir_regression_splines.R
@@ -1,0 +1,30 @@
+options(continue="  ", width=60)
+options(SweaveHooks=list(fig=function() par(mar=c(4.1, 4.1, .3, 1.1))))
+pdf.options(pointsize=8) #text in graph about the same as regular text
+options(contrasts=c("contr.treatment", "contr.poly")) #reset default
+require(survival)
+mfit <- coxph(Surv(futime, death) ~ sex + pspline(age, df=4), data=mgus)
+mfit
+termplot(mfit, term=2, se=TRUE, col.term=1, col.se=1)
+ptemp <- termplot(mfit, se=TRUE, plot=FALSE)
+attributes(ptemp)
+ptemp$age[1:4,]
+ageterm <- ptemp$age  # this will be a data frame
+center <- with(ageterm, y[x==50])
+ytemp <- ageterm$y + outer(ageterm$se, c(0, -1.96, 1.96), '*')
+matplot(ageterm$x, exp(ytemp - center), log='y',
+        type='l', lty=c(1,2,2), col=1, 
+        xlab="Age at diagnosis", ylab="Relative death rate")
+fit <- coxph(Surv(futime, death) ~ age + pspline(hgb, 4), mgus2)
+fit
+termplot(fit, se=TRUE, term=2, col.term=1, col.se=1,
+         xlab="Hemoglobin level")
+termplot(fit, se=TRUE, col.term=1, col.se=1, term=2,
+         xlab="Hemoglobin level", ylim=c(-.4, 1.3))
+df <- c(3, 2.5, 2)
+for (i in 1:3) {
+    tfit <- coxph(Surv(futime, death) ~ age + 
+                  pspline(hgb, df[i], nterm=8), mgus2)
+    temp <- termplot(tfit, se=FALSE, plot=FALSE, term=2)
+    lines(temp$hgb$x, temp$hgb$y, col=i+1, lwd=2)
+}


### PR DESCRIPTION
In general we should make sure that our framestates capture
the forced versions of a value, if we are going to force it.

additionally the speculation on `a[b,c]` is currently wrong.
we need to look at it more carefully and decide what to do.