### PR TITLE
Sometimes the context is needed for non fundamental stuff like, for i…

### DIFF
--- a/documentation/pir.md
+++ b/documentation/pir.md
@@ -140,8 +140,6 @@ Sometimes we do not know if an argument was already forced or not. For example i
 
 The modeling of missing is not very accurate at the moment.
 
-Currently we assume that there are no objects. If we add that to the picture it will become more annoying, since even things like `+`, even if bound to the default `+` primitive, might execute random code.
-
 No named args, no default args implemented.
 
 `Instruction` has virtual methods, would be nice to get rid of them, not sure how.

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -32,9 +32,10 @@ struct CallContext {
                 R_bcstack_t* stackArgs, Immediate* implicitArgs,
                 Immediate* names, SEXP callerEnv,
                 const Assumptions& givenAssumptions, Context* ctx)
-        : caller(c), suppliedArgs(nargs), passedArgs(nargs), stackArgs(stackArgs),
-          implicitArgs(implicitArgs), names(names), callerEnv(callerEnv),
-          ast(ast), callee(callee), givenAssumptions(givenAssumptions) {
+        : caller(c), suppliedArgs(nargs), passedArgs(nargs),
+          stackArgs(stackArgs), implicitArgs(implicitArgs), names(names),
+          callerEnv(callerEnv), ast(ast), callee(callee),
+          givenAssumptions(givenAssumptions) {
         assert(callee &&
                (TYPEOF(callee) == CLOSXP || TYPEOF(callee) == SPECIALSXP ||
                 TYPEOF(callee) == BUILTINSXP));
@@ -392,7 +393,7 @@ RIR_INLINE SEXP rirCallTrampoline(const CallContext& call, Function* fun,
 
 RIR_INLINE SEXP rirCallTrampoline(const CallContext& call, Function* fun,
                                   SEXP arglist, Context* ctx) {
-    return rirCallTrampoline(call, fun, (SEXP)NULL, arglist, call.stackArgs,
+    return rirCallTrampoline(call, fun, R_NilValue, arglist, call.stackArgs,
                              ctx);
 }
 
@@ -1675,7 +1676,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
             ostack_push(ctx, res);
 
             SLOWASSERT(ttt == R_PPStackTop);
-            SLOWASSERT(lll - call.suppliedArgs + 1 == (unsigned)ostack_length(ctx));
+            SLOWASSERT(lll - call.suppliedArgs + 1 ==
+                       (unsigned)ostack_length(ctx));
             NEXT();
         }
 
@@ -1714,7 +1716,8 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
             ostack_push(ctx, res);
 
             SLOWASSERT(ttt == R_PPStackTop);
-            SLOWASSERT(lll - call.suppliedArgs + 1 == (unsigned)ostack_length(ctx));
+            SLOWASSERT(lll - call.suppliedArgs + 1 ==
+                       (unsigned)ostack_length(ctx));
             NEXT();
         }
 


### PR DESCRIPTION
…nstance, to create gnu-r contexts and thus, a native nullptr triggers a segfault