### PR TITLE
fix call.nargs if dispatch pushes missing args

### DIFF
--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -78,7 +78,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
 
     unsigned numArgs;
 
-    const FunctionSignature& signature() { return signature_; }
+    const FunctionSignature& signature() const { return signature_; }
 
   private:
     FunctionSignature signature_; /// pointer to this version's signature

--- a/rir/tests/pir_regression_missing.R
+++ b/rir/tests/pir_regression_missing.R
@@ -1,0 +1,70 @@
+f <- function(a,b,c) nargs()
+g <- function() {
+  f()
+  f(1)
+  f(1,2)
+  f(1,2,3)
+}
+h <- function() g()
+
+f <- pir.compile(rir.compile(f))
+g <- pir.compile(rir.compile(g))
+h <- pir.compile(rir.compile(h))
+
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+
+
+
+
+f <- function(a,b,c) nargs() + (if (!missing(a)) a else 1)
+g <- function() {
+  stopifnot(f() == 1)
+  stopifnot(f(1) == 2)
+  stopifnot(f(1,2) == 3)
+  stopifnot(f(1,2,3) == 4)
+  f(1,2)
+}
+h <- function() g()
+
+f <- pir.compile(rir.compile(f))
+g <- pir.compile(rir.compile(g))
+h <- pir.compile(rir.compile(h))
+
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+
+
+
+
+f <- function(a,b,c) nargs() + a
+g <- function(q) {
+  stopifnot(f(q) == 2)
+  print (f(q,2))
+  stopifnot(f(q,2) == 3)
+  stopifnot(f(q,2,3) == 4)
+  f(q,2)
+}
+h <- function() g(1)
+
+f <- pir.compile(rir.compile(f))
+g <- pir.compile(rir.compile(g))
+h <- rir.compile(h)
+
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)
+stopifnot(h()==3)


### PR DESCRIPTION
during PIR dispatch we explicitly materialize R_MissingArg on the
stack, if the callee does not provide enough arguments. But this
needs to be reflected in the call.nargs field. Because, for example
we need to remove the missing args again, or we need to inform
the callee that the missing args are there.