### PR TITLE
Lazy context's promargs

### DIFF
--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -23,10 +23,10 @@ SEXP rirExpr(SEXP f);
 
 SEXP rirEval_f(SEXP f, SEXP env);
 
+SEXP argsLazyCreation(void* rirDataWrapper);
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif // RIR_INTERPRETER_C_H
-
-

--- a/rir/src/interpreter/interp_context.h
+++ b/rir/src/interpreter/interp_context.h
@@ -47,14 +47,14 @@ typedef struct {
 
  */
 
-typedef struct {
+struct Context {
     SEXP list;
     ResizeableList cp;
     ResizeableList src;
     ExprCompiler exprCompiler;
     ClosureCompiler closureCompiler;
     ClosureOptimizer closureOptimizer;
-} Context;
+};
 
 // Some symbols
 extern SEXP R_Subset2Sym;

--- a/rir/src/interpreter/interp_data.h
+++ b/rir/src/interpreter/interp_data.h
@@ -1,26 +1,26 @@
 #ifndef RIR_INTERPRETER_DATA_C_H
 #define RIR_INTERPRETER_DATA_C_H
 
-#include <stdint.h>
-#include <assert.h>
 #include "../config.h"
+#include <assert.h>
+#include <stdint.h>
 
+#include "runtime/ArgsLazyData.h"
 #include "runtime/Code.h"
-#include "runtime/Function.h"
 #include "runtime/DispatchTable.h"
+#include "runtime/Function.h"
 
 #include "R/r.h"
 
-
-#if defined(__GNUC__) && (! defined(NO_THREADED_CODE))
-#  define THREADED_CODE
+#if defined(__GNUC__) && (!defined(NO_THREADED_CODE))
+#define THREADED_CODE
 #endif
 
 // Indicates an argument is missing
 #define MISSING_ARG_IDX ((unsigned)-1)
 // Indicates an argument does not correspond to a valid CodeObject
 #define DOTS_ARG_IDX ((unsigned)-2)
-// Maximum valid entry for a CodeObject offset/idx entry 
+// Maximum valid entry for a CodeObject offset/idx entry
 #define MAX_ARG_IDX ((unsigned)-3)
 
 const static uint32_t NO_DEOPT_INFO = (uint32_t)-1;

--- a/rir/src/interpreter/runtime.cpp
+++ b/rir/src/interpreter/runtime.cpp
@@ -35,7 +35,7 @@ void initializeRuntime() {
     R_PreserveObject(promExecName);
     // initialize the global context
     globalContext_ = context_create();
-    registerExternalCode(rirEval_f, rir_compile, rirExpr);
+    registerExternalCode(rirEval_f, rir_compile, rirExpr, argsLazyCreation);
     configurations = new rir::Configurations();
 }
 

--- a/rir/src/runtime/ArgsLazyData.h
+++ b/rir/src/runtime/ArgsLazyData.h
@@ -1,0 +1,42 @@
+#ifndef RIR_ARGS_LAZY_H
+#define RIR_ARGS_LAZY_H
+
+#include "RirDataWrapper.h"
+#include <cassert>
+#include <cstdint>
+#include <functional>
+
+struct CallContext;
+struct Context;
+SEXP createLegacyArgsListFromStackValues(const CallContext& call,
+                                         bool eagerCallee, Context* ctx);
+
+namespace rir {
+
+typedef std::function<SEXP(void*)> LazyFunction;
+
+#define LAZY_ARGS_MAGIC 0x1a27a000
+
+/**
+ * ArgsLazyCreation holds the information needed to recreate the
+ * arguments list needed by gnu-r contexts whenever a function
+ * is called, lazily. In RCNTXT the field that hold the list is
+ * promargs.
+ */
+
+struct ArgsLazyData : public RirDataWrapper<ArgsLazyData, LAZY_ARGS_MAGIC> {
+    ArgsLazyData() = delete;
+    ArgsLazyData(const CallContext* callCtx, Context* cmpCtx)
+        : RirDataWrapper(2), callContext(callCtx), compilationContext(cmpCtx){};
+
+    const CallContext* callContext;
+    Context* compilationContext;
+
+    SEXP createArgsLists() {
+        return createLegacyArgsListFromStackValues(*callContext, false,
+                                                   compilationContext);
+    }
+};
+} // namespace rir
+
+#endif

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -145,6 +145,6 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
 
 #pragma pack(pop)
 
-}
+} // namespace rir
 
 #endif

--- a/rir/src/runtime/RirDataWrapper.h
+++ b/rir/src/runtime/RirDataWrapper.h
@@ -1,0 +1,48 @@
+#ifndef RIR_DATA_WRAPPER_H
+#define RIR_DATA_WRAPPER_H
+
+/** RirDataWrappers are wrappers (usually over SEXP) of relevant
+ * RIR level information that must be shared to the gnu-r
+ * interpreter. For instance for the interpreter to lazily
+ * create stuff depending on RIR information
+ */
+
+#include "R/r.h"
+#include <cassert>
+#include <cstdint>
+
+namespace rir {
+
+struct data_header {
+    // magic number to differentiate RIR objects
+    // needs to be in sync with gnur context.c
+    uint32_t magic;
+};
+
+template <typename BASE, uint32_t MAGIC>
+struct RirDataWrapper {
+    data_header info;
+
+    static BASE* check(SEXP s) {
+        BASE* b = (BASE*)s;
+        return b->info.magic == MAGIC ? b : nullptr;
+    }
+
+    static BASE* unpack(void* s) {
+        BASE* b = (BASE*)s;
+        assert(
+            b->info.magic == MAGIC &&
+            "Trying to unpack the wrong type of embedded RIR runtime object.");
+        return b;
+    }
+
+  protected:
+    RirDataWrapper(uint32_t count) : info{MAGIC} {
+        uint8_t* start = (uint8_t*)this + sizeof(uint32_t);
+        memset(start, 0, count * sizeof(void*));
+    }
+};
+
+} // namespace rir
+
+#endif


### PR DESCRIPTION
Do not create argslists (needed by gnu-r contexts) when we may not need them. For instance on eager calls. Instead, we put in the corresponding field a wrapper with all the necessary data to lazily create them in case later gnu-r triggers and needs them (for instance for S3 dispatching). 

I am not sure how much it pays off. We are creating the `c wrappers` instead of the `R SEXP`. There we should be faster. But then, the change needs some tests here and there (on every call) to check if the field is actually an argslists or a wrapper. 

If it finally pays off, a second iteration could go through those.