### PR TITLE
 make pir typesystem differ between values and promise wrapped values

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -138,7 +138,8 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
         auto force = Force::Cast(i);
         auto arg = force->arg<0>().val();
         if (!arg->type.maybeLazy()) {
-            effect.max(state.returnValues[i].merge(ValOrig(arg, i, depth)));
+            if (!arg->type.maybePromiseWrapped())
+                effect.max(state.returnValues[i].merge(ValOrig(arg, i, depth)));
             handled = true;
         }
 
@@ -146,7 +147,9 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
             lookup(state, arg->followCastsAndForce(),
                    [&](const AbstractPirValue& analysisRes) {
                        if (!analysisRes.type.maybeLazy()) {
-                           effect.max(state.returnValues[i].merge(analysisRes));
+                           if (!analysisRes.type.maybePromiseWrapped())
+                               effect.max(
+                                   state.returnValues[i].merge(analysisRes));
                            handled = true;
                        } else if (analysisRes.isSingleValue()) {
                            arg = analysisRes.singleValue().val;

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -35,7 +35,7 @@ class TheCleanup {
                     next = bb->remove(ip);
                 } else if (auto force = Force::Cast(i)) {
                     Value* arg = force->input();
-                    if (PirType::valOrMissing().isSuper(arg->type)) {
+                    if (!arg->type.maybePromiseWrapped()) {
                         removed = true;
                         force->replaceUsesWith(arg);
                         next = bb->remove(ip);

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -63,7 +63,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                 version, newAssumptions, [&](ClosureVersion* newCls) {
                     Visitor::run(newCls->entry, [&](Instruction* i) {
                         if (auto ld = LdArg::Cast(i)) {
-                            ld->type = PirType::val();
+                            ld->type = PirType::promiseWrappedVal();
                             ld->type.setNotObject();
                         }
                     });

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -59,6 +59,11 @@ void ElideEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                     if (!Env::isPirEnv(i))
                         envDependency[i] = i->env();
                 }
+
+                if (auto force = Force::Cast(i)) {
+                    if (!force->input()->type.maybeLazy())
+                        force->elideEnv();
+                }
             }
         }
     });

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -172,7 +172,7 @@ class TheInliner {
                                     a, RType::prom,
                                     mk->eagerArg() == Missing::instance()
                                         ? PirType::any()
-                                        : PirType::val());
+                                        : PirType::promiseWrappedVal());
                                 ip = bb->insert(ip + 1, cast);
                                 ip--;
                                 a = cast;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -739,11 +739,12 @@ class FLIE(Force, 2, Effect::Any, EnvAccess::Leak) {
     // Set to true if we are sure that the promise will be forced here
     bool strict = false;
     Force(Value* in, Value* env)
-        : FixedLenInstructionWithEnvSlot(PirType::val(), {{PirType::any()}},
+        : FixedLenInstructionWithEnvSlot(in->type.forced(), {{PirType::any()}},
                                          {{in}}, env) {}
     Value* input() const { return arg(0).val(); }
     const char* name() const override { return strict ? "Force!" : "Force"; }
     bool hasEffect() const override final { return input()->type.maybeLazy(); }
+    void updateType() override final { type = arg<0>().val()->type.forced(); }
 };
 
 class FLI(CastType, 1, Effect::None, EnvAccess::None) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -274,7 +274,7 @@ class InstructionImplementation : public Instruction {
     static constexpr bool mayChangeEnv_ = ENV >= EnvAccess::Write;
     static constexpr bool mayLeakEnv_ = ENV >= EnvAccess::Leak;
 
-    bool hasEffect() const override final { return EFFECT > Effect::None; }
+    bool hasEffect() const override { return EFFECT > Effect::None; }
     bool mayForcePromises() const override final {
         return EFFECT >= Effect::Force;
     }
@@ -743,6 +743,7 @@ class FLIE(Force, 2, Effect::Any, EnvAccess::Leak) {
                                          {{in}}, env) {}
     Value* input() const { return arg(0).val(); }
     const char* name() const override { return strict ? "Force!" : "Force"; }
+    bool hasEffect() const override final { return input()->type.maybeLazy(); }
 };
 
 class FLI(CastType, 1, Effect::None, EnvAccess::None) {

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -240,19 +240,25 @@ struct PirType {
         return t;
     }
 
+    PirType forced() const {
+        assert(isRType());
+        PirType t = *this;
+        t.flags_.reset(TypeFlags::promiseWrapped);
+        t.flags_.reset(TypeFlags::lazy);
+        t.flags_.reset(TypeFlags::missing);
+        return t;
+    }
+
     RIR_INLINE PirType baseType() const {
         assert(isRType());
         return PirType(t_.r);
     }
 
     RIR_INLINE void setNotObject() { *this = notObject(); }
-
     RIR_INLINE void setScalar() { *this = scalar(); }
 
     static const PirType voyd() { return NativeTypeSet(); }
-
     static const PirType missing() { return bottom().orMissing(); }
-
     static const PirType bottom() { return PirType(RTypeSet()); }
 
     RIR_INLINE PirType operator|(const PirType& o) const {

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -81,6 +81,7 @@ enum class TypeFlags : uint8_t {
     _UNUSED_,
 
     lazy,
+    promiseWrapped,
     missing,
     isScalar,
     maybeObject,
@@ -175,6 +176,7 @@ struct PirType {
     static PirType vecs() { return num() | RType::str | RType::vec; }
     static PirType closure() { return RType::closure; }
 
+    static PirType promiseWrappedVal() { return val().orPromiseWrapped(); }
     static PirType valOrMissing() { return val().orMissing(); }
     static PirType valOrLazy() { return val().orLazy(); }
     static PirType list() { return PirType(RType::cons) | RType::nil; }
@@ -185,6 +187,9 @@ struct PirType {
     }
     RIR_INLINE bool maybeLazy() const {
         return flags_.includes(TypeFlags::lazy);
+    }
+    RIR_INLINE bool maybePromiseWrapped() const {
+        return flags_.includes(TypeFlags::promiseWrapped);
     }
     RIR_INLINE bool isScalar() const {
         return flags_.includes(TypeFlags::isScalar);
@@ -220,10 +225,18 @@ struct PirType {
         return t;
     }
 
+    RIR_INLINE PirType orPromiseWrapped() const {
+        assert(isRType());
+        PirType t = *this;
+        t.flags_.set(TypeFlags::promiseWrapped);
+        return t;
+    }
+
     RIR_INLINE PirType orLazy() const {
         assert(isRType());
         PirType t = *this;
         t.flags_.set(TypeFlags::lazy);
+        t.flags_.set(TypeFlags::promiseWrapped);
         return t;
     }
 
@@ -279,6 +292,7 @@ struct PirType {
             return t_.n.includes(o.t_.n);
         }
         if ((!maybeLazy() && o.maybeLazy()) ||
+            (!maybePromiseWrapped() && o.maybePromiseWrapped()) ||
             (!maybeMissing() && o.maybeMissing()) ||
             (isScalar() && !o.isScalar())) {
             return false;
@@ -402,6 +416,8 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
         out << "$";
     if (t.maybeLazy())
         out << "^";
+    else if (t.maybePromiseWrapped())
+        out << "~";
     if (t.maybeMissing())
         out << "?";
     if (!t.maybeObj())

--- a/rir/src/compiler/transform/insert_cast.cpp
+++ b/rir/src/compiler/transform/insert_cast.cpp
@@ -6,7 +6,7 @@ namespace rir {
 namespace pir {
 
 pir::Instruction* InsertCast::cast(pir::Value* v, PirType t, Value* env) {
-    if (v->type.maybeLazy() && !t.maybeLazy()) {
+    if (v->type.maybePromiseWrapped() && !t.maybePromiseWrapped()) {
         return new pir::Force(v, env);
     }
     if (v->type.maybeMissing() && !t.maybeMissing()) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -159,8 +159,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     auto top = [&stack]() { return stack.at(0); };
     auto set = [&stack](unsigned i, Value* v) { stack.at(i) = v; };
 
-    auto forceIfLazy = [&](unsigned i) {
-        if (stack.at(i)->type.maybeLazy()) {
+    auto forceIfPromised = [&](unsigned i) {
+        if (stack.at(i)->type.maybePromiseWrapped()) {
             stack.at(i) = insert(new Force(at(i), env));
         }
     };
@@ -467,9 +467,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 
     case Opcode::extract1_1_: {
         if (!inPromise()) {
-            forceIfLazy(
+            forceIfPromised(
                 1); // <- ensure forced version are captured in framestate
-            forceIfLazy(0);
+            forceIfPromised(0);
             addCheckpoint(srcCode, pos, stack, insert);
         }
         Value* idx = pop();
@@ -480,9 +480,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 
     case Opcode::extract2_1_: {
         if (!inPromise()) {
-            forceIfLazy(
+            forceIfPromised(
                 1); // <- ensure forced version are captured in framestate
-            forceIfLazy(0);
+            forceIfPromised(0);
             addCheckpoint(srcCode, pos, stack, insert);
         }
         Value* idx = pop();
@@ -561,8 +561,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 #define BINOP(Name, Op)                                                        \
     case Opcode::Op: {                                                         \
         if (!inPromise()) {                                                    \
-            forceIfLazy(1);                                                    \
-            forceIfLazy(0);                                                    \
+            forceIfPromised(1);                                                \
+            forceIfPromised(0);                                                \
             addCheckpoint(srcCode, pos, stack, insert);                        \
         }                                                                      \
         auto lhs = at(1);                                                      \

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -92,7 +92,7 @@ Builder::Builder(ClosureVersion* version, Value* closureEnv)
     for (long i = closure->nargs() - 1; i >= 0; --i) {
         args[i] = this->operator()(new LdArg(i));
         if (assumptions.isEager(i))
-            args[i]->type = PirType::val();
+            args[i]->type = PirType::promiseWrappedVal();
         if (assumptions.notObj(i))
             args[i]->type.setNotObject();
     }


### PR DESCRIPTION
based on #301 

A R value can be:

1. an unevaluated promise
2. an evaluated promise
3. a value

In the past we did not differ between 2 and 3 which can lead to
confusing situations and easily leads to a situation where we
put the wrong kind of value in the wrong place.

This commit adds a new type flag `promiseWrapped`.

Therefore:

1. maybeLazy && maybePromiseWrapped
2. !maybeLazy && maybePromiseWrapped
3. !maybeLazy && !maybePromiseWrapped

To transition 2 => 3 a Force instruction is always needed, because
many internal instruction expect either one or the other.

From 1 => 2 it is enough to prove that a value is already evaluated
and then remove the maybeLazy flag.

Evaluated promises are marked with the type flag `~` in the textual format.