### PR TITLE
don't rsync recommended packages

### DIFF
--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -42,7 +42,7 @@ function build_r {
     cd src/library/Recommended/
     tar xf ../../../../custom-r/cache_recommended.tar
     cd ../../..
-    tools/rsync-recommended || true
+    # tools/rsync-recommended || true
 
     if [ ! -f $R_DIR/Makefile ]; then
         echo "-> configure gnur"


### PR DESCRIPTION
it seems that the currently there is some build breakage in the
recommended packages. let's disable syncing for now, so we use
our known good version of the recommended packages from the cache.