### PR TITLE
fastrack common builtin calls from pir optimized code

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -517,7 +517,7 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
     }
 
     switch (call.callee->u.primsxp.offset) {
-    case 90: { // c
+    case 90: { // "c"
         if (nargs == 0)
             return R_NilValue;
 
@@ -548,11 +548,13 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
             auto len = XLENGTH(args[i]);
             for (long j = 0; j < len; ++j) {
                 assert(pos < total);
+                // We handle LGL and INT in the same case here. That is fine,
+                // because they are essentially the same type.
+                SLOWASSERT(NA_INTEGER == NA_LOGICAL);
                 if (type == REALSXP) {
                     if (TYPEOF(args[i]) == REALSXP) {
                         REAL(res)[pos++] = REAL(args[i])[j];
                     } else {
-                        SLOWASSERT(NA_INTEGER == NA_LOGICAL);
                         if (INTEGER(args[i])[j] == NA_INTEGER) {
                             REAL(res)[pos++] = NA_REAL;
                         } else {
@@ -567,7 +569,7 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
         return res;
     }
 
-    case 109: { //"vector"
+    case 109: { // "vector"
         if (nargs != 2)
             return nullptr;
         if (TYPEOF(args[0]) != STRSXP)
@@ -625,6 +627,7 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
     }
 
     case 412: { // "list"
+        // "lists" at the R level are VECSXP's in the implementation
         auto res = Rf_allocVector(VECSXP, nargs);
         for (size_t i = 0; i < nargs; ++i)
             SET_VECTOR_ELT(res, i, args[i]);
@@ -719,7 +722,7 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
         return isArray(args[0]) ? R_TrueValue : R_FalseValue;
     }
 
-    case 389: { // "is.atomic" (389) nargs : 1 arg0 : double a 0
+    case 389: { // "is.atomic" (389)
         if (nargs != 1)
             return nullptr;
         switch (TYPEOF(args[0])) {
@@ -739,7 +742,7 @@ SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
         assert(false);
     }
 
-    case 384: { // "is.object" (384) nargs : 1 arg0 : double a 0
+    case 384: { // "is.object" (384)
         if (nargs != 1)
             return nullptr;
         return OBJECT(args[0]) ? R_TrueValue : R_FalseValue;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -491,6 +491,264 @@ RIR_INLINE SEXP legacyCall(const CallContext& call, Context* ctx) {
     return res;
 }
 
+SEXP tryFastSpecialCall(const CallContext& call, Context* ctx) {
+    SLOWASSERT(call.hasStackArgs() && !call.hasNames());
+    return nullptr;
+}
+
+SEXP tryFastBuiltinCall(const CallContext& call, Context* ctx) {
+    SLOWASSERT(call.hasStackArgs() && !call.hasNames());
+
+    static constexpr size_t MAXARGS = 32;
+    std::array<SEXP, MAXARGS> args;
+    auto nargs = call.suppliedArgs;
+
+    if (nargs > MAXARGS)
+        return nullptr;
+
+    for (size_t i = 0; i < call.suppliedArgs; ++i) {
+        auto arg = call.stackArg(i);
+        if (TYPEOF(arg) == PROMSXP)
+            arg = PRVALUE(arg);
+        if (arg == R_UnboundValue || arg == R_MissingArg ||
+            ATTRIB(arg) != R_NilValue)
+            return nullptr;
+        args[i] = arg;
+    }
+
+    switch (call.callee->u.primsxp.offset) {
+    case 90: { // c
+        if (nargs == 0)
+            return R_NilValue;
+
+        auto type = TYPEOF(args[0]);
+        if (type != REALSXP && type != LGLSXP && type != INTSXP)
+            return nullptr;
+        long total = XLENGTH(args[0]);
+        for (size_t i = 1; i < nargs; ++i) {
+            auto thistype = TYPEOF(args[i]);
+            if (thistype != REALSXP && thistype != LGLSXP && thistype != INTSXP)
+                return nullptr;
+
+            if (thistype == INTSXP && type == LGLSXP)
+                type = INTSXP;
+
+            if (thistype == REALSXP && type != REALSXP)
+                type = REALSXP;
+
+            total += XLENGTH(args[i]);
+        }
+
+        if (total == 0)
+            return nullptr;
+
+        long pos = 0;
+        auto res = Rf_allocVector(type, total);
+        for (size_t i = 0; i < nargs; ++i) {
+            auto len = XLENGTH(args[i]);
+            for (long j = 0; j < len; ++j) {
+                assert(pos < total);
+                if (type == REALSXP) {
+                    if (TYPEOF(args[i]) == REALSXP) {
+                        REAL(res)[pos++] = REAL(args[i])[j];
+                    } else {
+                        SLOWASSERT(NA_INTEGER == NA_LOGICAL);
+                        if (INTEGER(args[i])[j] == NA_INTEGER) {
+                            REAL(res)[pos++] = NA_REAL;
+                        } else {
+                            REAL(res)[pos++] = INTEGER(args[i])[j];
+                        }
+                    }
+                } else {
+                    INTEGER(res)[pos++] = INTEGER(args[i])[j];
+                }
+            }
+        }
+        return res;
+    }
+
+    case 109: { //"vector"
+        if (nargs != 2)
+            return nullptr;
+        if (TYPEOF(args[0]) != STRSXP)
+            return nullptr;
+        if (XLENGTH(args[0]) != 1)
+            return nullptr;
+        size_t length = -1;
+        if (IS_SIMPLE_SCALAR(args[1], INTSXP)) {
+            if (INTEGER(args[1])[0] == NA_INTEGER)
+                return nullptr;
+            length = INTEGER(args[1])[0];
+        } else if (IS_SIMPLE_SCALAR(args[1], REALSXP)) {
+            if (REAL(args[1])[0] == NA_REAL)
+                return nullptr;
+            length = REAL(args[1])[0];
+        } else {
+            return nullptr;
+        }
+        int type = str2type(CHAR(args[0]));
+
+        switch (type) {
+        case LGLSXP:
+        case INTSXP: {
+            auto res = allocVector(type, length);
+            Memzero(INTEGER(res), length);
+            return res;
+        }
+        case CPLXSXP: {
+            auto res = allocVector(type, length);
+            Memzero(COMPLEX(res), length);
+            return res;
+        }
+        case RAWSXP: {
+            auto res = allocVector(type, length);
+            Memzero(RAW(res), length);
+            return res;
+        }
+        case REALSXP: {
+            auto res = allocVector(type, length);
+            Memzero(REAL(res), length);
+            return res;
+        }
+        case STRSXP:
+        case EXPRSXP:
+        case VECSXP:
+            return allocVector(type, length);
+        case LISTSXP:
+            if (length > INT_MAX)
+                return nullptr;
+            return allocList((int)length);
+        default:
+            return nullptr;
+        }
+        assert(false);
+    }
+
+    case 412: { // "list"
+        auto res = Rf_allocVector(VECSXP, nargs);
+        for (size_t i = 0; i < nargs; ++i)
+            SET_VECTOR_ELT(res, i, args[i]);
+        return res;
+    }
+
+    case 399: { // "is.vector"
+        if (nargs != 1)
+            return nullptr;
+
+        auto arg = args[0];
+        if (XLENGTH(arg) != 1)
+            return nullptr;
+        return TYPEOF(arg) == VECSXP ? R_TrueValue : R_FalseValue;
+    }
+
+    case 395: { // "is.na"
+        if (nargs != 1)
+            return nullptr;
+
+        auto arg = args[0];
+        if (XLENGTH(arg) != 1)
+            return nullptr;
+
+        switch (TYPEOF(arg)) {
+        case INTSXP:
+            return INTEGER(arg)[0] == NA_INTEGER ? R_TrueValue : R_FalseValue;
+        case LGLSXP:
+            return LOGICAL(arg)[0] == NA_LOGICAL ? R_TrueValue : R_FalseValue;
+        case REALSXP:
+            return ISNAN(REAL(arg)[0]) ? R_TrueValue : R_FalseValue;
+        default:
+            return nullptr;
+        }
+        assert(false);
+    }
+
+    case 393: { // "is.function"
+        if (nargs != 1)
+            return nullptr;
+        return isFunction(args[0]) ? R_TrueValue : R_FalseValue;
+    }
+
+    case 507: { // "islistfactor"
+        if (nargs != 2)
+            return nullptr;
+        auto n = XLENGTH(args[0]);
+        if (n == 0 || !isVectorList(args[0]))
+            return R_FalseValue;
+        int recursive = asLogical(args[1]);
+        if (recursive)
+            return nullptr;
+
+        for (int i = 0; i < n; i++)
+            if (!isFactor(VECTOR_ELT(args[0], i)))
+                return R_FalseValue;
+
+        return R_TrueValue;
+    }
+
+    case 88: { // "length"
+        if (nargs != 1)
+            return nullptr;
+
+        switch (TYPEOF(args[0])) {
+        case INTSXP:
+        case REALSXP:
+        case LGLSXP:
+            return Rf_ScalarInteger(XLENGTH(args[0]));
+        default:
+            return nullptr;
+        }
+        assert(false);
+    }
+
+    case 386: { // "is.numeric"
+        if (nargs != 1)
+            return nullptr;
+        return isNumeric(args[0]) && !isLogical(args[0]) ? R_TrueValue
+                                                         : R_FalseValue;
+    }
+
+    case 387: { // "is.matrix"
+        if (nargs != 1)
+            return nullptr;
+        return isMatrix(args[0]) ? R_TrueValue : R_FalseValue;
+    }
+
+    case 388: { // "is.array"
+        if (nargs != 1)
+            return nullptr;
+        return isArray(args[0]) ? R_TrueValue : R_FalseValue;
+    }
+
+    case 389: { // "is.atomic" (389) nargs : 1 arg0 : double a 0
+        if (nargs != 1)
+            return nullptr;
+        switch (TYPEOF(args[0])) {
+        case NILSXP:
+            /* NULL is atomic (S compatibly), but not in isVectorAtomic(.) */
+        case CHARSXP:
+        case LGLSXP:
+        case INTSXP:
+        case REALSXP:
+        case CPLXSXP:
+        case STRSXP:
+        case RAWSXP:
+            return R_TrueValue;
+        default:
+            return R_FalseValue;
+        }
+        assert(false);
+    }
+
+    case 384: { // "is.object" (384) nargs : 1 arg0 : double a 0
+        if (nargs != 1)
+            return nullptr;
+        return OBJECT(args[0]) ? R_TrueValue : R_FalseValue;
+    }
+    }
+
+    return nullptr;
+}
+
 SEXP closureArgumentAdaptor(const CallContext& call, SEXP arglist,
                             SEXP suppliedvars) {
     SEXP op = call.callee;
@@ -785,14 +1043,83 @@ RIR_INLINE SEXP rirCall(CallContext& call, Context* ctx) {
     return result;
 }
 
+#ifdef DEBUG_SLOWCASES
+
+class SlowcaseCounter {
+  public:
+    std::unordered_map<std::string, size_t> counter;
+
+    void count(const std::string& kind, CallContext& call, Context* ctx) {
+        std::stringstream message;
+        message << "Fast case " << kind << " failed for "
+                << getBuiltinName(getBuiltinNr(call.callee)) << " ("
+                << getBuiltinNr(call.callee) << ") "
+                << "nargs : " << call.suppliedArgs;
+        if (call.suppliedArgs > 0) {
+            auto arg = call.stackArg(0);
+            if (TYPEOF(arg) == PROMSXP)
+                arg = PRVALUE(arg);
+            if (arg == R_UnboundValue)
+                message << "arg0 lazy";
+            else if (arg == R_MissingArg)
+                message << "arg0 missing";
+            else
+                message << " arg0 : " << type2char(TYPEOF(arg)) << " a "
+                        << (ATTRIB(arg) != R_NilValue);
+        }
+        if (!counter.count(message.str()))
+            counter[message.str()] = 0;
+        counter[message.str()]++;
+    }
+
+    static constexpr size_t TRESHOLD = 100;
+    ~SlowcaseCounter() {
+        std::map<size_t, std::set<std::string>> order;
+        for (auto& e : counter)
+            if (e.second > TRESHOLD)
+                order[e.second].insert(e.first);
+        for (auto& o : order) {
+            for (auto& e : o.second) {
+                std::cout << o.first << " times: " << e << "\n";
+            }
+        }
+    }
+};
+SlowcaseCounter SLOWCASE_COUNTER;
+#endif
+
+RIR_INLINE SEXP builtinCall(CallContext& call, Context* ctx) {
+    if (call.hasStackArgs() && !call.hasNames()) {
+        SEXP res = tryFastBuiltinCall(call, ctx);
+        if (res)
+            return res;
+#ifdef DEBUG_SLOWCASES
+        SLOWCASE_COUNTER.count("builtin", call, ctx);
+#endif
+    }
+    return legacyCall(call, ctx);
+}
+
+RIR_INLINE SEXP specialCall(CallContext& call, Context* ctx) {
+    if (call.hasStackArgs() && !call.hasNames()) {
+        SEXP res = tryFastSpecialCall(call, ctx);
+        if (res)
+            return res;
+#ifdef DEBUG_SLOWCASES
+        SLOWCASE_COUNTER.count("special", call, ctx);
+#endif
+    }
+    return legacySpecialCall(call, ctx);
+}
+
 SEXP doCall(CallContext& call, Context* ctx) {
     assert(call.callee);
 
     switch (TYPEOF(call.callee)) {
     case SPECIALSXP:
-        return legacySpecialCall(call, ctx);
+        return specialCall(call, ctx);
     case BUILTINSXP:
-        return legacyCall(call, ctx);
+        return builtinCall(call, ctx);
     case CLOSXP: {
         if (TYPEOF(BODY(call.callee)) != EXTERNALSXP)
             return legacyCall(call, ctx);
@@ -1710,7 +2037,7 @@ SEXP evalRirCode(Code* c, Context* ctx, SEXP* env, const CallContext* callCtxt,
             advanceImmediate();
             CallContext call(c, callee, n, ast, ostack_cell_at(ctx, n - 1),
                              *env, Assumptions(), ctx);
-            res = legacyCall(call, ctx);
+            res = builtinCall(call, ctx);
             ostack_popn(ctx, call.passedArgs);
             ostack_push(ctx, res);
 


### PR DESCRIPTION
calling from pir optimized code into builtins is rather slow. because pir collects args on the stack, but the builtins take an arguments list.

In this commit I just picked a couple of low-hanging fruits. I looked at the builtin implementations in gnur (ie. check names.c, then go to the relevant `do_...` implementation of the builtin). For a couple of builtins that occur often in our benchmark suite I implemented the subset of types and arguments, that can be easily implemented in a couple of lines..

This commit also features a DEBUG_SLOWCASES define that can be enabled. This will print a statistics of the most used slow builtin calls when the process terminates and can help to identify the next builtin to be implemented.