### PR TITLE
fixed missing implicit args in pir compiled function

### DIFF
--- a/rir/src/interpreter/call_context.h
+++ b/rir/src/interpreter/call_context.h
@@ -72,8 +72,11 @@ struct CallContext {
     bool hasNames() const { return names; }
 
     Immediate implicitArgIdx(unsigned i) const {
-        assert(implicitArgs && i < passedArgs);
-        return implicitArgs[i];
+        assert(implicitArgs);
+        if (i < passedArgs)
+            return implicitArgs[i];
+        else
+            return MISSING_ARG_IDX;
     }
 
     bool missingArg(unsigned i) const {

--- a/rir/tests/pir_regression_missing.R
+++ b/rir/tests/pir_regression_missing.R
@@ -77,6 +77,7 @@ g <- rir.compile(function() {
   f(1,2,3)
 })
 
-rir.disassemble(f)
+stopifnot(g()==1)
+pir.compile(g)
 stopifnot(g()==1)
 

--- a/rir/tests/pir_regression_missing.R
+++ b/rir/tests/pir_regression_missing.R
@@ -68,3 +68,15 @@ stopifnot(h()==3)
 stopifnot(h()==3)
 stopifnot(h()==3)
 stopifnot(h()==3)
+
+f <- pir.compile(rir.compile(function(a,b,c) a))
+g <- rir.compile(function() {
+  f()
+  f(1)
+  f(1,2)
+  f(1,2,3)
+})
+
+rir.disassemble(f)
+stopifnot(g()==1)
+


### PR DESCRIPTION
Also added a regression test:

```r
f <- pir.compile(rir.compile(function(a,b,c) a))
g <- rir.compile(function() {
  f()
  f(1)
  f(1,2)
  f(1,2,3)
})

rir.disassemble(f)
stopifnot(g()==1)
```

Calling `g` fails an assertion in call_context.cpp: `i < passedArgs`. `ldarg` assumes that we pass the loaded argument. However, when calling a function implicitly this isn't always true. This PR makes it so, when `i >= passedArgs`, a missing implicit argument is returned instead.

Perhaps we should add this guard `ldarg` instead