### PR TITLE
Fix edge-split check in verifier

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -69,9 +69,9 @@ class TheVerifier {
             make it a conscious decision if we want to violate it.
             This basically rules out graphs of the following form:
 
-                A       B
+               A      B
                 \   /   \
-                    C       D
+                  C      D
 
             or
                 _
@@ -88,10 +88,17 @@ class TheVerifier {
         */
         if (slow && cfg(bb->owner).isMergeBlock(bb)) {
             for (auto in : cfg(bb->owner).immediatePredecessors(bb)) {
-                if (in->falseBranch()) {
-                    std::cerr << "BB " << in->id << " merges into " << bb->id
-                              << " and branches into " << in->falseBranch()->id
-                              << " at the same time.\n";
+                if (in->isBranch()) {
+                    unsigned other = (in->trueBranch()->id == bb->id)
+                                         ? in->falseBranch()->id
+                                         : in->trueBranch()->id;
+                    std::cerr << "BB" << bb->id << " is a merge node, but "
+                              << "predecessor BB" << in->id << " has two "
+                              << "successors (BB" << in->trueBranch()->id
+                              << " and BB" << in->falseBranch()->id << "):\n"
+                              << " n      " << in->id << "\n"
+                              << "  \\   /   \\\n"
+                              << "    " << bb->id << "      " << other << "\n";
                     ok = false;
                 }
             }

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -64,43 +64,43 @@ class TheVerifier {
             }
             verify(i, bb);
         }
+        /* This check verifies that our graph is in edge-split format.
+            Currently we do not rely on this property, however we should
+            make it a conscious decision if we want to violate it.
+            This basically rules out graphs of the following form:
+
+                A       B
+                \   /   \
+                    C       D
+
+            or
+                _
+            | / \
+            A __/
+            |
+
+            The nice property about edge-split graphs is, that merge-points
+            are always dominated by *both* inputs, therefore local code
+            motion can push instructions to both input blocks.
+
+            In the above example, we can't push an instruction from C to A
+            and B, without worrying about D.
+        */
+        if (slow && cfg(bb->owner).isMergeBlock(bb)) {
+            for (auto in : cfg(bb->owner).immediatePredecessors(bb)) {
+                if (in->falseBranch()) {
+                    std::cerr << "BB " << in->id << " merges into " << bb->id
+                              << " and branches into " << in->falseBranch()->id
+                              << " at the same time.\n";
+                    ok = false;
+                }
+            }
+        }
+
         if (bb->isEmpty()) {
             if (bb->isExit()) {
                 std::cerr << "bb" << bb->id << " has no successor\n";
                 ok = false;
-            }
-            /* This check verifies that our graph is in edge-split format.
-               Currently we do not rely on this property, however we should
-               make it a conscious decision if we want to violate it.
-               This basically rules out graphs of the following form:
-
-                 A       B
-                   \   /   \
-                     C       D
-
-               or
-                   _
-                | / \
-                A __/
-                |
-
-               The nice property about edge-split graphs is, that merge-points
-               are always dominated by *both* inputs, therefore local code
-               motion can push instructions to both input blocks.
-
-               In the above example, we can't push an instruction from C to A
-               and B, without worrying about D.
-            */
-            if (slow && cfg(bb->owner).isMergeBlock(bb)) {
-                for (auto in : cfg(bb->owner).immediatePredecessors(bb)) {
-                    if (in->falseBranch()) {
-                        std::cerr << "BB " << in->id << " merges into "
-                                  << bb->id << " and branches into "
-                                  << in->falseBranch()->id
-                                  << " at the same time.\n";
-                        ok = false;
-                    }
-                }
             }
         } else {
             Instruction* last = bb->last();

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -90,6 +90,8 @@ class BB {
 
     bool isExit() const { return !next0 && !next1; }
 
+    bool isBranch() const { return next0 && next1; }
+
     void setBranch(BB* trueBranch, BB* falseBranch) {
         assert(!next0 && !next1);
         this->next0 = trueBranch;


### PR DESCRIPTION
The first commit just moves the check outside the `if`, because we want to check non-empty BBs as well.

The second commit hopefully makes the error message more readable. I found the original message unhelpful, and it got worse after the bugfix because it could say something like "BB 3 merges into 4 and branches into 4 at the same time." Now this is what it says:

```
BB5 is a merge node, but predecessor BB3 has two successors (BB4 and BB5):
 n      3
  \   /   \
    5      4
```