### PR TITLE
fix force dominance analysis in loops and with deopt exits

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -122,6 +122,9 @@ struct AbstractPirValue {
     }
 
     AbstractResult merge(const AbstractPirValue& other);
+    AbstractResult mergeExit(const AbstractPirValue& other) {
+        return merge(other);
+    }
 
     void print(std::ostream& out, bool tty = false) const;
 };
@@ -171,6 +174,10 @@ struct AbstractREnvironment {
     }
 
     const bool absent(SEXP e) const { return !tainted && !entries.count(e); }
+
+    AbstractResult mergeExit(const AbstractREnvironment& other) {
+        return merge(other);
+    }
 
     AbstractResult merge(const AbstractREnvironment& other) {
         AbstractResult res;
@@ -259,6 +266,10 @@ class AbstractREnvironmentHierarchy {
 
     std::unordered_map<Value*, Value*> aliases;
 
+    AbstractResult mergeExit(const AbstractREnvironmentHierarchy& other) {
+        return merge(other);
+    }
+
     AbstractResult merge(const AbstractREnvironmentHierarchy& other) {
         AbstractResult res;
 
@@ -322,6 +333,9 @@ class AbstractUnique {
 
     Kind* get() const { return val; }
 
+    AbstractResult mergeExit(const AbstractUnique& other) {
+        return merge(other);
+    }
     AbstractResult merge(const AbstractUnique& other) {
         if (val && val != other.val) {
             val = nullptr;

--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -16,6 +16,7 @@ class DeadStoreAnalysis {
       public:
         typedef std::unordered_set<Value*> Envs;
         Envs envs;
+        AbstractResult mergeExit(const EnvSet& other) { return merge(other); }
         AbstractResult merge(const EnvSet& other) {
             AbstractResult res;
             for (const auto& f : other.envs) {
@@ -77,6 +78,9 @@ class DeadStoreAnalysis {
         std::unordered_set<Variable, pairhash> partiallyObserved;
         std::unordered_set<Variable, pairhash> ignoreStore;
 
+        AbstractResult mergeExit(const ObservedStores& other) {
+            return merge(other);
+        }
         AbstractResult merge(const ObservedStores& other) {
             AbstractResult res;
             for (const auto& f : other.completelyObserved) {

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -305,7 +305,7 @@ class StaticAnalysis {
                 if (bb->isExit()) {
                     logExit(state);
                     if (reachedExit) {
-                        exitpoint.merge(state);
+                        exitpoint.mergeExit(state);
                     } else {
                         exitpoint = state;
                         reachedExit = true;
@@ -325,7 +325,7 @@ class StaticAnalysis {
                     auto& extra = snapshots[bb].extra;
                     const auto& entry = extra.find(rec.second);
                     if (entry != extra.end()) {
-                        auto mres = entry->second.merge(exitpoint);
+                        auto mres = entry->second.mergeExit(exitpoint);
                         if (mres > AbstractResult::None) {
                             logChange(entry->second, mres, rec.second);
                             changed[bb] = true;
@@ -661,7 +661,7 @@ class BackwardStaticAnalysis {
                     if (bb == code->entry) {
                         logExit(state);
                         if (reachedExit) {
-                            exitpoint.merge(state);
+                            exitpoint.mergeExit(state);
                         } else {
                             exitpoint = state;
                             reachedExit = true;
@@ -681,7 +681,7 @@ class BackwardStaticAnalysis {
                         auto& extra = snapshots[bb].extra;
                         const auto& entry = extra.find(rec.second);
                         if (entry != extra.end()) {
-                            auto mres = entry->second.merge(exitpoint);
+                            auto mres = entry->second.mergeExit(exitpoint);
                             if (mres > AbstractResult::None) {
                                 logChange(entry->second, mres, rec.second);
                                 changed[bb] = true;

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -57,6 +57,10 @@ class ScopeAnalysisState {
         return res.max(mergeGeneric(other));
     }
 
+    AbstractResult mergeExit(const ScopeAnalysisState& other) {
+        return mergeGeneric(other);
+    }
+
     bool envNotEscaped(Value* v) const {
         return envs.known(v) && !envs.at(v).leaked;
     }

--- a/rir/src/compiler/analysis/unnecessary_contexts.h
+++ b/rir/src/compiler/analysis/unnecessary_contexts.h
@@ -43,7 +43,7 @@ class UnnecessaryContexts : public StaticAnalysis<UnnecessaryContextsState> {
             state.set(p);
             state.affected.clear();
             return AbstractResult::Updated;
-        } else if (CallInstruction::CastCall(i) || CallBuiltin::Cast(i)) {
+        } else if (CallInstruction::CastCall(i) && !CallSafeBuiltin::Cast(i)) {
             // Contexts are needed for non-local returns and reflection. On
             // deoptimization we can synthesize them, thus none needed for
             // checkpoints.

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -249,6 +249,15 @@ class TheVerifier {
             }
         }
 
+        if (auto fs = FrameState::Cast(i)) {
+            if (fs->env() == Env::elided()) {
+                std::cerr << "Error at instruction '";
+                i->print(std::cerr);
+                std::cerr << " framestate env cannot be elided\n";
+                ok = false;
+            }
+        }
+
         if (auto cast = CastType::Cast(i)) {
             auto arg = cast->arg<0>().val();
             // assertion is:

--- a/rir/src/compiler/analysis/visibility.h
+++ b/rir/src/compiler/analysis/visibility.h
@@ -12,6 +12,10 @@ class LastVisibilityUpdate {
     std::unordered_set<Instruction*> observable;
     Instruction* last;
 
+    AbstractResult mergeExit(const LastVisibilityUpdate& other) {
+        return merge(other);
+    }
+
     AbstractResult merge(const LastVisibilityUpdate& other) {
         AbstractResult res;
         for (auto& v : other.observable) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -91,8 +91,7 @@ class TheCleanup {
                         next = bb->remove(ip);
                     }
                 } else if (auto env = MkEnv::Cast(i)) {
-                    static std::unordered_set<Tag> tags{Tag::FrameState,
-                                                        Tag::IsEnvStub};
+                    static std::unordered_set<Tag> tags{Tag::IsEnvStub};
                     if (env->stub && env->usesAreOnly(function->entry, tags)) {
                         env->replaceUsesWith(Env::elided());
                         removed = true;

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -104,7 +104,7 @@ void DelayEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                                               BB* fastPathBranch) {
                 auto newEnvInstr = envInstr->clone();
                 deoptBranch->insert(deoptBranch->begin(), newEnvInstr);
-                envInstr->replaceUsesIn(newEnvInstr, deoptBranch);
+                envInstr->replaceUsesWithLimits(newEnvInstr, deoptBranch);
                 it = bb->moveToBegin(it, fastPathBranch);
             };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -233,7 +233,8 @@ class Instruction : public Value {
     void replaceUsesWith(Value* val);
     void replaceUsesAndSwapWith(Instruction* val,
                                 std::vector<Instruction*>::iterator it);
-    void replaceUsesIn(Value* val, BB* target);
+    void replaceUsesWithLimits(Value* val, BB* start,
+                               Instruction* stop = nullptr);
     bool usesAreOnly(BB*, std::unordered_set<Tag>);
     bool usesDoNotInclude(BB*, std::unordered_set<Tag>);
     bool unused();

--- a/rir/src/compiler/translations/pir_2_rir/stack_use.h
+++ b/rir/src/compiler/translations/pir_2_rir/stack_use.h
@@ -35,6 +35,9 @@ struct StackUseAnalysisState {
     bool isDead;
 
     AbstractResult merge(const StackUseAnalysisState& other);
+    AbstractResult mergeExit(const StackUseAnalysisState& other) {
+        return merge(other);
+    }
     void print(std::ostream& out, bool tty) const;
 };
 


### PR DESCRIPTION
1. creating a promise in a loop should reset the state every time a new
promise is created.
2. deopt exits with unforced promises should not make analysis state
ambiguous, because either we exit with the unforced promise, or we force
and then exit later with the forced version (both things cannot happen by the construction of the graph).

Also there were small issues:
* CallSafeBuiltin did block context removal.
* Cleanup elided envs on framestates (which leads to deopt with elided env)
* Promise inliner didn't correctly update the new promise it creates (somtimes updating it before it's defined) and also deleted the original promise even if it was still in use.