### PR TITLE
Fix for #368

### DIFF
--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -68,19 +68,7 @@ void LogStream::pirOptimizationsFinished(ClosureVersion* closure) {
         std::regex_match(name.begin(), name.end(), options.functionFilter)) {
         preparePrint();
         section("PIR Version After Optimizations");
-        switch (options.style) {
-        case DebugStyle::Standard:
-            closure->print(out, tty());
-            break;
-        case DebugStyle::GraphViz:
-            closure->printGraph(out, tty());
-            break;
-        case DebugStyle::GraphVizBB:
-            closure->printBBGraph(out, tty());
-            break;
-        default:
-            assert(false);
-        }
+        closure->print(out, tty());
         out << "\n";
     }
 }

--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -58,7 +58,7 @@ void LogStream::compilationEarlyPir(ClosureVersion* closure) {
     if (options.includes(DebugFlag::PrintEarlyPir)) {
         preparePrint();
         section("Compiled to PIR Version");
-        closure->print(out, tty());
+        closure->print(options.style, out, tty());
     }
 }
 
@@ -68,7 +68,7 @@ void LogStream::pirOptimizationsFinished(ClosureVersion* closure) {
         std::regex_match(name.begin(), name.end(), options.functionFilter)) {
         preparePrint();
         section("PIR Version After Optimizations");
-        closure->print(out, tty());
+        closure->print(options.style, out, tty());
         out << "\n";
     }
 }
@@ -107,7 +107,7 @@ void LogStream::pirOptimizationsHeader(ClosureVersion* closure,
 void LogStream::pirOptimizations(ClosureVersion* closure,
                                  const PirTranslator* pass) {
     if (shouldLog(closure, pass, options)) {
-        closure->print(out, tty());
+        closure->print(options.style, out, tty());
     }
 }
 
@@ -144,7 +144,7 @@ void LogStream::finalPIR(ClosureVersion* code) {
     if (options.includes(DebugFlag::PrintFinalPir)) {
         preparePrint();
         section("Final PIR Version");
-        code->print(out, tty());
+        code->print(options.style, out, tty());
         out << "\n";
     }
 }

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -9,7 +9,23 @@
 namespace rir {
 namespace pir {
 
-void ClosureVersion::print(std::ostream& out, bool tty) const {
+void ClosureVersion::print(DebugStyle style, std::ostream& out, bool tty) const {
+    switch (style) {
+    case DebugStyle::Standard:
+        closure->print(out, tty);
+        break;
+    case DebugStyle::GraphViz:
+        closure->printGraph(out, tty);
+        break;
+    case DebugStyle::GraphVizBB:
+        closure->printBBGraph(out, tty);
+        break;
+    default:
+        assert(false);
+    }
+}
+    
+void ClosureVersion::printStandard(std::ostream& out, bool tty) const {
     out << *this << "\n";
     printCode(out, tty);
     for (auto p : promises_) {

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -16,13 +16,13 @@ void ClosureVersion::print(std::ostream& out, bool tty) const {
 void ClosureVersion::print(DebugStyle style, std::ostream& out, bool tty) const {
     switch (style) {
     case DebugStyle::Standard:
-        closure->print(out, tty);
+        printStandard(out, tty);
         break;
     case DebugStyle::GraphViz:
-        closure->printGraph(out, tty);
+        printGraph(out, tty);
         break;
     case DebugStyle::GraphVizBB:
-        closure->printBBGraph(out, tty);
+        printBBGraph(out, tty);
         break;
     default:
         assert(false);

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -8,6 +8,10 @@
 
 namespace rir {
 namespace pir {
+    
+void ClosureVersion::print(std::ostream& out, bool tty) const {
+    print(DebugStyle::Standard, out, tty);
+}
 
 void ClosureVersion::print(DebugStyle style, std::ostream& out, bool tty) const {
     switch (style) {

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -68,6 +68,7 @@ class ClosureVersion : public Code {
     const std::string& nameSuffix() const { return nameSuffix_; }
 
     void print(std::ostream& out, bool tty) const;
+    void printStandard(std::ostream& out, bool tty) const;
     void printGraph(std::ostream& out, bool tty) const;
     void printBBGraph(std::ostream& out, bool tty) const;
 

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -2,6 +2,7 @@
 #define COMPILER_CLOSURE_VERSION_H
 
 #include "../../runtime/Function.h"
+#include "../util/debugging.h"
 #include "code.h"
 #include "optimization_context.h"
 #include "pir.h"
@@ -67,7 +68,7 @@ class ClosureVersion : public Code {
     const std::string& name() const { return name_; }
     const std::string& nameSuffix() const { return nameSuffix_; }
 
-    void print(std::ostream& out, bool tty) const;
+    void print(DebugStyle style, std::ostream& out, bool tty) const;
     void printStandard(std::ostream& out, bool tty) const;
     void printGraph(std::ostream& out, bool tty) const;
     void printBBGraph(std::ostream& out, bool tty) const;

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -68,6 +68,7 @@ class ClosureVersion : public Code {
     const std::string& name() const { return name_; }
     const std::string& nameSuffix() const { return nameSuffix_; }
 
+    void print(std::ostream& out, bool tty) const;
     void print(DebugStyle style, std::ostream& out, bool tty) const;
     void printStandard(std::ostream& out, bool tty) const;
     void printGraph(std::ostream& out, bool tty) const;

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -2,7 +2,7 @@
 #define COMPILER_CLOSURE_VERSION_H
 
 #include "../../runtime/Function.h"
-#include "../util/debugging.h"
+#include "../debugging/debugging.h"
 #include "code.h"
 #include "optimization_context.h"
 #include "pir.h"


### PR DESCRIPTION
This makes all calls to `ClosureVersion::print` use the currently set debug style. It doesn't affect printing CSSA or AfterAllocater because those use `printCode`