### PR TITLE
improve visibility analysis

### DIFF
--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -109,6 +109,8 @@ class StaticAnalysis {
     }
 
     const AbstractState& result() const {
+        if (!done)
+            const_cast<StaticAnalysis*>(this)->operator()();
         assert(done);
         return exitpoint;
     }

--- a/rir/src/compiler/analysis/visibility.cpp
+++ b/rir/src/compiler/analysis/visibility.cpp
@@ -4,19 +4,18 @@
 namespace rir {
 namespace pir {
 
-AbstractResult VisibilityAnalysis::apply(CurrentVisibility& vis,
+AbstractResult VisibilityAnalysis::apply(LastVisibilityUpdate& vis,
                                          Instruction* i) const {
-    // Default: visible
-    if (!code->entry->isEmpty() && i == *code->entry->begin())
-        vis.state = CurrentVisibility::Visible;
-
+    AbstractResult res;
+    auto isVisibilityChanging = [&]() {
+        if (vis.last != i) {
+            vis.last = i;
+            vis.observable.clear();
+            res.update();
+        }
+    };
     switch (i->tag) {
     case Tag::Invisible:
-        if (vis.state != CurrentVisibility::Invisible) {
-            vis.state = CurrentVisibility::Invisible;
-            return AbstractResult::Updated;
-        }
-        break;
     case Tag::Visible:
     case Tag::LdVar:
     case Tag::LdVarSuper:
@@ -24,10 +23,7 @@ AbstractResult VisibilityAnalysis::apply(CurrentVisibility& vis,
     case Tag::Extract2_1D:
     case Tag::Extract1_2D:
     case Tag::Extract2_2D:
-        if (vis.state != CurrentVisibility::Visible) {
-            vis.state = CurrentVisibility::Visible;
-            return AbstractResult::Updated;
-        }
+        isVisibilityChanging();
         break;
     case Tag::CallBuiltin:
     case Tag::CallSafeBuiltin:
@@ -39,26 +35,16 @@ AbstractResult VisibilityAnalysis::apply(CurrentVisibility& vis,
         }
 
         if (builtinUpdatesVisibility(builtinId)) {
-            bool visible = builtinVisibility(builtinId);
-            if (visible && vis.state != CurrentVisibility::Visible) {
-                vis.state = CurrentVisibility::Visible;
-                return AbstractResult::Updated;
-            }
-            if (!visible && vis.state != CurrentVisibility::Invisible) {
-                vis.state = CurrentVisibility::Invisible;
-                return AbstractResult::Updated;
-            }
+            isVisibilityChanging();
         }
         break;
     default:
-        if (i->mightChangeVisibility()) {
-            if (vis.state != CurrentVisibility::Unknown) {
-                vis.state = CurrentVisibility::Unknown;
-                return AbstractResult::Updated;
-            }
+        if (i->exits() && vis.last) {
+            vis.observable.insert(vis.last);
+            res.update();
         }
     }
-    return AbstractResult::None;
+    return res;
 };
 
 } // namespace rir

--- a/rir/src/compiler/analysis/visibility.h
+++ b/rir/src/compiler/analysis/visibility.h
@@ -7,49 +7,56 @@
 namespace rir {
 namespace pir {
 
-class CurrentVisibility {
+class LastVisibilityUpdate {
   public:
-    enum State { Visible, Invisible, Unknown };
+    std::unordered_set<Instruction*> observable;
+    Instruction* last;
 
-    State state = Unknown;
-
-    CurrentVisibility() {}
-
-    AbstractResult merge(const CurrentVisibility& other) {
-        if (state != Unknown && state != other.state) {
-            state = Unknown;
-            return AbstractResult::Updated;
+    AbstractResult merge(const LastVisibilityUpdate& other) {
+        AbstractResult res;
+        for (auto& v : other.observable) {
+            if (!observable.count(v)) {
+                observable.insert(v);
+                res.update();
+            }
         }
-        return AbstractResult::None;
+        if (last != other.last) {
+            if (last && !observable.count(last)) {
+                observable.insert(last);
+                res.update();
+            }
+            if (other.last && !observable.count(other.last)) {
+                observable.insert(other.last);
+                res.update();
+            }
+        }
+        return res;
     }
 
     void print(std::ostream& out, bool tty) const {
-        switch (state) {
-        case Unknown:
-            out << "?";
-            break;
-        case Visible:
-            out << "visible";
-            break;
-        case Invisible:
-            out << "invisible";
-            break;
+        if (last) {
+            out << "Last Update : ";
+            last->printRef(std::cout);
+            out << "\n";
+        }
+        out << "Observable: ";
+        for (auto& o : observable) {
+            o->printRef(out);
+            out << " ";
         }
         out << "\n";
     };
 };
 
-class VisibilityAnalysis : public StaticAnalysis<CurrentVisibility> {
+class VisibilityAnalysis : public StaticAnalysis<LastVisibilityUpdate> {
   public:
     VisibilityAnalysis(ClosureVersion* cls, LogStream& log)
         : StaticAnalysis("VisibilityAnalysis", cls, cls, log) {}
 
-    AbstractResult apply(CurrentVisibility& vis,
+    AbstractResult apply(LastVisibilityUpdate& vis,
                          Instruction* i) const override final;
 
-    CurrentVisibility::State at(Instruction* i) {
-        return StaticAnalysis::at<PositioningStyle::BeforeInstruction>(i).state;
-    }
+    bool observed(Instruction* i) { return result().observable.count(i); }
 };
 
 } // namespace pir

--- a/rir/src/compiler/opt/visibility.cpp
+++ b/rir/src/compiler/opt/visibility.cpp
@@ -24,11 +24,11 @@ void OptimizeVisibility::apply(RirCompiler&, ClosureVersion* function,
             auto instr = *ip;
 
             if (auto vis = Visible::Cast(instr)) {
-                if (visible.at(vis) == CurrentVisibility::Visible) {
+                if (!visible.observed(vis)) {
                     next = bb->remove(ip);
                 }
             } else if (auto vis = Invisible::Cast(instr)) {
-                if (visible.at(vis) == CurrentVisibility::Invisible) {
+                if (!visible.observed(vis)) {
                     next = bb->remove(ip);
                 }
             }


### PR DESCRIPTION
Visibility analysis keeps track of observed visibility changing
instructions. A visibility change is observed, only if its effect
lasts until a function exit point.

If we merge two states, then we conservatively assume that either
branches last visibility changing instruction could be observed.
As soon as we have a visibility changing instruction, all previous
visibility changes are not observed anymore.