### PR TITLE
Debug-only opcodes

### DIFF
--- a/rir/src/common.h
+++ b/rir/src/common.h
@@ -13,9 +13,11 @@ extern void printBacktrace();
 
 #ifdef ENABLE_SLOWASSERT
 #define SLOWASSERT(what) assert(what)
+#define IFDBG(what) what
 #else
 #define SLOWASSERT(what)                                                       \
     {}
+#define IFDBG(what)
 #endif
 
 // from boost

--- a/rir/src/common.h
+++ b/rir/src/common.h
@@ -13,10 +13,15 @@ extern void printBacktrace();
 
 #ifdef ENABLE_SLOWASSERT
 #define SLOWASSERT(what) assert(what)
-#define IFDBG(what) what
+#define ENABLE_DEBUGOPS
 #else
 #define SLOWASSERT(what)                                                       \
     {}
+#endif
+
+#ifdef ENABLE_DEBUGOPS
+#define IFDBG(what) what
+#else
 #define IFDBG(what)
 #endif
 

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -29,7 +29,7 @@ class TheCleanup {
                 auto next = ip + 1;
                 bool removed = false;
                 if (!i->branchOrExit() && !i->hasObservableEffects() &&
-                    i->unused()) {
+                    i->unused() && !i->isDebug()) {
                     removed = true;
                     next = bb->remove(ip);
                 } else if (auto force = Force::Cast(i)) {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -738,7 +738,7 @@ void Checkpoint::printGraphBranches(std::ostream& out, size_t bbId) const {
 
 BB* Checkpoint::deoptBranch() { return bb()->falseBranch(); }
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
 void TmpGet::printArgs(std::ostream& out, bool tty) const {
     FixedLenInstruction::printArgs(out, tty);
     out << " [" << idx << "]";

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -751,6 +751,10 @@ void Print::printArgs(std::ostream& out, bool tty) const {
     // TODO: Could import and use escapeString if necessary
     out << " \"" << prefix() << "\"";
 }
+void PrintStack::printArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+    out << " \"" << prefix() << "\"";
+}
 #endif
 
 } // namespace pir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -7,6 +7,7 @@
 #include "utils/Pool.h"
 #include "utils/Terminal.h"
 #include "utils/capture_out.h"
+#include "utils/escape_string.h"
 
 #include <algorithm>
 #include <cassert>
@@ -736,6 +737,23 @@ void Checkpoint::printGraphBranches(std::ostream& out, size_t bbId) const {
 }
 
 BB* Checkpoint::deoptBranch() { return bb()->falseBranch(); }
+
+#ifdef ENABLE_SLOWASSERT
+void TmpGet::printArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+    out << " [" << idx << "]";
+}
+
+void TmpSet::printArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+    out << " [" << idx << "]";
+}
+
+void Print::printArgs(std::ostream& out, bool tty) const {
+    FixedLenInstruction::printArgs(out, tty);
+    out << " \"" << escapeString(prefix()) << "\"";
+}
+#endif
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -7,7 +7,6 @@
 #include "utils/Pool.h"
 #include "utils/Terminal.h"
 #include "utils/capture_out.h"
-#include "utils/escape_string.h"
 
 #include <algorithm>
 #include <cassert>
@@ -751,7 +750,8 @@ void TmpSet::printArgs(std::ostream& out, bool tty) const {
 
 void Print::printArgs(std::ostream& out, bool tty) const {
     FixedLenInstruction::printArgs(out, tty);
-    out << " \"" << escapeString(prefix()) << "\"";
+    // TODO: Could import and use escapeString if necessary
+    out << " \"" << prefix() << "\"";
 }
 #endif
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -238,6 +238,7 @@ class Instruction : public Value {
     bool usesAreOnly(BB*, std::unordered_set<Tag>);
     bool usesDoNotInclude(BB*, std::unordered_set<Tag>);
     bool unused();
+    virtual bool isDebug() const { return false; }
 
     virtual void updateType(){};
 
@@ -1532,6 +1533,7 @@ class FLI(TmpGet, 0, Effects::None()) {
     explicit TmpGet(DebugPoolIdx idx_)
         : FixedLenInstruction(PirType::bottom(), {{}}, {{}}), idx(idx_) {}
 
+    bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
@@ -1543,6 +1545,7 @@ class FLI(TmpSet, 1, Effects::None()) {
         : FixedLenInstruction(PirType::voyd(), {{PirType::any()}}, {{val}}),
           idx(idx_) {}
 
+    bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
@@ -1555,6 +1558,7 @@ class FLI(Print, 1, Effects::None()) {
           idx(idx_) {}
 
     const char* prefix() const { return DebugPool::prefixAt(idx); }
+    bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
@@ -1562,6 +1566,8 @@ class FLI(Assert, 1, Effects::None()) {
   public:
     explicit Assert(Value* val)
         : FixedLenInstruction(PirType::voyd(), {{PirType::any()}}, {{val}}) {}
+
+    bool isDebug() const override { return true; }
 };
 #endif
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1524,6 +1524,47 @@ class ScheduledDeopt
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
+#ifdef ENABLE_SLOWASSERT
+class FLI(TmpGet, 0, Effects::None()) {
+  public:
+    const DebugPoolIdx idx = (DebugPoolIdx)-1;
+
+    explicit TmpGet(DebugPoolIdx idx_)
+        : FixedLenInstruction(PirType::bottom(), {{}}, {{}}), idx(idx_) {}
+
+    void printArgs(std::ostream& out, bool tty) const override;
+};
+
+class FLI(TmpSet, 1, Effects::None()) {
+  public:
+    const DebugPoolIdx idx = (DebugPoolIdx)-1;
+
+    explicit TmpSet(DebugPoolIdx idx_, Value* val)
+        : FixedLenInstruction(PirType::voyd(), {{PirType::any()}}, {{val}}),
+          idx(idx_) {}
+
+    void printArgs(std::ostream& out, bool tty) const override;
+};
+
+class FLI(Print, 1, Effects::None()) {
+  public:
+    const DebugPoolIdx idx = (DebugPoolIdx)-1;
+
+    explicit Print(DebugPoolIdx idx_, Value* val)
+        : FixedLenInstruction(PirType::voyd(), {{PirType::any()}}, {{val}}),
+          idx(idx_) {}
+
+    const char* prefix() const { return DebugPool::prefixAt(idx); }
+    void printArgs(std::ostream& out, bool tty) const override;
+};
+
+class FLI(Assert, 1, Effects::None()) {
+  public:
+    explicit Assert(Value* val)
+        : FixedLenInstruction(PirType::voyd(), {{PirType::any()}}, {{val}}) {}
+};
+#endif
+
 #undef FLI
 #undef VLI
 #undef FLIE

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1599,6 +1599,9 @@ class FLI(TmpGet, 0, Effects::None()) {
 
     bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
+    size_t gvnBase() const override {
+        return hash_combine(InstructionImplementation::gvnBase(), idx);
+    }
 };
 
 class FLI(TmpSet, 1, Effects::None()) {
@@ -1611,6 +1614,9 @@ class FLI(TmpSet, 1, Effects::None()) {
 
     bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
+    size_t gvnBase() const override {
+        return hash_combine(InstructionImplementation::gvnBase(), idx);
+    }
 };
 
 class FLI(Print, 1, Effects::None()) {
@@ -1624,6 +1630,24 @@ class FLI(Print, 1, Effects::None()) {
     const char* prefix() const { return DebugPool::prefixAt(idx); }
     bool isDebug() const override { return true; }
     void printArgs(std::ostream& out, bool tty) const override;
+    size_t gvnBase() const override {
+        return hash_combine(InstructionImplementation::gvnBase(), idx);
+    }
+};
+
+class FLI(PrintStack, 0, Effects::None()) {
+  public:
+    const DebugPoolIdx idx = (DebugPoolIdx)-1;
+
+    explicit PrintStack(DebugPoolIdx idx_)
+        : FixedLenInstruction(PirType::voyd(), {{}}, {{}}), idx(idx_) {}
+
+    const char* prefix() const { return DebugPool::prefixAt(idx); }
+    bool isDebug() const override { return true; }
+    void printArgs(std::ostream& out, bool tty) const override;
+    size_t gvnBase() const override {
+        return hash_combine(InstructionImplementation::gvnBase(), idx);
+    }
 };
 
 class FLI(Assert, 1, Effects::None()) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1524,7 +1524,7 @@ class ScheduledDeopt
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
 class FLI(TmpGet, 0, Effects::None()) {
   public:
     const DebugPoolIdx idx = (DebugPoolIdx)-1;

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -93,6 +93,7 @@
     IFDBG(V(TmpGet))                                                           \
     IFDBG(V(TmpSet))                                                           \
     IFDBG(V(Print))                                                            \
+    IFDBG(V(PrintStack))                                                       \
     IFDBG(V(Assert))
 
 #endif

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -1,6 +1,7 @@
 #ifndef COMPILER_INSTRUCTION_LIST_H
 #define COMPILER_INSTRUCTION_LIST_H
 
+#include "../../common.h"
 #include "../../simple_instruction_list.h"
 
 // Please keep in sync with implementation of instructions in instruction.h
@@ -88,6 +89,10 @@
     V(Visible)                                                                 \
     V(Invisible)                                                               \
     V(PirCopy)                                                                 \
-    V(Nop)
+    V(Nop)                                                                     \
+    IFDBG(V(TmpGet))                                                           \
+    IFDBG(V(TmpSet))                                                           \
+    IFDBG(V(Print))                                                            \
+    IFDBG(V(Assert))
 
 #endif

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1244,22 +1244,22 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 #ifdef ENABLE_DEBUGOPS
             case Tag::TmpGet: {
                 auto tmpGet = TmpGet::Cast(instr);
-                cs << BC::tmpGet(tmpGet->idx);
+                cb.add(BC::tmpGet(tmpGet->idx));
                 break;
             }
             case Tag::TmpSet: {
                 auto tmpSet = TmpSet::Cast(instr);
-                cs << BC::tmpSet(tmpSet->idx);
+                cb.add(BC::tmpSet(tmpSet->idx));
                 break;
             }
             case Tag::Print: {
                 auto print = Print::Cast(instr);
-                cs << BC::print(print->idx);
+                cb.add(BC::print(print->idx));
                 break;
             }
             case Tag::PrintStack: {
                 auto print = PrintStack::Cast(instr);
-                cs << BC::printStack(print->idx);
+                cb.add(BC::printStack(print->idx));
                 break;
             }
 #endif

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1149,6 +1149,11 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 cs << BC::print(print->idx);
                 break;
             }
+            case Tag::PrintStack: {
+                auto print = PrintStack::Cast(instr);
+                cs << BC::printStack(print->idx);
+                break;
+            }
 #endif
 
             // Values, not instructions

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -951,6 +951,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE(Seq, seq);
                 SIMPLE(MkCls, close);
                 SIMPLE(SetShared, setShared);
+                IFDBG(SIMPLE(Assert, assert_));
 #define V(V, name, Name) SIMPLE(Name, name);
                 SIMPLE_INSTRUCTIONS(V, _);
 #undef V
@@ -1131,6 +1132,24 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 // deopt is exit, return
                 return;
             }
+
+#ifdef ENABLE_SLOWASSERT
+            case Tag::TmpGet: {
+                auto tmpGet = TmpGet::Cast(instr);
+                cs << BC::tmpGet(tmpGet->idx);
+                break;
+            }
+            case Tag::TmpSet: {
+                auto tmpSet = TmpSet::Cast(instr);
+                cs << BC::tmpSet(tmpSet->idx);
+                break;
+            }
+            case Tag::Print: {
+                auto print = Print::Cast(instr);
+                cs << BC::print(print->idx);
+                break;
+            }
+#endif
 
             // Values, not instructions
             case Tag::Tombstone:

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1133,7 +1133,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
                 return;
             }
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
             case Tag::TmpGet: {
                 auto tmpGet = TmpGet::Cast(instr);
                 cs << BC::tmpGet(tmpGet->idx);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -750,6 +750,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     case Opcode::print_:
         insert(new Print(bc.immediate.debugIdx, pop()));
         break;
+    case Opcode::print_stack_:
+        insert(new PrintStack(bc.immediate.debugIdx));
+        break;
     case Opcode::assert_:
         insert(new Assert(pop()));
         break;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -740,7 +740,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         insert(new Visible());
         break;
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
     case Opcode::tmp_get_:
         push(insert(new TmpGet(bc.immediate.debugIdx)));
         break;

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -740,6 +740,21 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         insert(new Visible());
         break;
 
+#ifdef ENABLE_SLOWASSERT
+    case Opcode::tmp_get_:
+        push(insert(new TmpGet(bc.immediate.debugIdx)));
+        break;
+    case Opcode::tmp_set_:
+        insert(new TmpSet(bc.immediate.debugIdx, pop()));
+        break;
+    case Opcode::print_:
+        insert(new Print(bc.immediate.debugIdx, pop()));
+        break;
+    case Opcode::assert_:
+        insert(new Assert(pop()));
+        break;
+#endif
+
 #define V(_, name, Name)                                                       \
     case Opcode::name##_:                                                      \
         insert(new Name());                                                    \

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3360,7 +3360,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             NEXT();
         }
 
-#ifdef SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
         INSTRUCTION(tmp_get_) {
             DebugPoolIdx idx = (DebugPoolIdx)readImmediate();
             advanceImmediate();

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3383,6 +3383,23 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             NEXT();
         }
 
+        INSTRUCTION(print_stack_) {
+            DebugPoolIdx idx = (DebugPoolIdx)readImmediate();
+            advanceImmediate();
+            std::cout << "[Debug Stack] " << DebugPool::prefixAt(idx) << "\n";
+            int len = ostack_length(ctx);
+            int i = 0;
+            for (int i = 0; i < std::min(5, len); i++) {
+                Rf_PrintValue(ostack_at(ctx, i));
+            }
+            if (i == len) {
+                std::cout << "=====\n";
+            } else {
+                std::cout << "... =====\n";
+            }
+            NEXT();
+        }
+
         INSTRUCTION(assert_) {
             SEXP test = ostack_pop(ctx);
             if (!IS_SIMPLE_SCALAR(test, LGLSXP) || *LOGICAL(test) != 1) {

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -131,6 +131,7 @@ BC_NOARGS(V, _)
     case Opcode::tmp_get_:
     case Opcode::tmp_set_:
     case Opcode::print_:
+    case Opcode::print_stack_:
         cs.insert(immediate.debugIdx);
         return;
 #endif
@@ -340,6 +341,7 @@ BC_NOARGS(V, _)
         out << immediate.debugIdx;
         break;
     case Opcode::print_:
+    case Opcode::print_stack_:
         out << DebugPool::prefixAt(immediate.debugIdx);
         break;
 #endif

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -127,6 +127,14 @@ BC_NOARGS(V, _)
         cs.insert(immediate.loc_cpy);
         return;
 
+#ifdef ENABLE_SLOWASSERT
+    case Opcode::tmp_get_:
+    case Opcode::tmp_set_:
+    case Opcode::print_:
+        cs.insert(immediate.debugIdx);
+        return;
+#endif
+
     case Opcode::invalid_:
     case Opcode::num_of:
         assert(false);
@@ -326,6 +334,17 @@ BC_NOARGS(V, _)
     case Opcode::br_:
         out << immediate.offset;
         break;
+#ifdef ENABLE_SLOWASSERT
+    case Opcode::tmp_get_:
+    case Opcode::tmp_set_:
+        out << immediate.debugIdx;
+        break;
+    case Opcode::print_:
+        out << DebugPool::prefixAt(immediate.debugIdx);
+        break;
+#endif
+    default:
+        assert(false);
     }
     out << "\n";
 }

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -127,7 +127,7 @@ BC_NOARGS(V, _)
         cs.insert(immediate.loc_cpy);
         return;
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
     case Opcode::tmp_get_:
     case Opcode::tmp_set_:
     case Opcode::print_:
@@ -334,7 +334,7 @@ BC_NOARGS(V, _)
     case Opcode::br_:
         out << immediate.offset;
         break;
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
     case Opcode::tmp_get_:
     case Opcode::tmp_set_:
         out << immediate.debugIdx;

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -327,6 +327,14 @@ BC BC::print(DebugPoolIdx idx) {
 BC BC::print(const char* prefix) {
     return BC::print(DebugPool::prefixIdx(prefix));
 }
+BC BC::printStack(DebugPoolIdx idx) {
+    ImmediateArguments i;
+    i.debugIdx = idx;
+    return BC(Opcode::print_stack_, i);
+}
+BC BC::printStack(const char* prefix) {
+    return BC::printStack(DebugPool::prefixIdx(prefix));
+}
 #endif
 
 } // namespace rir

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -305,6 +305,30 @@ BC BC::deopt(SEXP deoptMetadata) {
     return BC(Opcode::deopt_, i);
 }
 
+#ifdef ENABLE_SLOWASSERT
+BC BC::tmpGet(DebugPoolIdx idx) {
+    ImmediateArguments i;
+    i.debugIdx = idx;
+    return BC(Opcode::tmp_get_, i);
+}
+
+BC BC::tmpSet(DebugPoolIdx idx) {
+    ImmediateArguments i;
+    i.debugIdx = idx;
+    return BC(Opcode::tmp_set_, i);
+}
+
+BC BC::print(DebugPoolIdx idx) {
+    ImmediateArguments i;
+    i.debugIdx = idx;
+    return BC(Opcode::print_, i);
+}
+
+BC BC::print(const char* prefix) {
+    return BC::print(DebugPool::prefixIdx(prefix));
+}
+#endif
+
 } // namespace rir
 
 #endif

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -305,7 +305,7 @@ BC BC::deopt(SEXP deoptMetadata) {
     return BC(Opcode::deopt_, i);
 }
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
 BC BC::tmpGet(DebugPoolIdx idx) {
     ImmediateArguments i;
     i.debugIdx = idx;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -15,6 +15,7 @@
 
 #include "ir/RuntimeFeedback.h"
 #include "runtime/Assumptions.h"
+#include "utils/DebugPool.h"
 
 #include "BC_noarg_list.h"
 
@@ -139,6 +140,7 @@ class BC {
         LocalsCopy loc_cpy;
         ObservedCallees callFeedback;
         ObservedValues binopFeedback[2];
+        DebugPoolIdx debugIdx;
         ImmediateArguments() { memset(this, 0, sizeof(ImmediateArguments)); }
     };
 
@@ -374,6 +376,13 @@ BC_NOARGS(V, _)
 
     inline static BC mkEnv(const std::vector<SEXP>& names,
                            SignedImmediate contextPos, bool stub);
+
+#ifdef ENABLE_SLOWASSERT
+    inline static BC tmpGet(DebugPoolIdx idx);
+    inline static BC tmpSet(DebugPoolIdx idx);
+    inline static BC print(DebugPoolIdx idx);
+    inline static BC print(const char* prefix);
+#endif
 
     inline static BC decode(Opcode* pc, const Code* code) {
         BC cur;
@@ -663,6 +672,13 @@ BC_NOARGS(V, _)
 BC_NOARGS(V, _)
 #undef V
             break;
+#ifdef ENABLE_SLOWASSERT
+        case Opcode::tmp_get_:
+        case Opcode::tmp_set_:
+        case Opcode::print_:
+            memcpy(&immediate.debugIdx, pc, sizeof(DebugPoolIdx));
+            break;
+#endif
         case Opcode::invalid_:
         case Opcode::num_of:
             assert(false);

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -377,7 +377,7 @@ BC_NOARGS(V, _)
     inline static BC mkEnv(const std::vector<SEXP>& names,
                            SignedImmediate contextPos, bool stub);
 
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
     inline static BC tmpGet(DebugPoolIdx idx);
     inline static BC tmpSet(DebugPoolIdx idx);
     inline static BC print(DebugPoolIdx idx);
@@ -672,7 +672,7 @@ BC_NOARGS(V, _)
 BC_NOARGS(V, _)
 #undef V
             break;
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
         case Opcode::tmp_get_:
         case Opcode::tmp_set_:
         case Opcode::print_:

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -382,6 +382,8 @@ BC_NOARGS(V, _)
     inline static BC tmpSet(DebugPoolIdx idx);
     inline static BC print(DebugPoolIdx idx);
     inline static BC print(const char* prefix);
+    inline static BC printStack(DebugPoolIdx idx);
+    inline static BC printStack(const char* prefix);
 #endif
 
     inline static BC decode(Opcode* pc, const Code* code) {
@@ -676,6 +678,7 @@ BC_NOARGS(V, _)
         case Opcode::tmp_get_:
         case Opcode::tmp_set_:
         case Opcode::print_:
+        case Opcode::print_stack_:
             memcpy(&immediate.debugIdx, pc, sizeof(DebugPoolIdx));
             break;
 #endif

--- a/rir/src/ir/BC_noarg_list.h
+++ b/rir/src/ir/BC_noarg_list.h
@@ -66,7 +66,8 @@
     V(NESTED, swap, swap)                                                      \
     V(NESTED, isobj, isobj)                                                    \
     V(NESTED, isstubenv, isstubenv)                                            \
-    V(NESTED, return_, return )
+    V(NESTED, return_, return )                                                \
+    IFDBG(V(NESTED, assert_, assert))
 
 #undef V_SIMPLE_INSTRUCTION
 

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -173,7 +173,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::deopt_:
     case Opcode::pop_context_:
     case Opcode::push_context_:
-#ifdef ENABLE_SLOWASSERT
+#ifdef ENABLE_DEBUGOPS
     case Opcode::tmp_get_:
     case Opcode::tmp_set_:
     case Opcode::print_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -177,6 +177,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::tmp_get_:
     case Opcode::tmp_set_:
     case Opcode::print_:
+    case Opcode::print_stack_:
     case Opcode::assert_:
         return Sources::NotNeeded;
 #endif

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -173,7 +173,13 @@ static Sources hasSources(Opcode bc) {
     case Opcode::deopt_:
     case Opcode::pop_context_:
     case Opcode::push_context_:
+#ifdef ENABLE_SLOWASSERT
+    case Opcode::tmp_get_:
+    case Opcode::tmp_set_:
+    case Opcode::print_:
+    case Opcode::assert_:
         return Sources::NotNeeded;
+#endif
 
     case Opcode::ldloc_:
     case Opcode::aslogical_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -502,6 +502,12 @@ DEF_INSTR(tmp_set_, 1, 1, 0, 0)
 DEF_INSTR(print_, 1, 1, 0, 0)
 
 /**
+ * print_stack_ :: reads index of c-string from opcode, pops, prints the string
+ * followed by up to 5 top stack contents.
+ */
+DEF_INSTR(print_stack_, 1, 1, 0, 0)
+
+/**
  * assert_ :: pops, crashes if not R_TrueValue.
  */
 DEF_INSTR(assert_, 0, 1, 0, 0)

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -480,4 +480,28 @@ DEF_INSTR(record_binop_, 2, 2, 2, 0)
 DEF_INSTR(int3_, 0, 0, 0, 0)
 DEF_INSTR(printInvocation_, 0, 0, 0, 0)
 
+// The following instructions are used for debugging. They will not exist in
+// release builds.
+
+/**
+ * tmp_get_ :: reads an SEXP at the associated index, pushes.
+ */
+IFDBG(DEF_INSTR(tmp_get_, 1, 0, 1, 0))
+
+/**
+ * tmp_set_ :: writes an SEXP to the associated index, pops.
+ */
+IFDBG(DEF_INSTR(tmp_set_, 1, 1, 0, 0))
+
+/**
+ * print_ :: reads index of c-string from opcode, pops, prints the string
+ * followed by the value.
+ */
+IFDBG(DEF_INSTR(print_, 1, 1, 0, 0))
+
+/**
+ * assert_ :: pops, crashes if not R_TrueValue.
+ */
+IFDBG(DEF_INSTR(assert_, 0, 1, 0, 0))
+
 #undef DEF_INSTR

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -480,28 +480,32 @@ DEF_INSTR(record_binop_, 2, 2, 2, 0)
 DEF_INSTR(int3_, 0, 0, 0, 0)
 DEF_INSTR(printInvocation_, 0, 0, 0, 0)
 
+#ifdef ENABLE_DEBUGOPS
+
 // The following instructions are used for debugging. They will not exist in
 // release builds.
 
 /**
  * tmp_get_ :: reads an SEXP at the associated index, pushes.
  */
-IFDBG(DEF_INSTR(tmp_get_, 1, 0, 1, 0))
+DEF_INSTR(tmp_get_, 1, 0, 1, 0)
 
 /**
  * tmp_set_ :: writes an SEXP to the associated index, pops.
  */
-IFDBG(DEF_INSTR(tmp_set_, 1, 1, 0, 0))
+DEF_INSTR(tmp_set_, 1, 1, 0, 0)
 
 /**
  * print_ :: reads index of c-string from opcode, pops, prints the string
  * followed by the value.
  */
-IFDBG(DEF_INSTR(print_, 1, 1, 0, 0))
+DEF_INSTR(print_, 1, 1, 0, 0)
 
 /**
  * assert_ :: pops, crashes if not R_TrueValue.
  */
-IFDBG(DEF_INSTR(assert_, 0, 1, 0, 0))
+DEF_INSTR(assert_, 0, 1, 0, 0)
+
+#endif
 
 #undef DEF_INSTR

--- a/rir/src/utils/DebugPool.cpp
+++ b/rir/src/utils/DebugPool.cpp
@@ -1,0 +1,9 @@
+#include "DebugPool.h"
+#include <vector>
+
+namespace rir {
+
+std::vector<SEXP> DebugPool::tmps;
+std::vector<const char*> DebugPool::prefixes;
+
+} // namespace rir

--- a/rir/src/utils/DebugPool.h
+++ b/rir/src/utils/DebugPool.h
@@ -1,0 +1,48 @@
+
+#ifndef DEBUG_POOL
+#define DEBUG_POOL
+
+#include "R/RVector.h"
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+#include "R/r.h"
+
+#include <unordered_map>
+
+namespace rir {
+
+typedef unsigned DebugPoolIdx;
+
+class DebugPool {
+    // These are supposed to be unprotected
+    static std::vector<SEXP> tmps;
+    static std::vector<const char*> prefixes;
+
+  public:
+    static SEXP& tmpAt(DebugPoolIdx idx) { return DebugPool::tmps[idx]; }
+
+    static DebugPoolIdx addTmp() {
+        DebugPool::tmps.push_back(nullptr);
+        return DebugPool::tmps.size() - 1;
+    }
+
+    static const char* prefixAt(DebugPoolIdx idx) {
+        return DebugPool::prefixes[idx];
+    }
+
+    static DebugPoolIdx prefixIdx(const char* prefix) {
+        for (DebugPoolIdx i = 0; i < DebugPool::prefixes.size(); i++) {
+            if (strcmp(DebugPool::prefixes[i], prefix) == 0) {
+                return i;
+            }
+        }
+        DebugPool::prefixes.push_back(prefix);
+        return DebugPool::prefixes.size() - 1;
+    }
+};
+} // namespace rir
+
+#endif


### PR DESCRIPTION
Adds opcodes which will be removed in the release build, which can be inserted by the compiler and used to debug RIR:

- `tmpSet`: Pops and stores an SEXP in a debug pool, at the given index (get a new index via `DebugPool::addTmp`). Doesn't protect the SEXP
- `tmpGet`: Reads and pushes an SEXP from the debug pool, at the given index
- `assert`: Pops an SEXP, asserts it's `R_TrueValue`
- `print`: Pops an SEXP and prints it
- `printStack`: Prints the top 5 stack contents