### PR TITLE
refactor effect system

### DIFF
--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -12,7 +12,7 @@ struct AvailableCheckpointsApply {
     static AbstractResult apply(AbstractUnique<Checkpoint>& state,
                                 Instruction* i) {
         if (state.get()) {
-            if (i->hasEffectIgnoreVisibility()) {
+            if (i->isDeoptBarrier()) {
                 state.clear();
                 return AbstractResult::Updated;
             }

--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -35,10 +35,8 @@ bool Query::noEnvSpec(Code* c) {
 }
 
 bool Query::pure(Code* c) {
-    return Visitor::check(c->entry, [](Instruction* i) {
-        // Yes visibility is a global effect. We try to preserve it. But geting
-        // it wrong is not a strong correctness issue.
-        return !i->hasEffectIgnoreVisibility() && !i->changesEnv();
+    return Visitor::check(c->entry, [&](Instruction* i) {
+        return i->getObservableEffects().empty() && !i->changesEnv();
     });
 }
 

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -41,8 +41,10 @@ class TheScopeResolution {
                 // reflection
                 if (i->hasEnv() &&
                     (CallInstruction::CastCall(i) || Force::Cast(i)) &&
-                    after.noReflection())
+                    after.noReflection()) {
                     i->elideEnv();
+                    i->effects.reset(Effect::Reflection);
+                }
 
                 // Dead store to non-escaping environment can be removed
                 if (auto st = StVar::Cast(i)) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -159,16 +159,17 @@ class Instruction : public Value {
         return leaksEnv() || effects.includes(Effect::LeakArg);
     }
 
-    void maskEffectsOnNonObjects() {
+    void maskEffectsOnNonObjects(Effects mask = Effects(Effect::Error) |
+                                                Effect::Warn |
+                                                Effect::Visibility) {
         bool maybeObj = false;
         eachArg([&](Value* v) {
             if (v->type.maybeObj())
                 maybeObj = true;
         });
         if (!maybeObj) {
-            effects =
-                Effects(Effect::Error) | Effect::Warn | Effect::Visibility;
-        };
+            effects = effects & mask;
+        }
     }
 
     virtual bool readsEnv() const = 0;

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -52,7 +52,7 @@ closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
     pir::StreamLogger logger({pir::DebugOptions::DebugFlags() |
                                   // pir::DebugFlag::PrintIntoStdout |
                                   // pir::DebugFlag::PrintEarlyRir |
-                                  // pir::DebugFlag::PrintOptimizationPasses |
+                                  pir::DebugFlag::PrintOptimizationPasses |
                                   pir::DebugFlag::PrintFinalPir,
                               std::regex(".*"), std::regex(".*")});
     pir::Rir2PirCompiler cmp(m, logger);

--- a/rir/src/compiler/pir_tests.cpp
+++ b/rir/src/compiler/pir_tests.cpp
@@ -52,7 +52,7 @@ closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
     pir::StreamLogger logger({pir::DebugOptions::DebugFlags() |
                                   // pir::DebugFlag::PrintIntoStdout |
                                   // pir::DebugFlag::PrintEarlyRir |
-                                  pir::DebugFlag::PrintOptimizationPasses |
+                                  // pir::DebugFlag::PrintOptimizationPasses |
                                   pir::DebugFlag::PrintFinalPir,
                               std::regex(".*"), std::regex(".*")});
     pir::Rir2PirCompiler cmp(m, logger);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -1050,7 +1050,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
             }
 
             if (!inPromise() && !insert.getCurrentBB()->isEmpty() &&
-                insert.getCurrentBB()->last()->hasEffectIgnoreVisibility()) {
+                insert.getCurrentBB()->last()->isDeoptBarrier()) {
                 addCheckpoint(srcCode, nextPos, cur.stack, insert);
             }
         }

--- a/rir/src/utils/EnumSet.h
+++ b/rir/src/utils/EnumSet.h
@@ -28,7 +28,17 @@ class EnumSet {
     }
 
   public:
-    EnumSet() {}
+    typedef Store StoreType;
+    typedef Element ElementType;
+
+    static constexpr EnumSet None() { return EnumSet(); }
+
+    static constexpr EnumSet Any() {
+        return ((1 << ((StoreType)(Element::LAST) + 1)) - 1) &
+               ~((1 << (StoreType)Element::FIRST) - 1);
+    }
+
+    constexpr EnumSet() {}
     EnumSet(const EnumSet& other) noexcept = default;
 
     constexpr EnumSet(Element e) : set_(1UL << static_cast<size_t>(e)) {
@@ -49,6 +59,8 @@ class EnumSet {
         set_ |= 1UL << static_cast<size_t>(e);
     }
 
+    RIR_INLINE void reset() { set_ = 0; }
+
     RIR_INLINE void reset(const Element& e) {
         assert(boundscheck(e));
         set_ &= ~(1UL << static_cast<size_t>(e));
@@ -63,7 +75,7 @@ class EnumSet {
     }
 
     RIR_INLINE bool operator==(const Element& t) const {
-        return EnumSet(t) == set_;
+        return EnumSet(t).set_ == set_;
     }
 
     RIR_INLINE bool operator==(const EnumSet& s) const {
@@ -91,6 +103,8 @@ class EnumSet {
     }
 
     RIR_INLINE Store to_i() const { return set_; }
+
+    constexpr operator StoreType() const { return set_; }
 
     RIR_INLINE bool empty() const { return set_ == 0; }
 

--- a/rir/src/utils/EnumSet.h
+++ b/rir/src/utils/EnumSet.h
@@ -29,13 +29,12 @@ class EnumSet {
 
   public:
     typedef Store StoreType;
-    typedef Element ElementType;
 
     static constexpr EnumSet None() { return EnumSet(); }
 
     static constexpr EnumSet Any() {
-        return ((1 << ((StoreType)(Element::LAST) + 1)) - 1) &
-               ~((1 << (StoreType)Element::FIRST) - 1);
+        return ((1 << ((Store)(Element::LAST) + 1)) - 1) &
+               ~((1 << (Store)Element::FIRST) - 1);
     }
 
     constexpr EnumSet() {}
@@ -104,7 +103,7 @@ class EnumSet {
 
     RIR_INLINE Store to_i() const { return set_; }
 
-    constexpr operator StoreType() const { return set_; }
+    constexpr operator Store() const { return set_; }
 
     RIR_INLINE bool empty() const { return set_ == 0; }
 


### PR DESCRIPTION
This adds the following two changes:

1. convert effect lattice (where stronger effect includes all previous
effects) with a set of effects.
3. make effects per instruction instance. So we can keep fine grained
taps on effects of single instructions (depending on their context).

This also fixes some mislabeled instructions. For example binops are
certainly not pure. When they have object args, they can doe whatever
and otherwise they can still print warnings and errors.