### PR TITLE
[wip] GraphViz

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -39,6 +39,10 @@ completely disables the PIR optimizer. As follows are the different Options avai
         regex      only show functions matching regex
                    (might need .*, sometimes names are missing)
 
+    PIR_DEBUG_STYLE=
+        Standard   print pir in human-readable format, to view directly in console
+        GraphViz   print pir in GraphViz, displaying all instructions within BBs
+        GraphVizBB print pir in GraphViz, displaying only BB names and connections
     PIR_MEASURE_COMPILER=
         1          print overal time spend in different passes on shutdown
 

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -29,7 +29,7 @@ rir.compile <- function(what) {
 }
 
 # optimizes given rir compiled closure
-pir.compile <- function(what, debugFlags, P_EARLY=FALSE, P_FINAL=FALSE, P_OPT=FALSE, WARN=FALSE) {
+pir.compile <- function(what, debugFlags, debugStyle, P_EARLY=FALSE, P_FINAL=FALSE, P_OPT=FALSE, WARN=FALSE) {
     debugFlags <-
         if (missing(debugFlags)) {
             if (P_EARLY)
@@ -43,11 +43,18 @@ pir.compile <- function(what, debugFlags, P_EARLY=FALSE, P_FINAL=FALSE, P_OPT=FA
         } else {
             debugFlags
         }
+    debugStyle <-
+      if (missing(debugStyle)) {
+        NULL
+      } else {
+        as.name(as.character(substitute(debugStyle)))
+      }
 
     .Call("pir_compile",
           what,
           as.name(as.character(substitute(what))),
-          debugFlags)
+          debugFlags,
+          debugStyle)
 }
 
 pir.tests <- function() {

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -12,7 +12,8 @@ extern int R_ENABLE_JIT;
 
 REXPORT SEXP rir_invocation_count(SEXP what);
 REXPORT SEXP rir_eval(SEXP exp, SEXP env);
-REXPORT SEXP pir_compile(SEXP closure, SEXP name, SEXP sebugFlags);
+REXPORT SEXP pir_compile(SEXP closure, SEXP name, SEXP debugFlags,
+                         SEXP debugStyle);
 REXPORT SEXP rir_compile(SEXP what, SEXP env);
 SEXP pirCompile(SEXP closure, const rir::Assumptions& assumptions,
                 const std::string& name, const rir::pir::DebugOptions);

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -29,6 +29,11 @@ namespace pir {
     V(PrintIntoStdout)                                                         \
     LIST_OF_PIR_PRINT_DEBUGGING_FLAGS(V)
 
+#define LIST_OF_DEBUG_STYLES(V)                                                \
+    V(Standard)                                                                \
+    V(GraphViz)                                                                \
+    V(GraphVizBB)
+
 enum class DebugFlag {
 #define V(n) n,
     LIST_OF_PIR_DEBUGGING_FLAGS(V)
@@ -38,14 +43,21 @@ enum class DebugFlag {
     LAST = PrintFinalRir
 };
 
+enum class DebugStyle {
+#define V(style) style,
+    LIST_OF_DEBUG_STYLES(V)
+#undef V
+};
+
 struct DebugOptions {
     typedef EnumSet<DebugFlag, int> DebugFlags;
     DebugFlags flags;
     const std::regex passFilter;
     const std::regex functionFilter;
+    DebugStyle style;
 
     DebugOptions operator|(const DebugFlags& f) const {
-        return {flags | f, passFilter, functionFilter};
+        return {flags | f, passFilter, functionFilter, style};
     }
     bool includes(const DebugFlags& otherFlags) const {
         return flags.includes(otherFlags);
@@ -56,8 +68,9 @@ struct DebugOptions {
 
     explicit DebugOptions(unsigned long long flags) : flags(flags) {}
     DebugOptions(const DebugFlags& flags, const std::regex& filter,
-                 const std::regex& functionFilter)
-        : flags(flags), passFilter(filter), functionFilter(functionFilter) {}
+                 const std::regex& functionFilter, DebugStyle style)
+        : flags(flags), passFilter(filter), functionFilter(functionFilter),
+          style(style) {}
     DebugOptions() {}
 };
 

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -66,7 +66,8 @@ struct DebugOptions {
         return flags.intersects(otherFlags);
     }
 
-    explicit DebugOptions(unsigned long long flags) : flags(flags) {}
+    explicit DebugOptions(unsigned long long flags)
+        : flags(flags), style(DebugStyle::Standard) {}
     DebugOptions(const DebugFlags& flags, const std::regex& filter,
                  const std::regex& functionFilter, DebugStyle style)
         : flags(flags), passFilter(filter), functionFilter(functionFilter),

--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -68,7 +68,19 @@ void LogStream::pirOptimizationsFinished(ClosureVersion* closure) {
         std::regex_match(name.begin(), name.end(), options.functionFilter)) {
         preparePrint();
         section("PIR Version After Optimizations");
-        closure->print(out, tty());
+        switch (options.style) {
+        case DebugStyle::Standard:
+            closure->print(out, tty());
+            break;
+        case DebugStyle::GraphViz:
+            closure->printGraph(out, tty());
+            break;
+        case DebugStyle::GraphVizBB:
+            closure->printBBGraph(out, tty());
+            break;
+        default:
+            assert(false);
+        }
         out << "\n";
     }
 }

--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -1,3 +1,4 @@
+#include "../../utils/escape_string.h"
 #include "../util/visitor.h"
 #include "pir_impl.h"
 
@@ -31,6 +32,37 @@ void BB::print(std::ostream& out, bool tty) {
     if (isJmp()) {
         out << "  goto BB" << next0->id << "\n";
     }
+}
+
+void BB::printGraph(std::ostream& out, bool tty) {
+    out << "BB" << id << " [shape=\"box\", fontname=\"monospace\", xlabel=\"BB"
+        << id << "\", label=\"\\\n";
+    for (auto i : instrs) {
+        std::stringstream buf;
+        i->printGraph(buf);
+        out << escapeString(buf.str()) << "\\l\\\n";
+    }
+    out << "\"];\n";
+    if (!instrs.empty() && last()->branches()) {
+        last()->printGraphBranches(out, id);
+    }
+    if (isJmp()) {
+        out << "BB" << id << " -> "
+            << "BB" << next0->id << ";\n";
+    }
+    out << "\n";
+}
+
+void BB::printBBGraph(std::ostream& out) {
+    out << "BB" << id << " [shape=\"circle\", label=\"BB" << id << "\"];\n";
+    if (!instrs.empty() && last()->branches()) {
+        last()->printGraphBranches(out, id);
+    }
+    if (isJmp()) {
+        out << "BB" << id << " -> "
+            << "BB" << next0->id << ";\n";
+    }
+    out << "\n";
 }
 
 BB::~BB() {

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -77,6 +77,8 @@ class BB {
     void swapWithNext(Instrs::iterator);
 
     void print(std::ostream& = std::cout, bool tty = false);
+    void printGraph(std::ostream& = std::cout, bool tty = false);
+    void printBBGraph(std::ostream& = std::cout);
 
     Instrs::iterator begin() { return instrs.begin(); }
     Instrs::iterator end() { return instrs.end(); }

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -18,6 +18,24 @@ void ClosureVersion::print(std::ostream& out, bool tty) const {
     }
 }
 
+void ClosureVersion::printGraph(std::ostream& out, bool tty) const {
+    out << *this << "\n";
+    printGraphCode(out, tty);
+    for (auto p : promises_) {
+        if (p)
+            p->print(out, tty);
+    }
+}
+
+void ClosureVersion::printBBGraph(std::ostream& out, bool tty) const {
+    out << *this << "\n";
+    printBBGraphCode(out);
+    for (auto p : promises_) {
+        if (p)
+            p->print(out, tty);
+    }
+}
+
 Promise* ClosureVersion::createProm(unsigned srcPoolIdx) {
     Promise* p = new Promise(this, promises_.size(), srcPoolIdx);
     promises_.push_back(p);

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -68,6 +68,8 @@ class ClosureVersion : public Code {
     const std::string& nameSuffix() const { return nameSuffix_; }
 
     void print(std::ostream& out, bool tty) const;
+    void printGraph(std::ostream& out, bool tty) const;
+    void printBBGraph(std::ostream& out, bool tty) const;
 
     Promise* createProm(unsigned srcPoolIdx);
 

--- a/rir/src/compiler/pir/code.cpp
+++ b/rir/src/compiler/pir/code.cpp
@@ -11,6 +11,18 @@ void Code::printCode(std::ostream& out, bool tty) const {
     BreadthFirstVisitor::run(entry, [&](BB* bb) { bb->print(out, tty); });
 }
 
+void Code::printGraphCode(std::ostream& out, bool tty) const {
+    out << "digraph {\n";
+    BreadthFirstVisitor::run(entry, [&](BB* bb) { bb->printGraph(out, tty); });
+    out << "}\n";
+}
+
+void Code::printBBGraphCode(std::ostream& out) const {
+    out << "digraph {\n";
+    BreadthFirstVisitor::run(entry, [&](BB* bb) { bb->printBBGraph(out); });
+    out << "}\n";
+}
+
 Code::~Code() {
     std::stack<BB*> toDel;
     Visitor::run(entry, [&toDel](BB* bb) { toDel.push(bb); });

--- a/rir/src/compiler/pir/code.h
+++ b/rir/src/compiler/pir/code.h
@@ -20,6 +20,8 @@ class Code {
 
     Code() {}
     void printCode(std::ostream&, bool tty) const;
+    void printGraphCode(std::ostream&, bool tty) const;
+    void printBBGraphCode(std::ostream&) const;
     virtual ~Code();
 
     virtual size_t size() const;

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -77,10 +77,25 @@ void Instruction::printArgs(std::ostream& out, bool tty) const {
         out << ", ";
 }
 
+void Instruction::printGraphArgs(std::ostream& out, bool tty) const {
+    printArgs(out, tty);
+}
+
+void Instruction::printGraphBranches(std::ostream& out, int bbId) const {
+    assert(false);
+}
+
 void Instruction::print(std::ostream& out, bool tty) const {
     printPaddedTypeAndRef(out, this);
     printPaddedInstructionName(out, name());
     printArgs(out, tty);
+    printEnv(out, tty);
+}
+
+void Instruction::printGraph(std::ostream& out, bool tty) const {
+    printPaddedTypeAndRef(out, this);
+    printPaddedInstructionName(out, name());
+    printGraphArgs(out, tty);
     printEnv(out, tty);
 }
 
@@ -270,6 +285,16 @@ void Branch::printArgs(std::ostream& out, bool tty) const {
     FixedLenInstruction::printArgs(out, tty);
     out << " -> BB" << bb()->trueBranch()->id << " (if true) | BB"
         << bb()->falseBranch()->id << " (if false)";
+}
+
+void Branch::printGraphArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+}
+
+void Branch::printGraphBranches(std::ostream& out, int bbId) const {
+    out << "  BB" << bbId << " -> BB" << bb()->trueBranch()->id
+        << " [color=green];\n  BB" << bbId << " -> BB"
+        << bb()->falseBranch()->id << " [color=red];\n";
 }
 
 void MkArg::printArgs(std::ostream& out, bool tty) const {
@@ -654,6 +679,15 @@ void Checkpoint::printArgs(std::ostream& out, bool tty) const {
     FixedLenInstruction::printArgs(out, tty);
     out << " -> BB" << bb()->trueBranch()->id << " (default) | BB"
         << bb()->falseBranch()->id << " (if assume failed)";
+}
+
+void Checkpoint::printGraphArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+}
+
+void Checkpoint::printGraphBranches(std::ostream& out, int bbId) const {
+    out << "  BB" << bbId << " -> BB" << bb()->trueBranch()->id << ";\n  BB"
+        << bbId << " -> BB" << bb()->falseBranch()->id << " [color=red];\n";
 }
 
 BB* Checkpoint::deoptBranch() { return bb()->falseBranch(); }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -181,7 +181,10 @@ class Instruction : public Value {
 
     virtual void printEnv(std::ostream& out, bool tty) const;
     virtual void printArgs(std::ostream& out, bool tty) const;
+    virtual void printGraphArgs(std::ostream& out, bool tty) const;
+    virtual void printGraphBranches(std::ostream& out, int bbId) const;
     virtual void print(std::ostream& out, bool tty = false) const;
+    void printGraph(std::ostream& out, bool tty = false) const;
     void printRef(std::ostream& out) const override final;
     void print() const { print(std::cerr, true); }
 
@@ -692,6 +695,8 @@ class Branch
         : FixedLenInstruction(PirType::voyd(), {{NativeType::test}}, {{test}}) {
     }
     void printArgs(std::ostream& out, bool tty) const override;
+    void printGraphArgs(std::ostream& out, bool tty) const override;
+    void printGraphBranches(std::ostream& out, int bbId) const override;
 };
 
 class Return : public FixedLenInstruction<Tag::Return, Return, 1, Effect::Order,
@@ -1420,6 +1425,8 @@ class Checkpoint
   public:
     Checkpoint() : FixedLenInstruction(NativeType::checkpoint) {}
     void printArgs(std::ostream& out, bool tty) const override;
+    void printGraphArgs(std::ostream& out, bool tty) const override;
+    void printGraphBranches(std::ostream& out, int bbId) const override;
     BB* deoptBranch();
 };
 

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -54,7 +54,8 @@ closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
                                   // pir::DebugFlag::PrintEarlyRir |
                                   // pir::DebugFlag::PrintOptimizationPasses |
                                   pir::DebugFlag::PrintFinalPir,
-                              std::regex(".*"), std::regex(".*")});
+                              std::regex(".*"), std::regex(".*"),
+                              pir::DebugStyle::Standard});
     pir::Rir2PirCompiler cmp(m, logger);
 
     // Compile every function in the environment

--- a/rir/src/utils/escape_string.h
+++ b/rir/src/utils/escape_string.h
@@ -1,0 +1,49 @@
+#ifndef ESCAPE_STRING
+#define ESCAPE_STRING
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <unistd.h>
+
+namespace rir {
+
+static std::string escapeString(std::string str) {
+    std::string res = "";
+    for (char c : str) {
+        if (c >= ' ' && c <= '~' && c != '\\' && c != '"') {
+            res += c;
+        } else {
+            res += '\\';
+            switch (c) {
+            case '"':
+            case '\\':
+                res += c;
+                break;
+            case '\n':
+                res += 'n';
+                break;
+            case '\r':
+                res += 'r';
+                break;
+            case '\t':
+                res += 't';
+                break;
+            default:
+                const char* hexs = "0123456789ABCDEF";
+                res += 'x';
+                res += hexs[c >> 4];
+                res += hexs[c & 0xF];
+                break;
+            }
+        }
+    }
+    return res;
+}
+
+} // namespace rir
+
+#endif


### PR DESCRIPTION
This adds GraphViz output to PIR ([#324]). Enable either by passing `PIR_DEBUG_STYLE=GraphViz`, or calling `pir.compile(fun, debugStyle=GraphViz)`.

Currently not much more than @o-'s example. Only `pir::Code`'s are changed. The GraphViz is in raw DOT, so it's not ideal (see the example).

I implemented this by adding a custom class, `PrintStream`, and replacing uses of `std::ostream` with it. In the future, we can add a lot more output styles, and customize almost anything that gets printed. 

After this, I plan to add an alternate GraphViz output which only prints the BB's numbers (as suggested), and if there's a program/library for it, outputs for ASCII art GraphViz.

Sample output.

<pre><font color="#295FCC"><b>╞═══════════════════════════════╡  </b></font>Compiling f<font color="#295FCC"><b>  ╞══════════════════════════════╡</b></font>

<font color="#FF8787"><b>┌──────────────────────────────────────────────────────────────────────────────┐</b></font>
<font color="#FF8787"><b>│ f[0x55f8a48730e0]                                                            │</b></font>
<font color="#FF8787"><b>│ Assumptions: CorrOrd, !TMany                                                 │</b></font>
<font color="#FF8787"><b>│ Properties:  Eager, ForceOrd: 0                                              │</b></font>
<font color="#FF8787"><b>├────── PIR Version After Optimizations</b></font>
f[0x55f8a48730e0]
digraph {
  BB0 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
val?^   %0.0  = LdArg            0\l\
env     e0.1  = MkEnv            x=%0.0, parent=<font color="#DED82C"><b>&lt;environment: R_GlobalEnv&gt;</b></font>\l\
val?    %0.2  = Force!           %0.0, <font color="#CC58CC"><b>e0.1</b></font>\l\
real$&apos;  %0.3  = LdConst          [1] 1 \l\
cp      %0.4  = Checkpoint       \l\
&quot;];
  BB0 -&gt; BB2;
  BB0 -&gt; BB1 [color=red];

  BB2 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
t       %2.0  = IsObject         %0.2\l\
void            AssumeNot        %2.0, %0.4\l\
lgl&apos;    %2.2  = Lt               %0.2, %0.3, elided\l\
t       %2.3  = AsTest           %2.2\l\
void            Branch           %2.3\l\
&quot;];
  BB2 -&gt; BB4 [color=green];
  BB2 -&gt; BB3 [color=red];

  BB1 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
fs      %1.0  = FrameState       1+45: [%0.2, %0.3], env=<font color="#DED82C"><b>e0.1</b></font>\l\
void            Deopt            %1.0\l\
&quot;];

  BB4 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
&quot;];
BB4 -&gt; BB5;

  BB3 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
nil&apos;    %3.0  = LdConst          NULL \l\
void            Invisible        \l\
&quot;];
BB3 -&gt; BB12;

  BB5 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
val?^   %5.0  = LdVar            x, <font color="#DED82C"><b>e0.1</b></font>\l\
val?    %5.1  = Force            %5.0, <font color="#CC58CC"><b>e0.1</b></font>\l\
real$&apos;  %5.2  = LdConst          [1] 4 \l\
cp      %5.3  = Checkpoint       \l\
&quot;];
  BB5 -&gt; BB7;
  BB5 -&gt; BB6 [color=red];

  BB12 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
nil&apos;    %12.0 = Phi              %3.0:BB3, %8.0:BB8\l\
void            Return           %12.0\l\
&quot;];

  BB7 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
t       %7.0  = IsObject         %5.1\l\
void            AssumeNot        %7.0, %5.3\l\
lgl&apos;    %7.2  = Lt               %5.1, %5.2, elided\l\
t       %7.3  = AsTest           %7.2\l\
void            Branch           %7.3\l\
&quot;];
  BB7 -&gt; BB9 [color=green];
  BB7 -&gt; BB8 [color=red];

  BB6 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
fs      %6.0  = FrameState       1+108: [%5.1, %5.2], env=<font color="#DED82C"><b>e0.1</b></font>\l\
void            Deopt            %6.0\l\
&quot;];

  BB9 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
val?^   %9.0  = LdVar            x, <font color="#DED82C"><b>e0.1</b></font>\l\
val?    %9.1  = Force            %9.0, <font color="#CC58CC"><b>e0.1</b></font>\l\
str$&apos;   %9.2  = LdConst          [1] \&quot;foo\&quot; \l\
cp      %9.3  = Checkpoint       \l\
&quot;];
  BB9 -&gt; BB11;
  BB9 -&gt; BB10 [color=red];

  BB8 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
nil&apos;    %8.0  = LdConst          NULL \l\
void            Invisible        \l\
&quot;];
BB8 -&gt; BB12;

  BB11 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
t       %11.0 = IsObject         %9.1\l\
void            AssumeNot        %11.0, %9.3\l\
val?&apos;   %11.2 = Add              %9.1, %9.2, elided\l\
void            StVar            x, %11.2, <font color="#FF8787"><b>e0.1</b></font>\l\
void            Invisible        \l\
&quot;];
BB11 -&gt; BB5;

  BB10 [shape=&quot;box&quot;, fontname=&quot;monospace&quot;, label=&quot;\
fs      %10.0 = FrameState       1+160: [%9.1, %9.2], env=<font color="#DED82C"><b>e0.1</b></font>\l\
void            Deopt            %10.0\l\
&quot;];

}

<font color="#FF8787"><b>│ f[0x55f8a48730e0]                                                            │</b></font>
<font color="#FF8787"><b>└──────────────────────────────────────────────────────────────────────────────┘</b></font></pre>