### PR TITLE
Set default filters in DebugOptions constructor

### DIFF
--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -67,7 +67,8 @@ struct DebugOptions {
     }
 
     explicit DebugOptions(unsigned long long flags)
-        : flags(flags), style(DebugStyle::Standard) {}
+        : flags(flags), passFilter(".*"), functionFilter(".*"),
+          style(DebugStyle::Standard) {}
     DebugOptions(const DebugFlags& flags, const std::regex& filter,
                  const std::regex& functionFilter, DebugStyle style)
         : flags(flags), passFilter(filter), functionFilter(functionFilter),


### PR DESCRIPTION
The single-argument constructor for DebugOptions initializes the flags,
but not the pass filter or function filter. This means any matches
against the filters will always fail. This is very surprising and
difficult to diagnose, so the default filter should be ".*" and match
everything.

Currently, nothing uses the single-argument constructor, but it has been
used in the past, and without this commit it's a bug waiting to be
discovered...