### PR TITLE
Increase max compilation unit size and fix a number of bugs in the co…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
         - BUILD=debugopt
         - PIR_DEOPT_CHAOS_SETTING=1
         - TEST_VALGRIND=1
+        - PIR_MAX_INPUT_SIZE=1000
+        - PIR_INLINER_MAX_SIZE=800
 
     - env:
         - CXX_OVERRIDE=g++-7
@@ -49,6 +51,8 @@ matrix:
         - BUILD=release
         - TEST_GCTORTURE=1
         - PIR_WARMUP=4
+        - PIR_MAX_INPUT_SIZE=1000
+        - PIR_INLINER_MAX_SIZE=800
 
     - env:
         - CXX_OVERRIDE=g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - CC_OVERRIDE=clang
         - BUILD=debugopt
         - CHECK=check
-        - RIR_WARMUP=2
+        - PIR_WARMUP=2
       compiler: clang
 
     # linux gcc
@@ -48,7 +48,7 @@ matrix:
         - CHECK=check-recommended
         - BUILD=release
         - TEST_GCTORTURE=1
-        - RIR_WARMUP=4
+        - PIR_WARMUP=4
 
     - env:
         - CXX_OVERRIDE=g++-7

--- a/rir/src/R/Funtab.h
+++ b/rir/src/R/Funtab.h
@@ -120,6 +120,7 @@ static inline int getFlag(SEXP f) {
     int i = ((sexprec_rjit*)f)->u.i;
     return (((R_FunTab[i].eval) / 100) % 10);
 }
+static inline int getFlag(int i) { return (((R_FunTab[i].eval) / 100) % 10); }
 
 static inline int findBuiltin(const char* name) {
     int i = 0;

--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -78,6 +78,7 @@
     V(sysframe, "sys.frame")                                                   \
     V(syscall, "sys.call")                                                     \
     V(srcref, "srcref")                                                        \
-    V(ambiguousCallTarget, ".ambiguousCallTarget.")
+    V(ambiguousCallTarget, ".ambiguousCallTarget.")                            \
+    V(delayedArglist, ".delayedArglist.")
 
 #endif // SYMBOLS_LIST_H_

--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -17,7 +17,7 @@ class AvailableCheckpoints : public StaticAnalysis<AbstractUnique<Checkpoint>> {
     AbstractResult apply(AbstractUnique<Checkpoint>& state,
                          Instruction* i) const override {
         if (state.get()) {
-            if (i->hasObservableEffect()) {
+            if (i->hasEffectIgnoreVisibility()) {
                 state.clear();
                 return AbstractResult::Updated;
             }

--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -17,7 +17,9 @@ bool Query::noEnv(Code* c) {
 
 bool Query::pure(Code* c) {
     return Visitor::check(c->entry, [](Instruction* i) {
-        return !i->hasEffect() && !i->changesEnv();
+        // Yes visibility is a global effect. We try to preserve it. But geting
+        // it wrong is not a strong correctness issue.
+        return !i->hasEffectIgnoreVisibility() && !i->changesEnv();
     });
 }
 

--- a/rir/src/compiler/analysis/unnecessary_contexts.h
+++ b/rir/src/compiler/analysis/unnecessary_contexts.h
@@ -1,0 +1,56 @@
+#ifndef PIR_UNNECESSARY_CONTEXTS_H
+#define PIR_UNNECESSARY_CONTEXTS_H
+
+#include "../util/cfg.h"
+#include "abstract_value.h"
+#include "generic_static_analysis.h"
+
+namespace rir {
+namespace pir {
+
+struct UnnecessaryContextsState : public AbstractUnique<PushContext> {
+    bool needed = false;
+    AbstractResult merge(const UnnecessaryContextsState& other) {
+        AbstractResult res = AbstractUnique<PushContext>::merge(other);
+        if (get() && !needed && other.needed) {
+            needed = true;
+            res.update();
+        }
+        return res;
+    }
+};
+
+class UnnecessaryContexts : public StaticAnalysis<UnnecessaryContextsState> {
+  public:
+    ClosureVersion* code;
+    UnnecessaryContexts(ClosureVersion* cls, LogStream& log)
+        : StaticAnalysis("UnnecessaryContexts", cls, cls, log), code(cls) {}
+
+    AbstractResult apply(UnnecessaryContextsState& state,
+                         Instruction* i) const override {
+        if (auto p = PushContext::Cast(i)) {
+            state.set(p);
+            return AbstractResult::Updated;
+        } else if (CallInstruction::CastCall(i)) {
+            state.needed = true;
+            return AbstractResult::Updated;
+        } else if (auto p = PopContext::Cast(i)) {
+            if (state.get()) {
+                assert(state.get() == p->push());
+                state.clear();
+                return AbstractResult::Updated;
+            }
+        }
+        return AbstractResult::None;
+    };
+
+    bool canRemove(PopContext* i) {
+        auto res = StaticAnalysis::at<PositioningStyle::BeforeInstruction>(i);
+        return res.get() && res.get() == i->push() && !res.needed;
+    }
+};
+
+} // namespace pir
+} // namespace rir
+
+#endif

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -228,27 +228,27 @@ class TheVerifier {
                                   << " predecessors but "
                                   << phi->nargs() - directInputs
                                   << " more arguments than immediate preds.\n";
-                        std::cerr << "\
-This Means we created this kind of graph, where a3 is in BB3 instead of\n\
-BB0. This will be impossible to convert back to CSSA.\n\
-  .-----.                             \n\
-  | BB1 |         .-----.             \n\
-  |-----|----.----| BB0 |             \n\
-  | a1= |    |    '-----'             \n\
-  '-----'    v                        \n\
-          .-----.                     \n\
-          | BB3 |                     \n\
-          |-----|                     \n\
-          | a3= |                     \n\
-          '-----'                     \n\
-             |                        \n\
-             v                        \n\
-  .---------------------.             \n\
-  |         BB4         |             \n\
-  |---------------------|             \n\
-  | phi(BB1:a1, BB3:a3) |             \n\
-  '---------------------'             \n\
-";
+                        std::cerr << "This Means we created this kind of "
+                                     "graph, where a3 is in BB3 instead of\n"
+                                     "BB0. This will be impossible to convert "
+                                     "back to CSSA.\n"
+                                     "  .-----.                             \n"
+                                     "  | BB1 |         .-----.             \n"
+                                     "  |-----|----.----| BB0 |             \n"
+                                     "  | a1= |    |    '-----'             \n"
+                                     "  '-----'    v                        \n"
+                                     "          .-----.                     \n"
+                                     "          | BB3 |                     \n"
+                                     "          |-----|                     \n"
+                                     "          | a3= |                     \n"
+                                     "          '-----'                     \n"
+                                     "             |                        \n"
+                                     "             v                        \n"
+                                     "  .---------------------.             \n"
+                                     "  |         BB4         |             \n"
+                                     "  |---------------------|             \n"
+                                     "  | phi(BB1:a1, BB3:a3) |             \n"
+                                     "  '---------------------'             \n";
                         ok = false;
                         assert(false);
                     }

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -169,32 +169,109 @@ class TheVerifier {
             assert(i == bb->last() &&
                    "Only last instruction of BB can have controlflow");
 
-        Phi* phi = Phi::Cast(i);
-        i->eachArg([&](const InstrArg& a) -> void {
-            auto v = a.val();
-            auto t = a.type();
-            if (auto iv = Instruction::Cast(v)) {
-                if (phi) {
-                    if (slow &&
-                        !cfg(bb->owner).isPredecessor(iv->bb(), i->bb())) {
+        if (auto phi = Phi::Cast(i)) {
+            size_t directInputs = 0;
+            phi->eachArg([&](BB* input, Value* v) {
+                if (auto iv = Instruction::Cast(v)) {
+                    if (input == phi->bb()) {
                         std::cerr << "Error at instruction '";
                         i->print(std::cerr);
                         std::cerr << "': input '";
                         iv->printRef(std::cerr);
-                        std::cerr << "' does not come from a predecessor.\n";
+                        std::cerr << "' has the phi block as input block\n";
                         ok = false;
                     }
-                } else if ((iv->bb() == i->bb() &&
-                            bb->indexOf(iv) > bb->indexOf(i)) ||
-                           (iv->bb() != i->bb() && slow &&
-                            !dom(bb->owner).dominates(iv->bb(), bb))) {
-                    std::cerr << "Error at instruction '";
-                    i->print(std::cerr);
-                    std::cerr << "': input '";
-                    iv->printRef(std::cerr);
-                    std::cerr << "' used before definition.\n";
-                    ok = false;
+
+                    if (slow) {
+                        if (cfg(bb->owner).isImmediatePredecessor(input, bb))
+                            directInputs++;
+
+                        if ((!cfg(bb->owner).isPredecessor(iv->bb(), i->bb()) ||
+                             // A block can be it's own predecessor (loop). But
+                             // then the input must come after the phi!
+                             (iv->bb() == i->bb() &&
+                              i->bb()->indexOf(iv) < i->bb()->indexOf(i)))) {
+                            std::cerr << "Error at instruction '";
+                            i->print(std::cerr);
+                            std::cerr << "': input '";
+                            iv->printRef(std::cerr);
+                            std::cerr
+                                << "' does not come from a predecessor.\n";
+                            ok = false;
+                        }
+                    }
                 }
+            });
+            if (slow) {
+                if (directInputs ==
+                    cfg(bb->owner).immediatePredecessors(bb).size()) {
+                    if (directInputs != phi->nargs()) {
+                        std::cout << "digraph { ";
+                        Visitor::run(f->entry, [&](BB* bb) {
+                            //                          std::cout << "BB" <<
+                            //                          bb->id << "
+                            //                          [shape=\"box\"
+                            //                          label=\"BB" << bb->id <<
+                            //                          "\"]; ";
+                            if (bb->next0)
+                                std::cout << "BB" << bb->id << " -> BB"
+                                          << bb->next0->id << "; ";
+                            if (bb->next1 && !Checkpoint::Cast(bb->last()))
+                                std::cout << "BB" << bb->id << " -> BB"
+                                          << bb->next1->id << "; ";
+                        });
+                        std::cout << "}\n";
+
+                        std::cerr << "Error at instruction '";
+                        i->print(std::cerr);
+                        std::cerr << "'\nI have inputs from all my immediate "
+                                  << " predecessors but "
+                                  << phi->nargs() - directInputs
+                                  << " more arguments than immediate preds.\n";
+                        std::cerr << "\
+This Means we created this kind of graph, where a3 is in BB3 instead of\n\
+BB0. This will be impossible to convert back to CSSA.\n\
+  .-----.                             \n\
+  | BB1 |         .-----.             \n\
+  |-----|----.----| BB0 |             \n\
+  | a1= |    |    '-----'             \n\
+  '-----'    v                        \n\
+          .-----.                     \n\
+          | BB3 |                     \n\
+          |-----|                     \n\
+          | a3= |                     \n\
+          '-----'                     \n\
+             |                        \n\
+             v                        \n\
+  .---------------------.             \n\
+  |         BB4         |             \n\
+  |---------------------|             \n\
+  | phi(BB1:a1, BB3:a3) |             \n\
+  '---------------------'             \n\
+";
+                        ok = false;
+                        assert(false);
+                    }
+                }
+            }
+        }
+
+        i->eachArg([&](const InstrArg& a) -> void {
+            auto v = a.val();
+            auto t = a.type();
+            if (auto iv = Instruction::Cast(v)) {
+                if (!Phi::Cast(i))
+                    if ((iv->bb() == i->bb() &&
+                         bb->indexOf(iv) > bb->indexOf(i)) ||
+                        (iv->bb() != i->bb() && slow &&
+                         !dom(bb->owner).dominates(iv->bb(), bb))) {
+                        std::cerr << "Error at instruction '";
+                        i->print(std::cerr);
+                        std::cerr << "': input '";
+                        iv->printRef(std::cerr);
+                        std::cerr << "' used before definition.\n";
+                        ok = false;
+                    }
 
                 if (iv->bb()->owner != i->bb()->owner) {
                     std::cerr << "Error at instruction '";

--- a/rir/src/compiler/analysis/visibility.cpp
+++ b/rir/src/compiler/analysis/visibility.cpp
@@ -1,0 +1,65 @@
+#include "visibility.h"
+#include "R/Funtab.h"
+
+namespace rir {
+namespace pir {
+
+AbstractResult VisibilityAnalysis::apply(CurrentVisibility& vis,
+                                         Instruction* i) const {
+    // Default: visible
+    if (!code->entry->isEmpty() && i == *code->entry->begin())
+        vis.state = CurrentVisibility::Visible;
+
+    switch (i->tag) {
+    case Tag::Invisible:
+        if (vis.state != CurrentVisibility::Invisible) {
+            vis.state = CurrentVisibility::Invisible;
+            return AbstractResult::Updated;
+        }
+        break;
+    case Tag::Visible:
+    case Tag::LdVar:
+    case Tag::LdVarSuper:
+    case Tag::Extract1_1D:
+    case Tag::Extract2_1D:
+    case Tag::Extract1_2D:
+    case Tag::Extract2_2D:
+        if (vis.state != CurrentVisibility::Visible) {
+            vis.state = CurrentVisibility::Visible;
+            return AbstractResult::Updated;
+        }
+        break;
+    case Tag::CallBuiltin:
+    case Tag::CallSafeBuiltin:
+        int flag;
+        if (auto c = CallBuiltin::Cast(i)) {
+            flag = getFlag(c->builtinId);
+        } else {
+            flag = getFlag(CallSafeBuiltin::Cast(i)->builtinId);
+        }
+
+        if (flag < 2) {
+            bool visible = static_cast<Rboolean>(flag != 1);
+            if (visible && vis.state != CurrentVisibility::Visible) {
+                vis.state = CurrentVisibility::Visible;
+                return AbstractResult::Updated;
+            }
+            if (!visible && vis.state != CurrentVisibility::Invisible) {
+                vis.state = CurrentVisibility::Invisible;
+                return AbstractResult::Updated;
+            }
+        }
+        break;
+    default:
+        if (i->mightChangeVisibility()) {
+            if (vis.state != CurrentVisibility::Unknown) {
+                vis.state = CurrentVisibility::Unknown;
+                return AbstractResult::Updated;
+            }
+        }
+    }
+    return AbstractResult::None;
+};
+
+} // namespace rir
+} // namespace pir

--- a/rir/src/compiler/analysis/visibility.h
+++ b/rir/src/compiler/analysis/visibility.h
@@ -46,25 +46,7 @@ class VisibilityAnalysis : public StaticAnalysis<CurrentVisibility> {
         : StaticAnalysis("VisibilityAnalysis", cls, cls, log), code(cls) {}
 
     AbstractResult apply(CurrentVisibility& vis,
-                         Instruction* i) const override {
-        if (Invisible::Cast(i)) {
-            if (vis.state != CurrentVisibility::Invisible) {
-                vis.state = CurrentVisibility::Invisible;
-                return AbstractResult::Updated;
-            }
-        } else if (Visible::Cast(i)) {
-            if (vis.state != CurrentVisibility::Visible) {
-                vis.state = CurrentVisibility::Visible;
-                return AbstractResult::Updated;
-            }
-        } else if (i->mightChangeVisibility()) {
-            if (vis.state != CurrentVisibility::Unknown) {
-                vis.state = CurrentVisibility::Unknown;
-                return AbstractResult::Updated;
-            }
-        }
-        return AbstractResult::None;
-    };
+                         Instruction* i) const override final;
 
     CurrentVisibility::State at(Instruction* i) {
         return StaticAnalysis::at<PositioningStyle::BeforeInstruction>(i).state;

--- a/rir/src/compiler/opt/context.cpp
+++ b/rir/src/compiler/opt/context.cpp
@@ -1,0 +1,55 @@
+#include "../analysis/unnecessary_contexts.h"
+#include "../pir/pir_impl.h"
+#include "../translations/pir_translator.h"
+#include "../util/cfg.h"
+#include "../util/visitor.h"
+
+#include "R/r.h"
+#include "pass_definitions.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rir {
+namespace pir {
+
+void OptimizeContexts::apply(RirCompiler&, ClosureVersion* function,
+                             LogStream& log) const {
+    UnnecessaryContexts unnecessary(function, log);
+
+    std::unordered_set<Instruction*> toRemove;
+    Visitor::run(function->entry, [&](BB* bb) {
+        for (auto i : *bb) {
+            if (auto pop = PopContext::Cast(i)) {
+                if (unnecessary.canRemove(pop)) {
+                    toRemove.insert(pop->push());
+                    toRemove.insert(pop);
+                }
+            }
+        }
+    });
+
+    if (toRemove.empty())
+        return;
+
+    assert(toRemove.size() % 2 == 0);
+
+    Visitor::run(function->entry, [&](BB* bb) {
+        auto ip = bb->begin();
+        while (ip != bb->end()) {
+            auto next = ip + 1;
+            auto instr = *ip;
+
+            auto e = toRemove.find(instr);
+            if (e != toRemove.end()) {
+                next = bb->remove(ip);
+                toRemove.erase(e);
+            }
+
+            ip = next;
+        }
+    });
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -252,7 +252,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                 Replace::usesOfValue(prom_copy, e, mk->promEnv());
                 prom_copy->remove(prom_copy->begin());
 
-                Value* promRes = BBTransform::forInline(prom_copy, split);
+                Value* promRes = BBTransform::forInline(prom_copy, split).first;
                 mk->eagerArg(promRes);
 
                 bb = split;

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -346,7 +346,8 @@ void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
 
                                 // Create a return value phi of the promise
                                 Value* promRes =
-                                    BBTransform::forInline(prom_copy, split);
+                                    BBTransform::forInline(prom_copy, split)
+                                        .first;
 
                                 f = Force::Cast(*split->begin());
                                 assert(f);

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -97,6 +97,9 @@ class TheInliner {
                             return false;
                         }
                     }
+                    if (CallInstruction::CastCall(i)) {
+                        return false;
+                    }
                     return true;
                 };
 

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -274,12 +274,13 @@ class TheInliner {
 
 // TODO: maybe implement something more resonable to pass in those constants.
 // For now it seems a simple env variable is just fine.
-const size_t TheInliner::MAX_SIZE =
-    getenv("PIR_INLINER_MAX_SIZE") ? atoi(getenv("PIR_INLINER_MAX_SIZE")) : 500;
+const size_t TheInliner::MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
+                                        ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
+                                        : 4000;
 const size_t TheInliner::MAX_INLINEE_SIZE =
     getenv("PIR_INLINER_MAX_INLINEE_SIZE")
         ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-        : 50;
+        : 100;
 const size_t TheInliner::INITIAL_FUEL =
     getenv("PIR_INLINER_INITIAL_FUEL")
         ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -115,6 +115,8 @@ class PASS(EagerCalls);
 
 class PASS(OptimizeVisibility);
 
+class PASS(OptimizeContexts);
+
 class PhaseMarker : public PirTranslator {
   public:
     explicit PhaseMarker(const std::string& name) : PirTranslator(name) {}

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -17,10 +17,9 @@ class TheScopeResolution {
   public:
     ClosureVersion* function;
     CFG cfg;
-    DominanceGraph doms;
     LogStream& log;
     explicit TheScopeResolution(ClosureVersion* function, LogStream& log)
-        : function(function), cfg(function), doms(function), log(log) {}
+        : function(function), cfg(function), log(log) {}
 
     void operator()() {
         ScopeAnalysis analysis(function, log);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1334,6 +1334,23 @@ class VLIE(MkEnv, Effect::None, EnvAccess::Capture) {
     size_t nLocals() { return nargs() - 1; }
 };
 
+class FLIE(PushContext, 3, Effect::Any, EnvAccess::Capture) {
+  public:
+    PushContext(Value* ast, Value* op, Value* sysparent)
+        : FixedLenInstructionWithEnvSlot(NativeType::context,
+                                         {{PirType::any(), PirType::closure()}},
+                                         {{ast, op}}, sysparent) {}
+};
+
+class FLI(PopContext, 2, Effect::Any, EnvAccess::None) {
+  public:
+    PopContext(Value* res, PushContext* push)
+        : FixedLenInstruction(PirType::voyd(),
+                              {{PirType::any(), NativeType::context}},
+                              {{res, push}}) {}
+    PushContext* push() { return PushContext::Cast(arg<1>().val()); }
+};
+
 class VLI(Phi, Effect::None, EnvAccess::None) {
     std::vector<BB*> input;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -129,8 +129,8 @@ class Instruction : public Value {
         : Value(t, tag), srcIdx(srcIdx) {}
 
     virtual bool hasEffect() const = 0;
+    virtual bool hasEffectIgnoreVisibility() const = 0;
     virtual bool mightChangeVisibility() const = 0;
-    virtual bool hasObservableEffect() const = 0;
     virtual bool mayUseReflection() const = 0;
     virtual bool mayForcePromises() const = 0;
     virtual bool readsEnv() const = 0;
@@ -190,7 +190,7 @@ class Instruction : public Value {
         // TODO: for escape analysis we use leaksEnv || hasEffect as a very
         // crude approximation whether this instruction leaks arguments. We
         // should do better.
-        return leaksEnv() || hasEffect();
+        return leaksEnv() || mayForcePromises();
     }
 
     typedef std::function<bool(Value*)> ArgumentValuePredicateIterator;
@@ -284,8 +284,8 @@ class InstructionImplementation : public Instruction {
     bool mightChangeVisibility() const override {
         return EFFECT >= Effect::Visibility;
     }
-    bool hasObservableEffect() const override {
-        return EFFECT > Effect::Order && hasEffect();
+    bool hasEffectIgnoreVisibility() const override {
+        return EFFECT > Effect::Visibility && hasEffect();
     }
     bool mayForcePromises() const override final {
         return EFFECT >= Effect::Force;

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -62,6 +62,8 @@
     V(CallBuiltin)                                                             \
     V(CallSafeBuiltin)                                                         \
     V(MkEnv)                                                                   \
+    V(PushContext)                                                             \
+    V(PopContext)                                                              \
     V(LdFunctionEnv)                                                           \
     V(LAnd)                                                                    \
     V(LOr)                                                                     \

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -75,6 +75,7 @@ enum class NativeType : uint8_t {
     test,
     checkpoint,
     frameState,
+    context,
 
     FIRST = test,
     LAST = frameState,
@@ -310,6 +311,9 @@ struct PirType {
 
 inline std::ostream& operator<<(std::ostream& out, NativeType t) {
     switch (t) {
+    case NativeType::context:
+        out << "ct";
+        break;
     case NativeType::test:
         out << "t";
         break;

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -41,6 +41,10 @@ class Value {
     }
     virtual bool validIn(Code* code) const { return true; }
     virtual SEXP asRValue() const { assert(false && "Not a singleton"); }
+
+    bool producesRirResult() const {
+        return type != PirType::voyd() && type != NativeType::context;
+    }
 };
 
 }

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -108,8 +108,9 @@ BB* BBTransform::split(size_t next_id, BB* src, BB::Instrs::iterator it,
     return split;
 }
 
-Value* BBTransform::forInline(BB* inlinee, BB* splice) {
+std::pair<Value*, BB*> BBTransform::forInline(BB* inlinee, BB* splice) {
     Value* found = nullptr;
+    Return* ret;
     Visitor::run(inlinee, [&](BB* bb) {
         if (bb->next0 != nullptr)
             return;
@@ -118,7 +119,7 @@ Value* BBTransform::forInline(BB* inlinee, BB* splice) {
         if (Deopt::Cast(bb->last()))
             return;
 
-        Return* ret = Return::Cast(bb->last());
+        ret = Return::Cast(bb->last());
         assert(ret);
 
         // This transformation assumes that we have just one reachable return.
@@ -130,7 +131,7 @@ Value* BBTransform::forInline(BB* inlinee, BB* splice) {
         bb->remove(bb->end() - 1);
     });
     assert(found);
-    return found;
+    return {found, ret->bb()};
 }
 
 BB* BBTransform::lowerExpect(Code* code, BB* src, BB::Instrs::iterator position,

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -15,7 +15,7 @@ class BBTransform {
     static BB* splitEdge(size_t next_id, BB* from, BB* to, Code* target);
     static BB* split(size_t next_id, BB* src, BB::Instrs::iterator,
                      Code* target);
-    static Value* forInline(BB* inlinee, BB* cont);
+    static std::pair<Value*, BB*> forInline(BB* inlinee, BB* cont);
     static BB* lowerExpect(Code* closure, BB* src,
                            BB::Instrs::iterator position, Value* condition,
                            bool expected, BB* deoptBlock,

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -435,6 +435,7 @@ class SSAAllocator {
             --usedIdx;
         }
         assert(false && "Value wasn't found on the stack.");
+        return -1;
     }
 
     size_t stackPhiOffset(Instruction* executed, Phi* phi) const {
@@ -448,6 +449,7 @@ class SSAAllocator {
                 ++offset;
         }
         assert(false && "Phi wasn't found on the stack.");
+        return -1;
     }
 
     // Check if v is needed after argument argNumber of instruction executed

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -282,7 +282,7 @@ class SSAAllocator {
                     size_t argNum = 0;
                     i->eachArg([&](Value* a) {
                         auto ia = Instruction::Cast(a);
-                        if (!ia) {
+                        if (!ia || !ia->producesRirResult()) {
                             argNum++;
                             return;
                         }
@@ -345,7 +345,7 @@ class SSAAllocator {
                 // Remember this instruction if it writes to a slot
                 if (allocation.count(i)) {
                     if (allocation.at(i) == stackSlot) {
-                        if (i->type != PirType::voyd() && !sa.dead(i)) {
+                        if (i->producesRirResult() && !sa.dead(i)) {
                             stack.push_back(i);
                         }
                     } else {
@@ -533,6 +533,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
     // - how to pick lastInstr at the beginning of a merge block?
 
     LastEnv lastEnv(cls, code, log);
+    std::unordered_map<Value*, BC::Label> pushContexts;
 
     LoweringVisitor::run(code->entry, [&](BB* bb) {
         if (isJumpThrough(bb))
@@ -556,7 +557,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
         for (auto it = bb->begin(); it != bb->end(); ++it) {
             auto instr = *it;
 
-            bool hasResult = instr->type != PirType::voyd();
+            bool hasResult = instr->producesRirResult();
 
             // Prepare stack and araguments
             {
@@ -737,7 +738,8 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                     size_t argNumber = 0;
                     instr->eachArg([&](Value* what) {
                         if (what == Env::elided() ||
-                            what->tag == Tag::Tombstone) {
+                            what->tag == Tag::Tombstone ||
+                            what->type == NativeType::context) {
                             argNumber++;
                             return;
                         }
@@ -1028,6 +1030,22 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 auto blt = CallSafeBuiltin::Cast(instr);
                 cs << BC::callBuiltin(blt->nargs(), Pool::get(blt->srcIdx),
                                       blt->blt);
+                break;
+            }
+
+            case Tag::PushContext: {
+                if (!pushContexts.count(instr))
+                    pushContexts[instr] = cs.mkLabel();
+                cs << BC::pushContext(pushContexts.at(instr));
+                break;
+            }
+
+            case Tag::PopContext: {
+                auto push = PopContext::Cast(instr)->push();
+                if (!pushContexts.count(push))
+                    pushContexts[push] = cs.mkLabel();
+                cs << pushContexts.at(push);
+                cs << BC::popContext();
                 break;
             }
 

--- a/rir/src/compiler/translations/pir_2_rir/stack_use.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/stack_use.cpp
@@ -142,7 +142,8 @@ AbstractResult StackUseAnalysis::apply(StackUseAnalysisState& state,
             if (!v->isInstruction())
                 return;
             // For all else, check if this is the last use of the value
-            if (!liveness.live(i, v) && erasedArgs.count(v) == 0) {
+            if (v->producesRirResult() && !liveness.live(i, v) &&
+                erasedArgs.count(v) == 0) {
                 state.stack.eraseValue(v);
                 erasedArgs.insert(v);
             }
@@ -150,7 +151,7 @@ AbstractResult StackUseAnalysis::apply(StackUseAnalysisState& state,
     }
 
     // Add the value produced by this instruction if it's not dead
-    if (i->type != PirType::voyd()) {
+    if (i->producesRirResult()) {
         if (isDead(i))
             state.isDead = true;
         else

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -789,6 +789,8 @@ SIMPLE_INSTRUCTIONS(V, _)
     case Opcode::isobj_:
     case Opcode::check_missing_:
     case Opcode::static_call_:
+    case Opcode::pop_context_:
+    case Opcode::push_context_:
         log.unsupportedBC("Unsupported BC (are you recompiling?)", bc);
         assert(false && "Recompiling PIR not supported for now.");
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -1046,8 +1046,14 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
             }
 
             if (!inPromise() && !insert.getCurrentBB()->isEmpty() &&
-                insert.getCurrentBB()->last()->hasEffect())
+                insert.getCurrentBB()->last()->hasEffectIgnoreVisibility()) {
+
+                assert(!Visible::Cast(insert.getCurrentBB()->last()));
+                assert(!Invisible::Cast(insert.getCurrentBB()->last()));
+                assert(!LdConst::Cast(insert.getCurrentBB()->last()));
+
                 addCheckpoint(srcCode, nextPos, cur.stack, insert);
+            }
         }
     }
     assert(cur.stack.empty());

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -229,5 +229,8 @@ void Rir2PirCompiler::optimizeModule() {
     logger.flush();
 }
 
+const size_t Rir2PirCompiler::MAX_INPUT_SIZE =
+    getenv("PIR_MAX_INPUT_SIZE") ? atoi(getenv("PIR_MAX_INPUT_SIZE")) : 2500;
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -11,7 +11,7 @@ namespace pir {
 
 class Rir2PirCompiler : public RirCompiler {
   public:
-    static constexpr size_t MAX_INPUT_SIZE = 1000;
+    static constexpr size_t MAX_INPUT_SIZE = 3000;
 
     static constexpr Assumptions::Flags minimalAssumptions =
         Assumptions::Flags(Assumption::CorrectOrderOfArguments) |

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -11,8 +11,7 @@ namespace pir {
 
 class Rir2PirCompiler : public RirCompiler {
   public:
-    static constexpr size_t MAX_INPUT_SIZE = 2500;
-
+    static const size_t MAX_INPUT_SIZE;
     static constexpr Assumptions::Flags minimalAssumptions =
         Assumptions::Flags(Assumption::CorrectOrderOfArguments) |
         Assumption::NotTooManyArguments;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -11,7 +11,7 @@ namespace pir {
 
 class Rir2PirCompiler : public RirCompiler {
   public:
-    static constexpr size_t MAX_INPUT_SIZE = 3000;
+    static constexpr size_t MAX_INPUT_SIZE = 2500;
 
     static constexpr Assumptions::Flags minimalAssumptions =
         Assumptions::Flags(Assumption::CorrectOrderOfArguments) |

--- a/rir/src/compiler/util/phi_placement.cpp
+++ b/rir/src/compiler/util/phi_placement.cpp
@@ -1,0 +1,60 @@
+#include "phi_placement.h"
+#include "../pir/pir_impl.h"
+#include "../util/cfg.h"
+
+namespace rir {
+namespace pir {
+
+BB* PhiPlacement::find(const CFG& cfg, BB* searchBlock,
+                       const std::vector<BB*>& inputs) {
+    auto hasAllInputs = [&](BB* candidate) {
+        for (auto& input : inputs) {
+            // we cannot move the phi above its src
+            if (input == candidate)
+                return false;
+            if (!cfg.isPredecessor(input, candidate))
+                return false;
+        }
+        return true;
+    };
+    assert(hasAllInputs(searchBlock));
+
+    // First move up the phi until at least one input comes from a different
+    // block.
+    while (true) {
+        auto& preds = cfg.immediatePredecessors(searchBlock);
+        assert(!preds.empty());
+
+        for (auto pre : preds)
+            if (!hasAllInputs(pre))
+                goto checkCandidate;
+
+        searchBlock = *preds.begin();
+        assert(hasAllInputs(searchBlock));
+    }
+checkCandidate:
+
+    // Verify that we do not create an ambiguous phi. The problematic case we
+    // are looking for here is:
+    //
+    //    a1     {}
+    //     \    /
+    //       a2
+    //       |
+    //      phi(a1, a2)
+    //
+    // This can happen if the optimizer knows that a2 comes from the {} block,
+    // but at the same time the instruction already got delayed into the merge
+    // block.
+    for (auto& input : inputs)
+        if (cfg.isImmediatePredecessor(input, searchBlock))
+            for (auto& input2 : inputs)
+                if (input != input2)
+                    if (cfg.isPredecessor(input2, input))
+                        return nullptr;
+
+    return searchBlock;
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/util/phi_placement.h
+++ b/rir/src/compiler/util/phi_placement.h
@@ -1,0 +1,19 @@
+#ifndef PIR_PHI_PLACEMENT
+#define PIR_PHI_PLACEMENT
+
+#include "../pir/pir.h"
+#include "cfg.h"
+
+namespace rir {
+namespace pir {
+
+class PhiPlacement {
+  public:
+    static BB* find(const CFG& cfg, BB* searchBlock,
+                    const std::vector<BB*>& inputs);
+};
+
+} // namespace pir
+} // namespace rir
+
+#endif

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -3,6 +3,7 @@
 #include "R/Funtab.h"
 #include "R/Symbols.h"
 
+#include <iostream>
 #include <string>
 
 namespace rir {
@@ -285,6 +286,12 @@ bool SafeBuiltinsList::nonObject(SEXP builtin) {
 }
 
 #define UNSAFE_BUILTINS_FOR_INLINE(V)                                          \
+    V(exists)                                                                  \
+    V(parent.env)                                                              \
+    V(sys.nframe)                                                              \
+    V(lockBinding)                                                             \
+    V(lockEnvironment)                                                         \
+    V(unlockBinding)                                                           \
     V(as.environment)                                                          \
     V(on.exit)                                                                 \
     V(environment)                                                             \

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -3,7 +3,6 @@
 #include "R/Funtab.h"
 #include "R/Symbols.h"
 
-#include <iostream>
 #include <string>
 
 namespace rir {

--- a/rir/src/interpreter/builtins.cpp
+++ b/rir/src/interpreter/builtins.cpp
@@ -47,7 +47,7 @@ SEXP tryFastSpecialCall(const CallContext& call, InterpreterInstance* ctx) {
 SEXP tryFastBuiltinCall(const CallContext& call, InterpreterInstance* ctx) {
     SLOWASSERT(call.hasStackArgs() && !call.hasNames());
 
-    static constexpr size_t MAXARGS = 32;
+    static constexpr size_t MAXARGS = 16;
     std::array<SEXP, MAXARGS> args;
     auto nargs = call.suppliedArgs;
 

--- a/rir/src/interpreter/instance.h
+++ b/rir/src/interpreter/instance.h
@@ -172,14 +172,19 @@ class Locals final {
   private:
     R_bcstack_t* base;
     unsigned localsCount;
+    bool existingLocals;
 
   public:
-    explicit Locals(R_bcstack_t* base, unsigned count)
-        : base(base), localsCount(count) {
-        R_BCNodeStackTop += localsCount;
+    explicit Locals(R_bcstack_t* base, unsigned count, bool existingLocals)
+        : base(base), localsCount(count), existingLocals(existingLocals) {
+        if (!existingLocals)
+            R_BCNodeStackTop += localsCount;
     }
 
-    ~Locals() { R_BCNodeStackTop -= localsCount; }
+    ~Locals() {
+        if (!existingLocals)
+            R_BCNodeStackTop -= localsCount;
+    }
 
     SEXP load(unsigned offset) {
         SLOWASSERT(offset < localsCount &&

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1782,7 +1782,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP* env,
         INSTRUCTION(push_) {
             res = readConst(ctx, readImmediate());
             advanceImmediate();
-            R_Visible = TRUE;
             ostack_push(ctx, res);
             NEXT();
         }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -352,7 +352,11 @@ static void inlineContextTrampoline(Code* c, SEXP ast, SEXP sysparent, SEXP op,
     CallContext call(nullptr, op, -1, ast, 0, nullptr, nullptr, sysparent,
                      Assumptions(), ctx);
     RCNTXT cntxt;
-    initClosureContext(ast, &cntxt, R_NilValue, sysparent,
+    // The first env should be the callee env, but that will be done by the
+    // callee. We store sysparent there, because our optimizer may actually
+    // delay instructions into the inlinee and might assume that we still have
+    // to outer env.
+    initClosureContext(ast, &cntxt, sysparent, sysparent,
                        symbol::delayedArglist, op);
 
     if ((SETJMP(cntxt.cjmpbuf))) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -11,6 +11,7 @@
 
 #include <assert.h>
 #include <deque>
+#include <set>
 
 #define NOT_IMPLEMENTED assert(false)
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1290,7 +1290,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP* env,
 
         INSTRUCTION(pop_context_) {
             return ostack_pop(ctx);
-            NEXT();
         }
 
         INSTRUCTION(mk_env_) {

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -100,6 +100,7 @@ BC_NOARGS(V, _)
     case Opcode::br_:
     case Opcode::brtrue_:
     case Opcode::beginloop_:
+    case Opcode::push_context_:
     case Opcode::brobj_:
     case Opcode::brfalse_:
         cs.patchpoint(immediate.offset);
@@ -318,6 +319,7 @@ BC_NOARGS(V, _)
         out << std::hex << immediate.fun << std::dec;
         break;
     case Opcode::beginloop_:
+    case Opcode::push_context_:
     case Opcode::brtrue_:
     case Opcode::brobj_:
     case Opcode::brfalse_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -181,6 +181,11 @@ BC BC::brobj(Jmp j) {
     i.offset = j;
     return BC(Opcode::brobj_, i);
 }
+BC BC::pushContext(Jmp j) {
+    ImmediateArguments i;
+    i.offset = j;
+    return BC(Opcode::push_context_, i);
+}
 BC BC::beginloop(Jmp j) {
     ImmediateArguments i;
     i.offset = j;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -345,6 +345,7 @@ BC_NOARGS(V, _)
     inline static BC stvarSuper(SEXP sym);
     inline static BC missing(SEXP sym);
     inline static BC alloc(int type);
+    inline static BC pushContext(Jmp);
     inline static BC beginloop(Jmp);
     inline static BC brtrue(Jmp);
     inline static BC brfalse(Jmp);
@@ -627,6 +628,7 @@ BC_NOARGS(V, _)
         case Opcode::brobj_:
         case Opcode::brfalse_:
         case Opcode::beginloop_:
+        case Opcode::push_context_:
             memcpy(&immediate.offset, pc, sizeof(Jmp));
             break;
         case Opcode::pick_:

--- a/rir/src/ir/BC_noarg_list.h
+++ b/rir/src/ir/BC_noarg_list.h
@@ -7,6 +7,7 @@
 
 #define BC_NOARGS(V, NESTED)                                                   \
     SIMPLE_INSTRUCTIONS(V_SIMPLE_INSTRUCTION_IN_BC_NOARGS, V)                  \
+    V(NESTED, popContext, pop_context)                                         \
     V(NESTED, nop, nop)                                                        \
     V(NESTED, parentEnv, parent_env)                                           \
     V(NESTED, getEnv, get_env)                                                 \

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -170,6 +170,8 @@ static Sources hasSources(Opcode bc) {
     case Opcode::record_call_:
     case Opcode::record_binop_:
     case Opcode::deopt_:
+    case Opcode::pop_context_:
+    case Opcode::push_context_:
         return Sources::NotNeeded;
 
     case Opcode::ldloc_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -869,7 +869,7 @@ void compileGetvar(CodeStream& cs, SEXP name) {
 // Constant
 void compileConst(CodeStream& cs, SEXP constant) {
     SET_NAMED(constant, 2);
-    cs << BC::push(constant);
+    cs << BC::push(constant) << BC::visible();
 }
 
 void compileExpr(CompilerContext& ctx, SEXP exp) {

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -16,6 +16,9 @@ DEF_INSTR(invalid_, 0, 0, 0, 0)
  */
 DEF_INSTR(nop_, 0, 0, 0, 1)
 
+DEF_INSTR(push_context_, 1, 2, 0, 0)
+DEF_INSTR(pop_context_, 0, 1, 0, 0)
+
 /**
  * make_env_:: create a new environment with the parent and all locals taken
  * from stack and the argument names as immediates.
@@ -440,7 +443,7 @@ DEF_INSTR(make_unique_, 0, 1, 1, 1)
 /**
  * beginloop_:: begins loop context, break and continue target immediate (this is the target for break and next long jumps)
  */
-DEF_INSTR(beginloop_, 1, 0, 0, 1)
+DEF_INSTR(beginloop_, 1, 0, 0, 0)
 
 /**
  * endloop_:: end marker for a loop with context

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -46,6 +46,7 @@ void Configurations::defaultOptimizations() {
         optimizations.push_back(new pir::OptimizeVisibility());
         optimizations.push_back(new pir::ForceDominance());
         optimizations.push_back(new pir::ScopeResolution());
+        optimizations.push_back(new pir::OptimizeContexts());
         optimizations.push_back(new pir::EagerCalls());
         optimizations.push_back(new pir::Constantfold());
         optimizations.push_back(new pir::Cleanup());

--- a/rir/tests/pir_regression_regaloc.r
+++ b/rir/tests/pir_regression_regaloc.r
@@ -1,0 +1,17 @@
+f <- function() {
+  if ("")
+    x <- 1
+  else
+    x <- 2
+
+  if ("")
+    y <- 3
+  else
+    y <- 5
+
+  while("") {
+    x && y
+    x <- 10
+  }
+}
+pir.compile(rir.compile(f))


### PR DESCRIPTION
…mpiler

Due to large methods being excluded from compilation a number of
bugs managed to sneak in. They got revealed when I tried to
increase the limits. This commit fixes:

* the RIR push_ bytecode changed the visibility flag. However pir
LdConst of course is effectless. This can lead to missed invisible
settings. This is solved by making the visible explicit in rir already.
I fixed this, because it spams the test logs with, with NULL's from
dangling else branches in `cleanEx`, which lost their invisible.
* The above fix kills some optimizations. Thus i improved the visibility
analysis a bit. But also, We don't really care about
visible that much. We just want to get it right most of the times. Thus
this commit ignores visibility in some strategic cases. For example
promises which are pure except for visibility change, we still inline
(the subsequent call will change visibility anyway). Checkpoints also
ignore visibility. Worst case we deopt with the wrong visibility
setting.
* The scope analysis would sometimes generate pretty terrible phis, that
caused the lowering in the allocator to just diverge. Excluded those
kind of phis in the verifier and fixed the scope analysis to not produce
them.
* cleanup would happily merge the block with a phi input and the block
with the actual phi. this leads to input+phi ending up in the same
block.
* banned a couple more reflective functions from being inlined