### PR TITLE
fix vector builtin impl

### DIFF
--- a/rir/src/interpreter/builtins.cpp
+++ b/rir/src/interpreter/builtins.cpp
@@ -124,6 +124,8 @@ SEXP tryFastBuiltinCall(const CallContext& call, InterpreterInstance* ctx) {
             return nullptr;
         if (XLENGTH(args[0]) != 1)
             return nullptr;
+        if (Rf_length(args[1]) != 1)
+            return nullptr;
         auto length = asVecSize(args[1]);
         if (length < 0)
             return nullptr;


### PR DESCRIPTION
Just a small bugfix:
`f <- pir.compile(rir.compile(function(x) vector("character", x)))`
would work even with `f(1:10)` but gnur gives  error in that case.