### PR TITLE
Cleanup

### DIFF
--- a/rir/src/compiler/analysis/visibility.cpp
+++ b/rir/src/compiler/analysis/visibility.cpp
@@ -17,12 +17,6 @@ AbstractResult VisibilityAnalysis::apply(LastVisibilityUpdate& vis,
     switch (i->tag) {
     case Tag::Invisible:
     case Tag::Visible:
-    case Tag::LdVar:
-    case Tag::LdVarSuper:
-    case Tag::Extract1_1D:
-    case Tag::Extract2_1D:
-    case Tag::Extract1_2D:
-    case Tag::Extract2_2D:
         isVisibilityChanging();
         break;
     case Tag::CallBuiltin:

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -593,6 +593,7 @@ class FLIE(LdFun, 2, Effects::Any(), EnvAccess::Write) {
 class FLIE(LdVar, 1, Effect::Error, EnvAccess::Read) {
   public:
     SEXP varName;
+    bool fusedWithForce = false;
 
     LdVar(const char* name, Value* env)
         : FixedLenInstructionWithEnvSlot(PirType::any(), env),

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -875,16 +875,6 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 EMPTY(PirCopy);
 #undef EMPTY
 
-            case Tag::IsObject: {
-                cs << BC::isobj();
-                break;
-            }
-
-            case Tag::IsEnvStub: {
-                cs << BC::isstubenv();
-                break;
-            }
-
 #define SIMPLE(Name, Factory)                                                  \
     case Tag::Name: {                                                          \
         cs << BC::Factory();                                                   \
@@ -894,6 +884,8 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE(Visible, visible);
                 SIMPLE(Invisible, invisible);
                 SIMPLE(Identical, identicalNoforce);
+                SIMPLE(IsObject, isobj);
+                SIMPLE(IsEnvStub, isstubenv);
                 SIMPLE(LOr, lglOr);
                 SIMPLE(LAnd, lglAnd);
                 SIMPLE(Inc, inc);
@@ -1030,12 +1022,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
             case Tag::MkEnv: {
                 auto mkenv = MkEnv::Cast(instr);
-                bool stub;
-                if (mkenv->stub)
-                    stub = true;
-                else
-                    stub = false;
-                cs << BC::mkEnv(mkenv->varName, mkenv->context, stub);
+                cs << BC::mkEnv(mkenv->varName, mkenv->context, mkenv->stub);
                 break;
             }
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -797,7 +797,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         assert(false && "Recompiling PIR not supported for now.");
 
     // Unsupported opcodes:
-    case Opcode::ldlval_:
     case Opcode::asast_:
     case Opcode::beginloop_:
     case Opcode::endloop_:

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1623,7 +1623,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             Immediate id = readImmediate();
             advanceImmediate();
             res = cachedGetVar(env, id, ctx, bindingCache);
-            R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
                 SEXP sym = cp_pool_at(ctx, id);
@@ -1649,7 +1648,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             Immediate id = readImmediate();
             advanceImmediate();
             res = cachedGetVar(env, id, ctx, bindingCache);
-            R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
                 SEXP sym = cp_pool_at(ctx, id);
@@ -1671,7 +1669,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
             res = Rf_findVar(sym, ENCLOS(env));
-            R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
                 Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
@@ -1695,7 +1692,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
             res = Rf_findVar(sym, ENCLOS(env));
-            R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
                 Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
@@ -1715,7 +1711,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP sym = readConst(ctx, readImmediate());
             advanceImmediate();
             res = Rf_ddfindVar(sym, env);
-            R_Visible = TRUE;
 
             if (res == R_UnboundValue) {
                 Rf_error("object \"%s\" not found", CHAR(PRINTNAME(sym)));
@@ -2689,7 +2684,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
             ostack_popn(ctx, 3);
 
-            R_Visible = TRUE;
             ostack_push(ctx, res);
             NEXT();
         }
@@ -2714,7 +2708,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
             ostack_popn(ctx, 4);
 
-            R_Visible = TRUE;
             ostack_push(ctx, res);
             NEXT();
         }
@@ -2781,7 +2774,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 goto fallback;
             }
 
-            R_Visible = TRUE;
             ostack_popn(ctx, 2);
             ostack_push(ctx, res);
             NEXT();
@@ -2803,7 +2795,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             }
             ostack_popn(ctx, 3);
 
-            R_Visible = TRUE;
             ostack_push(ctx, res);
             NEXT();
         }
@@ -2830,7 +2821,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             }
             ostack_popn(ctx, 4);
 
-            R_Visible = TRUE;
             ostack_push(ctx, res);
             NEXT();
         }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1181,8 +1181,6 @@ static SEXP seq_int(int n1, int n2) {
     return ans;
 }
 
-extern SEXP Rf_deparse1(SEXP call, Rboolean abbrev, int opts);
-
 #define BINDING_CACHE_SIZE 5
 typedef struct {
     SEXP loc;
@@ -1722,29 +1720,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             // if promise, evaluate & return
             if (TYPEOF(res) == PROMSXP)
                 res = promiseValue(res, ctx);
-
-            if (res != R_NilValue)
-                ENSURE_NAMED(res);
-
-            ostack_push(ctx, res);
-            NEXT();
-        }
-
-        INSTRUCTION(ldlval_) {
-            Immediate id = readImmediate();
-            advanceImmediate();
-            res = cachedGetBindingCell(env, id, ctx, bindingCache);
-            assert(res);
-            res = CAR(res);
-            assert(res != R_UnboundValue);
-
-            R_Visible = TRUE;
-
-            if (TYPEOF(res) == PROMSXP)
-                res = PRVALUE(res);
-
-            assert(res != R_UnboundValue);
-            assert(res != R_MissingArg);
 
             if (res != R_NilValue)
                 ENSURE_NAMED(res);

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -42,7 +42,6 @@ BC_NOARGS(V, _)
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:
-    case Opcode::ldlval_:
     case Opcode::starg_:
     case Opcode::stvar_:
     case Opcode::stvar_super_:
@@ -236,7 +235,6 @@ void BC::print(std::ostream& out) const {
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:
-    case Opcode::ldlval_:
     case Opcode::ldddvar_:
     case Opcode::starg_:
     case Opcode::stvar_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -58,13 +58,6 @@ BC BC::ldddvar(SEXP sym) {
     i.pool = Pool::insert(sym);
     return BC(Opcode::ldddvar_, i);
 }
-BC BC::ldlval(SEXP sym) {
-    assert(TYPEOF(sym) == SYMSXP);
-    assert(strlen(CHAR(PRINTNAME(sym))));
-    ImmediateArguments i;
-    i.pool = Pool::insert(sym);
-    return BC(Opcode::ldlval_, i);
-}
 BC BC::ldvar(SEXP sym) {
     assert(TYPEOF(sym) == SYMSXP);
     assert(strlen(CHAR(PRINTNAME(sym))));

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -335,7 +335,6 @@ BC_NOARGS(V, _)
     inline static BC ldvarNoForce(SEXP sym);
     inline static BC ldvarSuper(SEXP sym);
     inline static BC ldvarNoForceSuper(SEXP sym);
-    inline static BC ldlval(SEXP sym);
     inline static BC ldddvar(SEXP sym);
     inline static BC ldarg(uint32_t offset);
     inline static BC ldloc(uint32_t offset);
@@ -596,7 +595,6 @@ BC_NOARGS(V, _)
         case Opcode::ldvar_noforce_:
         case Opcode::ldvar_super_:
         case Opcode::ldvar_noforce_super_:
-        case Opcode::ldlval_:
         case Opcode::ldddvar_:
         case Opcode::stvar_:
         case Opcode::starg_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -112,7 +112,6 @@ static Sources hasSources(Opcode bc) {
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:
-    case Opcode::ldlval_:
     case Opcode::starg_:
     case Opcode::stvar_:
     case Opcode::stvar_super_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -404,7 +404,6 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
         cs << BC::dup() << BC::ensureNamed();
 
         // Now load index and target
-        // cs << BC::ldvar(target);
         cs << (superAssign ? BC::ldvarSuper(target) : BC::ldvar(target));
         compileExpr(ctx, *idx);
         if (is2d) {

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -559,6 +559,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
                 cs << BC::extract1_1();
         }
         cs.addSrc(ast);
+        cs << BC::visible();
         return true;
     }
 
@@ -873,6 +874,7 @@ void compileGetvar(CodeStream& cs, SEXP name) {
     } else {
         cs << BC::ldvar(name);
     }
+    cs << BC::visible();
 }
 
 // Constant

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -76,11 +76,6 @@ DEF_INSTR(ldvar_noforce_super_, 1, 0, 1, 1)
 DEF_INSTR(ldddvar_, 1, 0, 1, 0)
 
 /**
- * ldlval_:: take immediate CP index of symbol, load value from local frame.
- */
-DEF_INSTR(ldlval_, 1, 0, 1, 1)
-
-/**
  * ldarg_:: load argument
  */
 DEF_INSTR(ldarg_, 1, 0, 1, 0)


### PR DESCRIPTION
Opinions?
* fuse ldvar and force instructions if they are adjacent and the force is the single use of the load
* try to lower pir to rir such that blocks executed one after another appear in the bc stream next to each other
* make visibility explicit even for extracts and loads
* remove unused instruction