### PR TITLE
Default type should include the lazy option

### DIFF
--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -27,6 +27,8 @@ void ElideEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                     if (!envIsNeeded) {
                         i->elideEnv();
                         i->type.setNotObject();
+                        i->type.setNonLazy();
+                        i->effects.reset(Effect::Reflection);
                     }
                 }
 

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -55,6 +55,8 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                     });
                     next = ip + 1;
                     i->type.setNotObject();
+                    i->type.setNonLazy();
+                    i->effects.reset(Effect::Reflection);
                 }
 
                 // Speculatively elide envs on forces that only require them in

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -213,13 +213,12 @@ class TheInliner {
                             if (auto mk = MkArg::Cast(a)) {
                                 // We need to cast from a promise to a lazy
                                 // value
-                                auto cast =
-                                    new CastType(a, RType::prom,
-                                                 mk->isEager()
-                                                     ? mk->eagerArg()
-                                                           ->type.forced()
-                                                           .promiseWrappedVal()
-                                                     : ld->type);
+                                auto cast = new CastType(
+                                    a, PirType(RType::prom).nonLazy(),
+                                    mk->isEager() ? mk->eagerArg()
+                                                        ->type.nonLazy()
+                                                        .promiseWrappedVal()
+                                                  : ld->type);
                                 ip = bb->insert(ip + 1, cast);
                                 ip--;
                                 a = cast;

--- a/rir/src/compiler/pir/env.h
+++ b/rir/src/compiler/pir/env.h
@@ -19,7 +19,8 @@ class Instruction;
  */
 class Env : public Value {
     Env(SEXP rho, Env* parent)
-        : Value(RType::env, Tag::Env), rho(rho), parent(parent) {}
+        : Value(PirType(RType::env).nonLazy(), Tag::Env), rho(rho),
+          parent(parent) {}
     friend class Module;
 
   public:
@@ -56,7 +57,7 @@ class Env : public Value {
 
     virtual ~Env() {}
 };
-}
-}
+} // namespace pir
+} // namespace rir
 
 #endif

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -267,7 +267,7 @@ bool Instruction::envOnlyForObj() {
 LdConst::LdConst(SEXP c, PirType t)
     : FixedLenInstruction(t), idx(Pool::insert(c)) {}
 LdConst::LdConst(SEXP c)
-    : FixedLenInstruction(PirType(c)), idx(Pool::insert(c)) {}
+    : FixedLenInstruction(PirType(c).nonLazy()), idx(Pool::insert(c)) {}
 
 SEXP LdConst::c() const { return Pool::get(idx); }
 
@@ -511,8 +511,9 @@ void ScheduledDeopt::printArgs(std::ostream& out, bool tty) const {
 }
 
 MkFunCls::MkFunCls(Closure* cls, DispatchTable* originalBody, Value* lexicalEnv)
-    : FixedLenInstructionWithEnvSlot(RType::closure, lexicalEnv), cls(cls),
-      originalBody(originalBody) {}
+    : FixedLenInstructionWithEnvSlot(PirType(RType::closure).nonLazy(),
+                                     lexicalEnv),
+      cls(cls), originalBody(originalBody) {}
 
 void MkFunCls::printArgs(std::ostream& out, bool tty) const {
     out << *cls;
@@ -639,7 +640,7 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
                      const std::vector<BC::PoolIdx>& names_, unsigned srcIdx)
     : VarLenInstructionWithEnvSlot(PirType::valOrLazy(), callerEnv, srcIdx) {
     assert(names_.size() == args.size());
-    pushArg(fun, RType::closure);
+    pushArg(fun, PirType(RType::closure).nonLazy());
     for (unsigned i = 0; i < args.size(); ++i) {
         pushArg(args[i], PirType(RType::prom) | RType::missing);
         auto name = Pool::get(names_[i]);

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -60,7 +60,9 @@ class UnboundValue : public SingletonValue<UnboundValue> {
 
   private:
     friend class SingletonValue;
-    UnboundValue() : SingletonValue(RType::unbound, Tag::UnboundValue) {}
+    UnboundValue()
+        : SingletonValue(PirType(RType::unbound).nonLazy(), Tag::UnboundValue) {
+    }
 };
 
 class True : public SingletonValue<True> {
@@ -97,7 +99,7 @@ class Tombstone : public Value {
             assert(false);
     }
     static Tombstone* closure() {
-        static Tombstone cls(RType::closure);
+        static Tombstone cls(PirType(RType::closure).nonLazy());
         return &cls;
     }
     static Tombstone* framestate() {
@@ -111,7 +113,7 @@ class Tombstone : public Value {
   private:
     explicit Tombstone(PirType t) : Value(t, Tag::Tombstone) {}
 };
-}
-}
+} // namespace pir
+} // namespace rir
 
 #endif

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -83,8 +83,16 @@ PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     }
 
     if (PirType::vecs().isSuper(*this)) {
-        if (Rf_length(e) == 1)
+        if (Rf_length(e) == 1) {
             flags_.set(TypeFlags::isScalar);
+            flags_.reset(TypeFlags::lazy);
+            flags_.reset(TypeFlags::promiseWrapped);
+        }
+    }
+
+    if (TYPEOF(e) != PROMSXP) {
+        flags_.reset(TypeFlags::lazy);
+        flags_.reset(TypeFlags::promiseWrapped);
     }
 }
 
@@ -102,5 +110,5 @@ void PirType::merge(const ObservedValues& other) {
         merge(record.sexptype);
     }
 }
-}
-}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -125,8 +125,10 @@ struct PirType {
     Type t_;
 
     static FlagSet defaultRTypeFlags() {
-        return FlagSet() | TypeFlags::rtype | TypeFlags::maybeObject;
+        return FlagSet() | TypeFlags::rtype | TypeFlags::maybeObject |
+               TypeFlags::lazy | TypeFlags::promiseWrapped;
     }
+
     static FlagSet optimisticRTypeFlags() {
         return FlagSet() | TypeFlags::rtype | TypeFlags::isScalar;
     }
@@ -174,7 +176,8 @@ struct PirType {
     static PirType val() {
         return PirType(vecs() | list() | RType::sym | RType::chr | RType::raw |
                        RType::closure | RType::prom | RType::code | RType::env |
-                       RType::missing | RType::unbound | RType::ast);
+                       RType::missing | RType::unbound | RType::ast)
+            .nonLazy();
     }
     static PirType vecs() { return num() | RType::str | RType::vec; }
     static PirType closure() { return RType::closure; }
@@ -224,6 +227,8 @@ struct PirType {
         assert(isRType());
         PirType t = *this;
         t.flags_.set(TypeFlags::isScalar);
+        t.flags_.reset(TypeFlags::lazy);
+        t.flags_.reset(TypeFlags::promiseWrapped);
         return t;
     }
 
@@ -242,7 +247,7 @@ struct PirType {
         return t;
     }
 
-    PirType forced() const {
+    PirType nonLazy() const {
         assert(isRType());
         PirType t = *this;
         t.flags_.reset(TypeFlags::promiseWrapped);
@@ -252,12 +257,13 @@ struct PirType {
 
     RIR_INLINE PirType baseType() const {
         assert(isRType());
-        return PirType(t_.r);
+        return PirType(t_.r).nonLazy();
     }
 
     RIR_INLINE void setNotMissing() { *this = notMissing(); }
     RIR_INLINE void setNotObject() { *this = notObject(); }
     RIR_INLINE void setScalar() { *this = scalar(); }
+    RIR_INLINE void setNonLazy() { *this = nonLazy(); }
 
     static const PirType voyd() { return NativeTypeSet(); }
     static const PirType bottom() { return PirType(RTypeSet()); }

--- a/rir/src/compiler/transform/insert_cast.cpp
+++ b/rir/src/compiler/transform/insert_cast.cpp
@@ -9,10 +9,11 @@ pir::Instruction* InsertCast::cast(pir::Value* v, PirType t, Value* env) {
     if (v->type.maybePromiseWrapped() && !t.maybePromiseWrapped()) {
         return new pir::Force(v, env);
     }
-    if (v->type == RType::logical && t == NativeType::test) {
+    if (v->type == PirType(RType::logical).nonLazy() && t == NativeType::test) {
         return new pir::AsTest(v);
     }
-    if (!v->type.isA(RType::closure) && t == RType::closure) {
+    if (!v->type.isA(PirType(RType::closure).nonLazy()) &&
+        t == PirType(RType::closure).nonLazy()) {
         return new pir::ChkClosure(v);
     }
 

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1225,7 +1225,7 @@ void Pir2Rir::lower(Code* code) {
                 if (use && Force::Cast(use) && next != bb->end() &&
                     use == *next) {
                     ldvar->fusedWithForce = true;
-                    ldvar->type = ldvar->type.forced();
+                    ldvar->type = ldvar->type.nonLazy();
                     use->replaceUsesWith(ldvar);
                     next = bb->remove(next);
                 }


### PR DESCRIPTION
Safe arithmetic ops does not use reflection.