### PR TITLE
Force constant promises for better dispatch from GNUR

### DIFF
--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -18,8 +18,8 @@ SEXP safeEval(SEXP e, SEXP rho) {
             // TODO: Is this possible? Should it be assert(false)?
             return R_UnboundValue;
         }
-        Case(BCODESXP) { assert(false); }
-        Case(EXTERNALSXP) { assert(false); }
+        Case(BCODESXP) { return R_UnboundValue; }
+        Case(EXTERNALSXP) { return R_UnboundValue; }
         // TODO : some code (eg. serialize.c:2154) puts closures into asts...
         //        not sure how we want to handle it...
         // Case(CLOSXP) {

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -8,7 +8,7 @@
 
 namespace rir {
 
-SEXP safeEval(SEXP e, SEXP rho) {
+static SEXP safeEval(SEXP e, SEXP rho) {
     Match(e) {
         // Function application
         Case(LANGSXP) { return R_UnboundValue; }

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -1,0 +1,68 @@
+#include "safe_force.h"
+#include "R/RList.h"
+#include "R/Sexp.h"
+#include "R/Symbols.h"
+#include "R/r.h"
+
+#include <assert.h>
+
+namespace rir {
+
+SEXP safeEval(SEXP e, SEXP rho) {
+    Match(e) {
+        // Function application
+        Case(LANGSXP) { return R_UnboundValue; }
+        // Variable lookup
+        Case(SYMSXP) { return R_UnboundValue; }
+        Case(PROMSXP) {
+            // TODO: Is this possible? Should it be assert(false)?
+            return R_UnboundValue;
+        }
+        Case(BCODESXP) { assert(false); }
+        Case(EXTERNALSXP) { assert(false); }
+        // TODO : some code (eg. serialize.c:2154) puts closures into asts...
+        //        not sure how we want to handle it...
+        // Case(CLOSXP) {
+        //     assert(false);
+        // }
+
+        // Constant
+        Else({ return e; });
+    }
+    assert(false);
+}
+
+// Copied from gnuR
+SEXP safeForcePromise(SEXP e) {
+    if (PRVALUE(e) == R_UnboundValue) {
+        SEXP val;
+        if (PRSEEN(e)) {
+            if (PRSEEN(e) == 1)
+                Rf_errorcall(R_GlobalContext->call,
+                             "promise already under evaluation: recursive "
+                             "default argument reference or earlier problems?");
+            else {
+                /* set PRSEEN to 1 to avoid infinite recursion */
+                SET_PRSEEN(e, 1);
+                Rf_warningcall(R_GlobalContext->call,
+                               "restarting interrupted promise evaluation");
+            }
+        }
+        /* Mark the promise as under evaluation, don't push it onto the promise
+         * stack because evaluation won't jump out */
+        SET_PRSEEN(e, 1);
+        val = safeEval(PRCODE(e), PRENV(e));
+        SET_PRSEEN(e, 0);
+        if (val != R_UnboundValue) {
+            SET_PRVALUE(e, val);
+            /* Also set the environment to R_NilValue to allow GC to
+               reclaim the promise environment; this is also useful for
+               fancy games with delayedAssign() */
+            ENSURE_NAMEDMAX(val);
+            SET_PRENV(e, R_NilValue);
+        }
+    }
+    return PRVALUE(e);
+}
+
+} // namespace rir

--- a/rir/src/interpreter/safe_force.h
+++ b/rir/src/interpreter/safe_force.h
@@ -1,0 +1,19 @@
+#ifndef RIR_SAFE_FORCE_H
+#define RIR_SAFE_FORCE_H
+
+#include "builtins.h"
+#include "call_context.h"
+#include "instance.h"
+
+#include "interp_incl.h"
+
+#include <R/r.h>
+
+namespace rir {
+
+// Will try to evaluate the promise if it definitely doesn't cause side effects
+SEXP safeForcePromise(SEXP e);
+
+} // namespace rir
+
+#endif


### PR DESCRIPTION
Currently, when dispatching, if an argument is an unbound promise we "give up" and don't assume anything about it. In this PR, we inspect the source of the promise. If it's simply a constant, we will "force" the promise, so that we can dispatch an eager non-obj version of the function.

This makes it so when we run code like `f(10); f(10); f(10)` in GNUR (e.g. from the REPL), PIR can infer that `f` is being called with an eager non-obj, and compile/dispatch a better version of it.

Later, we could also check variables referring to constants by loading them from the environment. If the variable is a promise, instead of forcing it, we'd either give up or "safe force" it again. But in the latter, we should probably have a counter, so we don't waste too much time only to realize we can't actually compute the promise without possible side effects.

I looked at how GNU-R forces promises, from https://github.com/reactorlabs/gnur/blob/c575dedb863481e6b6e904525a44a0fc2d65e7a6/src/main/eval.c.