### PR TITLE
Fix some issues with scope resolution

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -245,12 +245,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
             assert((CallBuiltin::Cast(i) || CallSafeBuiltin::Cast(i) ||
                     NamedCall::Cast(i)) &&
                    "New call instruction not handled?");
-            auto safe = false;
-            if (auto builtin = CallBuiltin::Cast(i)) {
-                if (SafeBuiltinsList::nonObject(builtin->blt))
-                    safe = true;
-            }
-            if (!CallSafeBuiltin::Cast(i) && !safe) {
+            if (!CallSafeBuiltin::Cast(i)) {
                 state.mayUseReflection = true;
                 effect.lostPrecision();
             } else {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -295,7 +295,7 @@ class InstructionImplementation : public Instruction {
         return EFFECT >= Effect::Force;
     }
     bool mayUseReflection() const override final {
-        return EFFECT > Effect::Reflection;
+        return hasEnv() && EFFECT >= Effect::Reflection;
     }
     bool mayAccessEnv() const override final { return mayAccessEnv_; }
     bool readsEnv() const override final { return hasEnv() && mayReadEnv_; }


### PR DESCRIPTION
* Although we can not run the safe version of a builtin we know that the safe builtins will not taint the environment
* Instructions should not have reflective effects if we dynamically know they not need an environment