### PR TITLE
protect constants in pir

### DIFF
--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -27,8 +27,8 @@ static LdConst* isConst(Value* instr) {
         if (auto instr = Instruction::Cast(i)) {                               \
             if (auto lhs = isConst(instr->arg<0>().val())) {                   \
                 if (auto rhs = isConst(instr->arg<1>().val())) {               \
-                    auto res = Rf_eval(Rf_lang3(Operation, lhs->c, rhs->c),    \
-                                       R_BaseEnv);                             \
+                    auto res = Rf_eval(                                        \
+                        Rf_lang3(Operation, lhs->c(), rhs->c()), R_BaseEnv);   \
                     cmp.preserve(res);                                         \
                     auto resi = new LdConst(res);                              \
                     instr->replaceUsesWith(resi);                              \
@@ -42,7 +42,7 @@ static LdConst* isConst(Value* instr) {
     do {                                                                       \
         if (auto instr = Instruction::Cast(i)) {                               \
             if (auto arg = isConst(instr->arg<0>().val())) {                   \
-                Operation(arg->c);                                             \
+                Operation(arg->c());                                           \
             }                                                                  \
         }                                                                      \
     } while (false)
@@ -52,7 +52,7 @@ static LdConst* isConst(Value* instr) {
         if (auto instr = Instruction::Cast(i)) {                               \
             if (auto lhs = isConst(instr->arg<0>().val())) {                   \
                 if (auto rhs = isConst(instr->arg<1>().val())) {               \
-                    Operation(lhs->c, rhs->c);                                 \
+                    Operation(lhs->c(), rhs->c());                             \
                 }                                                              \
             }                                                                  \
         }                                                                      \

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -223,11 +223,18 @@ bool Instruction::envOnlyForObj() {
     return false;
 }
 
+LdConst::LdConst(SEXP c, PirType t)
+    : FixedLenInstruction(t), idx(Pool::insert(c)) {}
+LdConst::LdConst(SEXP c)
+    : FixedLenInstruction(PirType(c)), idx(Pool::insert(c)) {}
+
+SEXP LdConst::c() const { return Pool::get(idx); }
+
 void LdConst::printArgs(std::ostream& out, bool tty) const {
     std::string val;
     {
         CaptureOut rec;
-        Rf_PrintValue(c);
+        Rf_PrintValue(Pool::get(idx));
         val = rec.oneline(40);
     }
     out << val;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -521,9 +521,10 @@ extern std::ostream& operator<<(std::ostream& out,
 
 class FLI(LdConst, 0, Effect::None, EnvAccess::None) {
   public:
-    LdConst(SEXP c, PirType t) : FixedLenInstruction(t), c(c) {}
-    explicit LdConst(SEXP c) : FixedLenInstruction(PirType(c)), c(c) {}
-    SEXP c;
+    BC::PoolIdx idx;
+    SEXP c() const;
+    LdConst(SEXP c, PirType t);
+    explicit LdConst(SEXP c);
     void printArgs(std::ostream& out, bool tty) const override;
 };
 

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -106,8 +106,8 @@ bool test42(const std::string& input) {
 
     auto ld = LdConst::Cast((*r.begin()));
     CHECK(ld);
-    CHECK(TYPEOF(ld->c) == INTSXP);
-    CHECK(INTEGER(ld->c)[0] == 42);
+    CHECK(TYPEOF(ld->c()) == INTSXP);
+    CHECK(INTEGER(ld->c())[0] == 42);
     return true;
 };
 

--- a/rir/src/compiler/translations/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir.cpp
@@ -812,7 +812,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
             switch (instr->tag) {
             case Tag::LdConst: {
-                cs << BC::push(LdConst::Cast(instr)->c);
+                cs << BC::push_from_pool(LdConst::Cast(instr)->idx);
                 break;
             }
             case Tag::LdFun: {

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -43,6 +43,12 @@ BC BC::push(int constant) {
     i.pool = Pool::getInt(constant);
     return BC(Opcode::push_, i);
 }
+BC BC::push_from_pool(PoolIdx idx) {
+    ImmediateArguments i;
+    i.pool = idx;
+    return BC(Opcode::push_, i);
+}
+
 BC BC::ldfun(SEXP sym) {
     ImmediateArguments i;
     i.pool = Pool::insert(sym);

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -326,6 +326,7 @@ BC_NOARGS(V, _)
     inline static BC push(SEXP constant);
     inline static BC push(double constant);
     inline static BC push(int constant);
+    inline static BC push_from_pool(PoolIdx idx);
     inline static BC push_code(FunIdx i);
     inline static BC ldfun(SEXP sym);
     inline static BC ldvar(SEXP sym);


### PR DESCRIPTION
Constants were not protected until they are lowered to rir. This
commit ensures that they already end up in the constants pool, when
the pir instruction gets created.