### PR TITLE
Speculate builtins

### DIFF
--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -77,6 +77,7 @@
     V(UseMethod, "UseMethod")                                                  \
     V(sysframe, "sys.frame")                                                   \
     V(syscall, "sys.call")                                                     \
-    V(srcref, "srcref")
+    V(srcref, "srcref")                                                        \
+    V(ambiguousCallTarget, ".ambiguousCallTarget.")
 
 #endif // SYMBOLS_LIST_H_

--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -1,0 +1,41 @@
+#ifndef PIR_AVAILABLE_CHECKPOINTS_H
+#define PIR_AVAILABLE_CHECKPOINTS_H
+
+#include "../util/cfg.h"
+#include "abstract_value.h"
+#include "generic_static_analysis.h"
+
+namespace rir {
+namespace pir {
+
+class AvailableCheckpoints : public StaticAnalysis<AbstractUnique<Checkpoint>> {
+  public:
+    ClosureVersion* code;
+    AvailableCheckpoints(ClosureVersion* cls, LogStream& log)
+        : StaticAnalysis("AvailableCheckpoints", cls, cls, log), code(cls) {}
+
+    AbstractResult apply(AbstractUnique<Checkpoint>& state,
+                         Instruction* i) const override {
+        if (state.get()) {
+            if (i->hasObservableEffect()) {
+                state.clear();
+                return AbstractResult::Updated;
+            }
+        } else {
+            if (auto cp = Checkpoint::Cast(i)) {
+                state.set(cp);
+                return AbstractResult::Updated;
+            }
+        }
+        return AbstractResult::None;
+    };
+
+    Checkpoint* at(Instruction* i) {
+        return StaticAnalysis::at<PositioningStyle::BeforeInstruction>(i).get();
+    }
+};
+
+} // namespace pir
+} // namespace rir
+
+#endif

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -125,7 +125,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
             auto binding = state.envs.superGet(ss->env(), ss->varName);
             if (!binding.result.isUnknown()) {
                 // Make sure the super env stores are not prematurely removed
-                binding.result.eachSource([&](ValOrig& src) {
+                binding.result.eachSource([&](const ValOrig& src) {
                     state.observedStores.insert(src.origin);
                 });
                 state.envs[superEnv].set(ss->varName, ss->val(), ss, depth);
@@ -318,7 +318,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
                     }
                 }
             } else {
-                load.result.eachSource([&](ValOrig& src) {
+                load.result.eachSource([&](const ValOrig& src) {
                     if (!state.observedStores.count(src.origin)) {
                         state.observedStores.insert(src.origin);
                         effect.update();

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -134,7 +134,7 @@ class BufferedLogStream : public LogStream {
 
 class StreamLogger {
   public:
-    explicit StreamLogger(DebugOptions options) : options(options) {}
+    explicit StreamLogger(const DebugOptions& options) : options(options) {}
     ~StreamLogger();
 
     static uint64_t logId;

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -1,3 +1,4 @@
+#include "../analysis/available_checkpoints.h"
 #include "../pir/pir_impl.h"
 #include "../translations/pir_translator.h"
 #include "../util/cfg.h"
@@ -13,42 +14,42 @@ namespace rir {
 namespace pir {
 
 void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
-                                LogStream&) const {
+                                LogStream& log) const {
     CFG cfg(function);
-    Visitor::run(function->entry, [&](BB* bb) {
+    AvailableCheckpoints checkpoint(function, log);
+
+    Visitor::runPostChange(function->entry, [&](BB* bb) {
         auto ip = bb->begin();
         while (ip != bb->end()) {
             auto next = ip + 1;
             auto instr = *ip;
 
+            // Remove Unneccessary checkpoints. If we arrive at a checkpoint and
+            // the previous checkpoint is still available, we might as well take
+            // this one.
+            if (auto cp = Checkpoint::Cast(instr)) {
+                if (auto cp0 = checkpoint.at(instr)) {
+                    assert(bb->last() == instr);
+                    cp->replaceUsesWith(cp0);
+                    bb->remove(ip);
+                    delete bb->next1;
+                    bb->next1 = nullptr;
+                    next = bb->end();
+                }
+            }
+
             if (auto assume = Assume::Cast(instr)) {
-                auto cp = assume->checkpoint();
-                auto bb = cp->bb();
                 // We are trying to group multiple assumes into the same
                 // checkpoint by finding for each assume the topmost compatible
                 // checkpoint.
                 // TODO: we could also try to move up the assume itself, since
                 // if we move both at the same time, we could even jump over
                 // effectful instructions.
-                while (true) {
-                    if (!cfg.hasSinglePred(bb))
-                        break;
-
-                    bool hasEffect = false;
-                    for (auto i : *bb)
-                        if (i->hasEffect())
-                            hasEffect = true;
-                    if (hasEffect)
-                        break;
-                    bb = cfg.immediatePredecessors(bb).front();
-
-                    if (!bb->isEmpty())
-                        if (auto prevCp = Checkpoint::Cast(bb->last()))
-                            cp = prevCp;
+                if (auto cp0 = checkpoint.at(instr)) {
+                    if (assume->checkpoint() != cp0)
+                        assume->checkpoint(cp0);
                 }
-                assume->checkpoint(cp);
             }
-
             ip = next;
         }
     });

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -1,3 +1,4 @@
+#include "../analysis/available_checkpoints.h"
 #include "../pir/pir_impl.h"
 #include "../transform/bb.h"
 #include "../transform/replace.h"
@@ -5,6 +6,8 @@
 #include "../util/cfg.h"
 #include "../util/safe_builtins_list.h"
 #include "../util/visitor.h"
+#include "R/Funtab.h"
+#include "R/Symbols.h"
 #include "R/r.h"
 #include "pass_definitions.h"
 
@@ -14,91 +17,213 @@ namespace rir {
 namespace pir {
 
 void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
-                       LogStream&) const {
+                       LogStream& log) const {
     std::unordered_set<MkArg*> todo;
     auto code = closure->entry;
+    AvailableCheckpoints checkpoint(closure, log);
 
+    auto replaceLdFunBuiltinWithDeopt = [&](BB* bb, BB::Instrs::iterator ip,
+                                            Checkpoint* cp, SEXP builtin,
+                                            LdFun* ldfun) {
+        assert(LdFun::Cast(*ip));
+        assert(cp);
+
+        // skip ldfun
+        ip++;
+
+        auto expected = new LdConst(builtin);
+        ip = bb->insert(ip, expected);
+        ip++;
+        Instruction* given = ldfun;
+
+        // Function c overwritten by non-function c happens too often. The more
+        // conservative ldvar is not a good fit here.
+        if (ldfun->varName != symbol::c) {
+            given = new LdVar(ldfun->varName, ldfun->env());
+            ip = bb->insert(ip, given);
+            ip++;
+        }
+
+        auto test = new Identical(given, expected);
+        ip = bb->insert(ip, test);
+        ip++;
+
+        auto assume = new Assume(test, cp);
+        ip = bb->insert(ip, assume);
+        ip++;
+
+        return ip;
+    };
+
+    auto replaceCallWithCallBuiltin = [&](BB* bb, BB::Instrs::iterator ip,
+                                          Call* call, SEXP builtin) {
+        std::vector<Value*> args;
+        call->eachCallArg([&](Value* a) {
+            args.push_back(a);
+            if (auto mk = MkArg::Cast(a))
+                if (!mk->isEager())
+                    todo.insert(mk);
+        });
+        auto bt =
+            BuiltinCallFactory::New(call->env(), builtin, args, call->srcIdx);
+        call->replaceUsesWith(bt);
+        bb->replace(ip, bt);
+    };
+
+    // Search for calls that likely point to a builtin.
+    std::unordered_map<LdFun*, SEXP> replaced;
     Visitor::run(code, [&](BB* bb) {
-        for (auto ip = bb->begin(); ip != bb->end(); ++ip) {
-            auto call = StaticCall::Cast(*ip);
-            if (!call)
-                continue;
+        auto ip = bb->begin();
+        while (ip != bb->end()) {
+            auto next = ip + 1;
 
-            Closure* cls = call->cls();
-            ClosureVersion* version = call->tryDispatch();
-
-            if (!version ||
-                call->nCallArgs() != cls->nargs())
-                continue;
-
-            bool allEager =
-                version->properties.includes(ClosureVersion::Property::IsEager);
-            if (!allEager && version->properties.argumentForceOrder.empty())
-                continue;
-
-            auto isEager = [&](size_t i) {
-                if (allEager)
-                    return true;
-                for (auto a : version->properties.argumentForceOrder) {
-                    // We know that a is forced before i, therefore we are not
-                    // in left-to-right order
-                    // TODO: support reordering of the evaluation
-                    if (a > i)
-                        return false;
-                    // We found the argument in the list of certainly forced
-                    // promises
-                    if (a == i)
-                        return true;
-                }
-                return false;
-            };
-
-            std::unordered_set<MkArg*> args;
-            bool noMissing = true;
-            size_t i = 0;
-            call->eachCallArg([&](Value* v) {
-                if (auto mk = MkArg::Cast(v)) {
-                    if (!mk->isEager() && isEager(i))
-                        args.insert(mk);
-                } else {
-                    noMissing = false;
-                }
-                i++;
-            });
-            if (!noMissing)
-                continue;
-            todo.insert(args.begin(), args.end());
-
-            Assumptions newAssumptions = call->inferAvailableAssumptions();
-            for (size_t i = 0; i < call->nCallArgs(); ++i) {
-                if (!newAssumptions.isEager(i) && isEager(i))
-                    newAssumptions.setEager(i);
-            }
-            // This might fire back, since we don't know if we really have no
-            // objects... We should have some profiling. It's still sound, since
-            // static_call_ will check the assumptions
-            for (size_t i = 0; i < call->nCallArgs(); ++i)
-                if (!newAssumptions.notObj(i) && newAssumptions.isEager(i))
-                    newAssumptions.setNotObj(i);
-
-            auto newVersion = cls->cloneWithAssumptions(
-                version, newAssumptions, [&](ClosureVersion* newCls) {
-                    Visitor::run(newCls->entry, [&](Instruction* i) {
-                        if (auto ld = LdArg::Cast(i)) {
-                            if (isEager(ld->id)) {
-                                ld->type = PirType::promiseWrappedVal()
-                                               .notObject()
-                                               .notMissing();
+            if (auto call = Call::Cast(*ip)) {
+                if (auto ldfun = LdFun::Cast(call->cls())) {
+                    if (ldfun->hint) {
+                        if (TYPEOF(ldfun->hint) == BUILTINSXP) {
+                            // We can only speculate if we have a checkpoint at
+                            // the ldfun position, since we want to deopt before
+                            // forcing arguments.
+                            if (checkpoint.at(ldfun)) {
+                                replaced.emplace(ldfun, ldfun->hint);
+                                replaceCallWithCallBuiltin(bb, ip, call,
+                                                           replaced.at(ldfun));
                             }
                         }
-                    });
+                    } else {
+                        // Only speculate if we don't have a static guess
+                        if (!ldfun->guessedBinding()) {
+                            auto env =
+                                Env::Cast(closure->owner()->closureEnv());
+                            if (env != Env::notClosed() && env->rho) {
+                                auto builtin =
+                                    Rf_findVar(ldfun->varName, env->rho);
+                                if (TYPEOF(builtin) == BUILTINSXP) {
+                                    if (checkpoint.at(ldfun)) {
+                                        replaced.emplace(ldfun, builtin);
+                                        replaceCallWithCallBuiltin(
+                                            bb, ip, call, replaced.at(ldfun));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            ip = next;
+        }
+    });
+
+    Visitor::run(code, [&](BB* bb) {
+        auto ip = bb->begin();
+        while (ip != bb->end()) {
+            auto next = ip + 1;
+
+            // Insert the actual guards needed for the above transformation
+            if (auto ldfun = LdFun::Cast(*ip)) {
+                auto r = replaced.find(ldfun);
+                if (r != replaced.end()) {
+                    ip = replaceLdFunBuiltinWithDeopt(
+                        bb, ip, checkpoint.at(*ip), r->second, ldfun);
+                    replaced.erase(r);
+                    continue;
+                }
+            }
+
+            // Look for static calls, where we statically know that all (or
+            // some) arguments are eager. In this case we will compile an
+            // special eager version of the function and call this one instead.
+            if (auto call = StaticCall::Cast(*ip)) {
+                Closure* cls = call->cls();
+                ClosureVersion* version = call->tryDispatch();
+
+                if (!version || call->nCallArgs() != cls->nargs()) {
+                    ip = next;
+                    continue;
+                }
+
+                bool allEager = version->properties.includes(
+                    ClosureVersion::Property::IsEager);
+                if (!allEager &&
+                    version->properties.argumentForceOrder.empty()) {
+                    ip = next;
+                    continue;
+                }
+
+                auto isEager = [&](size_t i) {
+                    if (allEager)
+                        return true;
+                    for (auto a : version->properties.argumentForceOrder) {
+                        // We know that a is forced before i, therefore we are
+                        // not in left-to-right order
+                        // TODO: support reordering of the evaluation
+                        if (a > i)
+                            return false;
+                        // We found the argument in the list of certainly forced
+                        // promises
+                        if (a == i)
+                            return true;
+                    }
+                    return false;
+                };
+
+                std::unordered_set<MkArg*> args;
+                bool noMissing = true;
+                size_t i = 0;
+                call->eachCallArg([&](Value* v) {
+                    if (auto mk = MkArg::Cast(v)) {
+                        if (!mk->isEager() && isEager(i))
+                            args.insert(mk);
+                    } else {
+                        noMissing = false;
+                    }
+                    i++;
                 });
-            call->hint = newVersion;
+                if (!noMissing) {
+                    ip = next;
+                    continue;
+                }
+
+                // Remember which arguments are already expected to be eager by
+                // the callee and ensure that we will evaluate them eagerly
+                // below.
+                todo.insert(args.begin(), args.end());
+
+                Assumptions newAssumptions = call->inferAvailableAssumptions();
+                for (size_t i = 0; i < call->nCallArgs(); ++i) {
+                    if (!newAssumptions.isEager(i) && isEager(i))
+                        newAssumptions.setEager(i);
+                }
+                // This might fire back, since we don't know if we really have no
+                // objects... We should have some profiling. It's still sound, since
+                // static_call_ will check the assumptions
+                for (size_t i = 0; i < call->nCallArgs(); ++i)
+                    if (!newAssumptions.notObj(i) && newAssumptions.isEager(i))
+                        newAssumptions.setNotObj(i);
+
+                auto newVersion = cls->cloneWithAssumptions(
+                    version, newAssumptions, [&](ClosureVersion* newCls) {
+                        Visitor::run(newCls->entry, [&](Instruction* i) {
+                            if (auto ld = LdArg::Cast(i)) {
+                                if (isEager(ld->id)) {
+                                    ld->type = PirType::promiseWrappedVal()
+                                                   .notObject()
+                                                   .notMissing();
+                               }
+                            }
+                        });
+                    });
+                call->hint = newVersion;
+            }
+            ip = next;
         }
     });
     if (todo.empty())
         return;
 
+    // Third step: eagerly evaluate arguments if we know from above that we will
+    // call a function that expects them to be eager.
     Visitor::run(code, [&](BB* bb) {
         for (auto ip = bb->begin(); ip != bb->end(); ++ip) {
             if (auto mk = MkArg::Cast(*ip)) {

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -42,8 +42,13 @@ void ElideEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                         SafeBuiltinsList::nonObject(b->builtinId)) {
                         std::vector<Value*> args;
                         i->eachArg([&](Value* v) {
-                            if (v != i->env())
-                                args.push_back(v);
+                            if (v != i->env()) {
+                                auto mk = MkArg::Cast(v);
+                                if (mk && mk->isEager())
+                                    args.push_back(mk->eagerArg());
+                                else
+                                    args.push_back(v);
+                            }
                         });
                         auto safe =
                             new CallSafeBuiltin(b->blt, args, b->srcIdx);

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -147,7 +147,7 @@ class TheScopeResolution {
                     if (!res.isUnknown() && isActualLoad) {
 
                         bool onlyLocalVals = true;
-                        res.eachSource([&](ValOrig& src) {
+                        res.eachSource([&](const ValOrig& src) {
                             if (src.recursionLevel > 0)
                                 onlyLocalVals = false;
                         });
@@ -157,15 +157,16 @@ class TheScopeResolution {
                             // Shift phi up until we see at least two inputs
                             // coming from different paths.
                             auto hasAllInputs = [&](BB* load) -> bool {
-                                return res.checkEachSource([&](ValOrig& src) {
-                                    auto i = Instruction::Cast(src.val);
-                                    if (!i)
-                                        return true;
-                                    // we cannot move the phi above its src
-                                    if (i->bb() == load)
-                                        return false;
-                                    return cfg.isPredecessor(i->bb(), load);
-                                });
+                                return res.checkEachSource(
+                                    [&](const ValOrig& src) {
+                                        auto i = Instruction::Cast(src.val);
+                                        if (!i)
+                                            return true;
+                                        // we cannot move the phi above its src
+                                        if (i->bb() == load)
+                                            return false;
+                                        return cfg.isPredecessor(i->bb(), load);
+                                    });
                             };
                             BB* phiBlock = bb;
                             for (bool up = true; up;) {
@@ -181,7 +182,7 @@ class TheScopeResolution {
 
                             // Insert a new phi
                             auto phi = new Phi;
-                            res.eachSource([&](ValOrig& src) {
+                            res.eachSource([&](const ValOrig& src) {
                                 phi->addInput(src.origin->bb(), src.val);
                             });
                             phi->updateType();

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -57,7 +57,7 @@ Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
     for (auto c = versions.rbegin(); c != versions.rend(); c++) {
         auto candidate = *c;
         auto candidateCtx = candidate.first;
-        if (candidateCtx.subtype(ctx.assumptions))
+        if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))
             return candidate.second;
     }
     return nullptr;

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -30,7 +30,7 @@ class ClosureVersion : public Code {
     struct Properties : public EnumSet<Property> {
         Properties() : EnumSet<Property>(){};
         Properties(const EnumSet<Property>& other) : EnumSet<Property>(other) {}
-        Properties(const Property& other) : EnumSet<Property>(other) {}
+        explicit Properties(const Property& other) : EnumSet<Property>(other) {}
 
         std::vector<size_t> argumentForceOrder;
         friend std::ostream& operator<<(std::ostream& out, const Properties&);

--- a/rir/src/compiler/pir/optimization_context.h
+++ b/rir/src/compiler/pir/optimization_context.h
@@ -9,7 +9,7 @@ namespace rir {
 namespace pir {
 
 struct OptimizationContext {
-    OptimizationContext(const Assumptions& assumptions)
+    explicit OptimizationContext(const Assumptions& assumptions)
         : assumptions(assumptions) {}
 
     Assumptions assumptions;

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -215,6 +215,8 @@ bool canRemoveEnvironmentIfTypeFeedback(const std::string& input) {
     bool t = verify(&m);
     m.eachPirClosureVersion(
         [&t](pir::ClosureVersion* f) { t = t && envOfAddElided(f); });
+    if (!t)
+        m.print(std::cout, true);
     return t;
 }
 

--- a/rir/src/compiler/translations/pir_translator.cpp
+++ b/rir/src/compiler/translations/pir_translator.cpp
@@ -5,4 +5,4 @@ namespace rir {
 namespace pir {
 
 }
-}    
+} // namespace rir

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -10,11 +10,6 @@ namespace pir {
 
 bool SafeBuiltinsList::always(int builtin) {
     static int safeBuiltins[] = {
-        findBuiltin("vector"),
-        findBuiltin("vector"),
-        findBuiltin("complex"),
-        findBuiltin("matrix"),
-        findBuiltin("array"),
         findBuiltin("diag"),
         findBuiltin("backsolve"),
         findBuiltin("max.col"),
@@ -78,6 +73,14 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         return true;
 
     static int safeBuiltins[] = {
+        // Those are not always safe, due to coerceVector, which can be
+        // overwritten by objects
+        findBuiltin("vector"),
+        findBuiltin("complex"),
+        findBuiltin("matrix"),
+        findBuiltin("array"),
+        findBuiltin("new.env"),
+
         findBuiltin("c"),
         findBuiltin("["),
         findBuiltin("[["),

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -207,8 +207,10 @@ void BC::print(std::ostream& out) const {
         BC::NumArgs nargs = args.nargs;
         auto target = Pool::get(args.targetClosure);
         auto targetV = Pool::get(args.versionHint);
-        out << nargs << " : (" << Function::unpack(targetV) << ") "
-            << dumpSexp(target).c_str();
+        out << nargs << " : ";
+        if (targetV != R_NilValue)
+            out << "(" << Function::unpack(targetV) << ") ";
+        out << dumpSexp(target).c_str();
         break;
     }
     case Opcode::mk_env_: {

--- a/rir/src/runtime/RirDataWrapper.h
+++ b/rir/src/runtime/RirDataWrapper.h
@@ -37,7 +37,7 @@ struct RirDataWrapper {
     }
 
   protected:
-    RirDataWrapper(uint32_t count) : info{MAGIC} {
+    explicit RirDataWrapper(uint32_t count) : info{MAGIC} {
         uint8_t* start = (uint8_t*)this + sizeof(uint32_t);
         memset(start, 0, count * sizeof(void*));
     }

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -44,14 +44,14 @@ void Configurations::defaultOptimizations() {
     };
     auto addDefaultOpt = [&]() {
         optimizations.push_back(new pir::ForceDominance());
-        optimizations.push_back(new pir::EagerCalls());
         optimizations.push_back(new pir::ScopeResolution());
+        optimizations.push_back(new pir::EagerCalls());
         optimizations.push_back(new pir::Constantfold());
         optimizations.push_back(new pir::Cleanup());
+        optimizations.push_back(new pir::OptimizeAssumptions());
         optimizations.push_back(new pir::DelayInstr());
         optimizations.push_back(new pir::ElideEnv());
         optimizations.push_back(new pir::DelayEnv());
-        optimizations.push_back(new pir::OptimizeAssumptions());
         optimizations.push_back(new pir::Cleanup());
         optimizations.push_back(new pir::Inline());
         optimizations.push_back(new pir::Cleanup());
@@ -60,7 +60,7 @@ void Configurations::defaultOptimizations() {
     phasemarker("Initial");
 
     // ==== Phase 1) Run the default passes a couple of times
-    for (size_t i = 0; i < 2; ++i)
+    for (size_t i = 0; i < 3; ++i)
         addDefaultOpt();
 
     phasemarker("Phase 1");


### PR DESCRIPTION
in eagerCall optimization pass also speculate on builtins, that we did not speculate so far.

If we have some builtin call, but we can't statically prove that the call does go to a builtin, then we would like to speculate.
Because speculating on a builtin allows us to eagerly evaluate all arguments.
So far we had to decide on whether to make this speculation in the first pass of the compiler.
This PR presents the first case where we are able to do this speculation late in the pipeline.
To be able to support this case, we need to find out if there is a deoptimization point available.
The deoptimization point can come from anywhere before the speculation, but after the last effect.
It is always better to use an earlier deoptimization point, because that leads to less deoptimization points being used, thus more that can be removed, thus less restrictions for the optimizer.
I added a simple `AvailableCheckpoints` analysis, that answers that question.
The api is `AvailableCheckpoint checkpoint(code); Checkpoint* res = checkpoint.at(instruction); if (res) ...`.
In the same PR is also improve the StaticAnalysis framework a bit, to speed up random access queries, like in this one.
(For the existing optimizations it was enough to be able to quickly iterate over the analysis result at every instruction in sequence.)