### PR TITLE
Interpreter performance

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -16,11 +16,8 @@ namespace pir {
 
 // Currently PIR optimized functions cannot handle too many arguments or
 // mis-ordered arguments. The caller needs to take care.
-const Assumptions::Flags Rir2PirCompiler::minimalAssumptions =
-    Assumptions::Flags(
-        {Assumption::CorrectOrderOfArguments, Assumption::NotTooManyArguments});
-const Assumptions Rir2PirCompiler::defaultAssumptions = Assumptions(
-    {Assumption::CorrectOrderOfArguments, Assumption::NotTooManyArguments}, 0);
+constexpr Assumptions::Flags Rir2PirCompiler::minimalAssumptions;
+constexpr Assumptions Rir2PirCompiler::defaultAssumptions;
 
 Rir2PirCompiler::Rir2PirCompiler(Module* module, StreamLogger& logger)
     : RirCompiler(module), logger(logger) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -13,8 +13,13 @@ class Rir2PirCompiler : public RirCompiler {
   public:
     static constexpr size_t MAX_INPUT_SIZE = 1000;
 
-    static const Assumptions::Flags minimalAssumptions;
-    static const Assumptions defaultAssumptions;
+    static constexpr Assumptions::Flags minimalAssumptions =
+        Assumptions::Flags(Assumption::CorrectOrderOfArguments) |
+        Assumption::NotTooManyArguments;
+    static constexpr Assumptions defaultAssumptions =
+        Assumptions(Assumptions::Flags(Assumption::CorrectOrderOfArguments) |
+                        Assumption::NotTooManyArguments,
+                    0);
 
     Rir2PirCompiler(Module* module, StreamLogger& logger);
 

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -600,7 +600,8 @@ BC_NOARGS(V, _)
         case Opcode::named_call_implicit_:
         case Opcode::call_:
         case Opcode::named_call_:
-            memcpy(&immediate.callFixedArgs, pc, sizeof(CallFixedArgs));
+            memcpy(&immediate.callFixedArgs,
+                   reinterpret_cast<CallFixedArgs*>(pc), sizeof(CallFixedArgs));
             break;
         case Opcode::mk_env_:
             memcpy(&immediate.mkEnvFixedArgs, pc, sizeof(MkEnvFixedArgs));

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -850,8 +850,8 @@ void compileCall(Context& ctx, SEXP ast, SEXP fun, SEXP args) {
     if (hasNames) {
         cs << BC::callImplicit(callArgs, names, ast, {});
     } else {
-        cs << BC::callImplicit(callArgs, ast,
-                               {Assumption::CorrectOrderOfArguments});
+        cs << BC::callImplicit(
+            callArgs, ast, Assumptions(Assumption::CorrectOrderOfArguments));
     }
 }
 

--- a/rir/src/runtime/ArgsLazyData.h
+++ b/rir/src/runtime/ArgsLazyData.h
@@ -26,6 +26,9 @@ typedef std::function<SEXP(void*)> LazyFunction;
 
 struct ArgsLazyData : public RirDataWrapper<ArgsLazyData, LAZY_ARGS_MAGIC> {
     ArgsLazyData() = delete;
+    ArgsLazyData(const ArgsLazyData&) = delete;
+    ArgsLazyData& operator=(const ArgsLazyData&) = delete;
+
     ArgsLazyData(const CallContext* callCtx, Context* cmpCtx)
         : RirDataWrapper(2), callContext(callCtx), compilationContext(cmpCtx){};
 

--- a/rir/src/runtime/Assumptions.cpp
+++ b/rir/src/runtime/Assumptions.cpp
@@ -55,47 +55,7 @@ std::ostream& operator<<(std::ostream& out, const Assumptions& a) {
     return out;
 }
 
-static constexpr std::array<Assumption, 3> ObjAssumptions = {
-    {Assumption::Arg1IsNonObj_, Assumption::Arg2IsNonObj_,
-     Assumption::Arg3IsNonObj_}};
-static constexpr std::array<Assumption, 3> EagerAssumptions = {
-    {Assumption::Arg1IsEager_, Assumption::Arg2IsEager_,
-     Assumption::Arg3IsEager_}};
-
-bool Assumptions::isEager(size_t i) const {
-    if (flags.includes(Assumption::EagerArgs_))
-        return true;
-
-    if (i < EagerAssumptions.size())
-        if (flags.includes(EagerAssumptions[i]))
-            return true;
-
-    return false;
-}
-
-void Assumptions::setEager(size_t i, bool eager) {
-    if (eager && i < EagerAssumptions.size())
-        flags.set(EagerAssumptions[i]);
-    else if (!eager)
-        flags.reset(Assumption::EagerArgs_);
-}
-
-bool Assumptions::notObj(size_t i) const {
-    if (flags.includes(Assumption::NonObjectArgs_))
-        return true;
-
-    if (i < ObjAssumptions.size())
-        if (flags.includes(ObjAssumptions[i]))
-            return true;
-
-    return false;
-}
-
-void Assumptions::setNotObj(size_t i, bool notObj) {
-    if (notObj && i < ObjAssumptions.size())
-        flags.set(ObjAssumptions[i]);
-    else if (!notObj)
-        flags.reset(Assumption::NonObjectArgs_);
-}
+constexpr std::array<Assumption, 3> Assumptions::ObjAssumptions;
+constexpr std::array<Assumption, 3> Assumptions::EagerAssumptions;
 
 } // namespace rir

--- a/rir/src/utils/EnumSet.h
+++ b/rir/src/utils/EnumSet.h
@@ -28,19 +28,16 @@ class EnumSet {
     }
 
   public:
-    EnumSet() {
+    EnumSet() {}
+    EnumSet(const EnumSet& other) noexcept = default;
+
+    constexpr EnumSet(Element e) : set_(1UL << static_cast<size_t>(e)) {
         static_assert(sizeof(*this) == sizeof(Store),
                       "No room for extra stuff");
     }
 
-    EnumSet(const std::initializer_list<Element>& ts) {
-        for (auto t : ts)
-            set(t);
-    }
-
     static_assert(!std::is_same<Element, Store>::value, "That is confusing");
-    EnumSet(const Element& e) { set(e); }
-    EnumSet(const Store& s) : set_(s) {}
+    constexpr EnumSet(const Store& s) : set_(s) {}
 
     RIR_INLINE bool contains(const Element& e) const {
         assert(boundscheck(e));
@@ -85,11 +82,11 @@ class EnumSet {
         return EnumSet(t) != set_;
     }
 
-    RIR_INLINE EnumSet operator|(const EnumSet& s) const {
+    constexpr RIR_INLINE EnumSet operator|(const EnumSet& s) const {
         return EnumSet(s.set_ | set_);
     }
 
-    RIR_INLINE EnumSet operator|(const Element& t) const {
+    constexpr RIR_INLINE EnumSet operator|(const Element& t) const {
         return *this | EnumSet(t);
     }
 


### PR DESCRIPTION
some small and stupid things that popped up on callgrind. Also fix gcc 8 warnings. Based on #309, this pr only adds the last commit.