### PR TITLE
small fix in insert_cast

### DIFF
--- a/rir/src/compiler/transform/insert_cast.cpp
+++ b/rir/src/compiler/transform/insert_cast.cpp
@@ -31,10 +31,7 @@ void InsertCast::apply(BB* bb) {
     auto ip = bb->begin();
     while (ip != bb->end()) {
         Instruction* instr = *ip;
-        Phi* p = nullptr;
-        if ((p = Phi::Cast(instr))) {
-            p->updateType();
-        }
+        instr->updateType();
         instr->eachArg([&](InstrArg& arg) {
             while (!arg.type().isSuper(arg.val()->type)) {
                 auto c = cast(arg.val(), arg.type(), env);


### PR DESCRIPTION
fixes a bug where type isn't updated if the instruction isn't `Phi`