### PR TITLE
fix bugs from some_eager_args branch

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -574,28 +574,17 @@ static SEXP findRootPromise(SEXP p) {
     return p;
 }
 
-static constexpr Assumptions::Flags ALL_ASSUMPTIONS =
-    Assumptions::Flags(Assumption::NotTooFewArguments) |
-    Assumption::EagerArgs_ | Assumption::NonObjectArgs_ |
-    Assumption::NoExplicitlyMissingArgs;
 void addDynamicAssumptionsFromContext(CallContext& call) {
     Assumptions& given = call.givenAssumptions;
 
     if (!call.hasNames())
         given.add(Assumption::CorrectOrderOfArguments);
 
-    // Fast track if all the assumptions are already statically there
-    if (given.includes(ALL_ASSUMPTIONS))
-        return;
-
     given.add(Assumption::NoExplicitlyMissingArgs);
     if (call.hasStackArgs()) {
         // Always true in this case, since we will pad missing args on the stack
         // later with R_MissingArg's
         given.add(Assumption::NotTooFewArguments);
-        // Make some optimistic assumptions, they might be reset below...
-        given.add(Assumption::EagerArgs_);
-        given.add(Assumption::NonObjectArgs_);
 
         auto testArg = [&](size_t i) {
             SEXP arg = call.stackArg(i);
@@ -613,8 +602,10 @@ void addDynamicAssumptionsFromContext(CallContext& call) {
             } else if (arg == R_MissingArg) {
                 given.remove(Assumption::NoExplicitlyMissingArgs);
             }
-            given.setEager(i, isEager);
-            given.setNotObj(i, notObj);
+            if (isEager)
+                given.setEager(i);
+            if (notObj)
+                given.setNotObj(i);
         };
 
         for (size_t i = 0; i < call.suppliedArgs; ++i) {

--- a/rir/src/runtime/Assumptions.cpp
+++ b/rir/src/runtime/Assumptions.cpp
@@ -16,14 +16,14 @@ std::ostream& operator<<(std::ostream& out, Assumption a) {
     case Assumption::Arg3IsEager_:
         out << "Eager3";
         break;
-    case Assumption::EagerArgs_:
-        out << "Eagers";
+    case Assumption::Arg4IsEager_:
+        out << "Eager4";
+        break;
+    case Assumption::Arg0IsEager_:
+        out << "Eager0";
         break;
     case Assumption::CorrectOrderOfArguments:
         out << "CorrOrd";
-        break;
-    case Assumption::NonObjectArgs_:
-        out << "!Objs";
         break;
     case Assumption::Arg1IsNonObj_:
         out << "!Obj1";
@@ -33,6 +33,9 @@ std::ostream& operator<<(std::ostream& out, Assumption a) {
         break;
     case Assumption::Arg3IsNonObj_:
         out << "!Obj3";
+        break;
+    case Assumption::Arg0IsNonObj_:
+        out << "!Obj0";
         break;
     case Assumption::NotTooManyArguments:
         out << "!TMany";
@@ -55,7 +58,7 @@ std::ostream& operator<<(std::ostream& out, const Assumptions& a) {
     return out;
 }
 
-constexpr std::array<Assumption, 3> Assumptions::ObjAssumptions;
-constexpr std::array<Assumption, 3> Assumptions::EagerAssumptions;
+constexpr std::array<Assumption, 5> Assumptions::ObjAssumptions;
+constexpr std::array<Assumption, 4> Assumptions::EagerAssumptions;
 
 } // namespace rir

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -10,17 +10,18 @@
 namespace rir {
 
 enum class Assumption {
-    EagerArgs_, // All arguments are already evaluated
+    // Arg is already evaluated
+    Arg0IsEager_,
+    Arg1IsEager_,
+    Arg2IsEager_,
+    Arg3IsEager_,
+    Arg4IsEager_,
 
-    Arg1IsEager_, // Arg1 is already evaluated
-    Arg2IsEager_, // Arg2 is already evaluated
-    Arg3IsEager_, // Arg3 is already evaluated
-
-    NonObjectArgs_, // All arguments are not objects
-
-    Arg1IsNonObj_, // Arg1 is not an object
-    Arg2IsNonObj_, // Arg2 is not an object
-    Arg3IsNonObj_, // Arg3 is not an object
+    // Arg is not an object
+    Arg0IsNonObj_,
+    Arg1IsNonObj_,
+    Arg2IsNonObj_,
+    Arg3IsNonObj_,
 
     NoExplicitlyMissingArgs, // Explicitly missing, e.g. f(,,)
     CorrectOrderOfArguments, // Ie. the args are not named
@@ -29,7 +30,7 @@ enum class Assumption {
                              //  Note: can still have explicitly missing args
     NotTooManyArguments,     // The number of args supplied is <= nargs
 
-    FIRST = EagerArgs_,
+    FIRST = Arg0IsEager_,
     LAST = NotTooManyArguments
 };
 
@@ -58,9 +59,11 @@ struct Assumptions {
     RIR_INLINE bool includes(const Flags& a) const { return flags.includes(a); }
 
     RIR_INLINE bool isEager(size_t i) const;
-    RIR_INLINE void setEager(size_t i, bool);
+    RIR_INLINE void setEager(size_t i);
+    RIR_INLINE void setEager();
     RIR_INLINE bool notObj(size_t i) const;
-    RIR_INLINE void setNotObj(size_t i, bool);
+    RIR_INLINE void setNotObj(size_t i);
+    RIR_INLINE void setNotObj();
 
     RIR_INLINE uint8_t numMissing() const { return missing; }
 
@@ -104,12 +107,13 @@ struct Assumptions {
     friend struct std::hash<rir::Assumptions>;
     friend std::ostream& operator<<(std::ostream& out, const Assumptions& a);
 
-    static constexpr std::array<Assumption, 3> ObjAssumptions = {
-        {Assumption::Arg1IsNonObj_, Assumption::Arg2IsNonObj_,
-         Assumption::Arg3IsNonObj_}};
-    static constexpr std::array<Assumption, 3> EagerAssumptions = {
-        {Assumption::Arg1IsEager_, Assumption::Arg2IsEager_,
-         Assumption::Arg3IsEager_}};
+    static constexpr std::array<Assumption, 5> ObjAssumptions = {
+        {Assumption::Arg0IsNonObj_, Assumption::Arg1IsNonObj_,
+         Assumption::Arg2IsNonObj_, Assumption::Arg3IsEager_,
+         Assumption::Arg4IsEager_}};
+    static constexpr std::array<Assumption, 4> EagerAssumptions = {
+        {Assumption::Arg0IsEager_, Assumption::Arg1IsEager_,
+         Assumption::Arg2IsEager_, Assumption::Arg3IsNonObj_}};
 
   private:
     Flags flags;
@@ -119,9 +123,6 @@ struct Assumptions {
 #pragma pack(pop)
 
 RIR_INLINE bool Assumptions::isEager(size_t i) const {
-    if (flags.includes(Assumption::EagerArgs_))
-        return true;
-
     if (i < EagerAssumptions.size())
         if (flags.includes(EagerAssumptions[i]))
             return true;
@@ -129,17 +130,18 @@ RIR_INLINE bool Assumptions::isEager(size_t i) const {
     return false;
 }
 
-RIR_INLINE void Assumptions::setEager(size_t i, bool eager) {
-    if (eager && i < EagerAssumptions.size())
+RIR_INLINE void Assumptions::setEager() {
+    for (size_t i = 0; i < EagerAssumptions.size(); ++i)
         flags.set(EagerAssumptions[i]);
-    else if (!eager)
-        flags.reset(Assumption::EagerArgs_);
+}
+
+RIR_INLINE void Assumptions::setEager(size_t i) {
+    if (i < EagerAssumptions.size()) {
+        flags.set(EagerAssumptions[i]);
+    }
 }
 
 RIR_INLINE bool Assumptions::notObj(size_t i) const {
-    if (flags.includes(Assumption::NonObjectArgs_))
-        return true;
-
     if (i < ObjAssumptions.size())
         if (flags.includes(ObjAssumptions[i]))
             return true;
@@ -147,11 +149,15 @@ RIR_INLINE bool Assumptions::notObj(size_t i) const {
     return false;
 }
 
-RIR_INLINE void Assumptions::setNotObj(size_t i, bool notObj) {
-    if (notObj && i < ObjAssumptions.size())
+RIR_INLINE void Assumptions::setNotObj() {
+    for (size_t i = 0; i < ObjAssumptions.size(); ++i)
         flags.set(ObjAssumptions[i]);
-    else if (!notObj)
-        flags.reset(Assumption::NonObjectArgs_);
+}
+
+RIR_INLINE void Assumptions::setNotObj(size_t i) {
+    if (i < ObjAssumptions.size()) {
+        flags.set(ObjAssumptions[i]);
+    }
 }
 
 typedef uint32_t Immediate;


### PR DESCRIPTION
A couple of issues in the branch prevented this from properly working.
First of all inferAvailableAssumptions was broken and would only change
argument 0. Then eager_call optimization might have cleared already existing
eagerness assumptions.

To simplify the overall approach I removed the eagerArgs and nonObjArgs
flags and now only rely on the eagerArg0 kind of flags, which specify
exactly one argument position. The combination of having eagerArgs,
saying all args are eager, and eagerArg0, saying just arg0 is eager, at
the same time is just too error prone.