### PR TITLE
Fix named counting

### DIFF
--- a/rir/src/compiler/analysis/refrence_count.h
+++ b/rir/src/compiler/analysis/refrence_count.h
@@ -1,0 +1,90 @@
+#ifndef PIR_REFERENCE_COUNT_H
+#define PIR_REFERENCE_COUNT_H
+
+#include "../pir/pir_impl.h"
+#include "generic_static_analysis.h"
+
+namespace rir {
+namespace pir {
+
+struct AUses {
+    std::unordered_map<Instruction*, size_t> uses;
+    AbstractResult mergeExit(const AUses& other) { return merge(other); }
+    AbstractResult merge(const AUses& other) {
+        AbstractResult res;
+        for (auto u : other.uses) {
+            if (!uses.count(u.first)) {
+                uses.emplace(u);
+                res.update();
+            } else if (uses.at(u.first) < u.second) {
+                // used in both branches, use count is the maximum
+                uses.at(u.first) = u.second;
+                res.update();
+            }
+        }
+        return res;
+    }
+    void print(std::ostream&, bool) const {
+        // TODO
+    }
+};
+
+class StaticReferenceCount : public StaticAnalysis<AUses> {
+  public:
+    StaticReferenceCount(ClosureVersion* cls, LogStream& log)
+        : StaticAnalysis("StaticReferenceCountAnalysis", cls, cls, log) {
+        Visitor::run(code->entry, [&](Instruction* i) {
+            if (Phi::Cast(i)) {
+                i->eachArg([&](Value* v) {
+                    if (auto a = Instruction::Cast(v))
+                        alias[i].insert(a);
+                });
+            }
+        });
+    }
+
+  protected:
+    std::unordered_map<Instruction*, SmallSet<Instruction*>> alias;
+
+    AbstractResult apply(AUses& state, Instruction* i) const override {
+        AbstractResult res;
+        if (Phi::Cast(i))
+            return res;
+
+        if (i->needsReferenceCount()) {
+            // This value was used only once in a loop, we can thus
+            // reset the count on redefinition.
+            if (state.uses.count(i) && state.uses.at(i) == 1) {
+                state.uses[i] = 0;
+                res.update();
+            }
+        }
+
+        auto count = [&](Instruction* i) {
+            auto& use = state.uses[i];
+            if (use < 2) {
+                use++;
+                res.update();
+            }
+        };
+
+        auto apply = [&](Value* v) {
+            if (auto j = Instruction::Cast(v)) {
+                if (!j->needsReferenceCount())
+                    return;
+                if (alias.count(j))
+                    for (auto a : alias.at(j))
+                        count(a);
+                else
+                    count(j);
+            }
+        };
+
+        i->eachArg(apply);
+        return res;
+    }
+};
+}
+}
+
+#endif

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -601,6 +601,7 @@ class FLI(LdConst, 0, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), c());
     }
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(LdFun, 2, Effects::Any()) {
@@ -634,6 +635,8 @@ class FLIE(LdFun, 2, Effects::Any()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(LdVar, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
@@ -653,6 +656,8 @@ class FLIE(LdVar, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLI(ForSeqSize, 1, Effect::Error) {
@@ -740,6 +745,8 @@ class FLIE(LdVarSuper, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(StVar, 2, Effect::WritesEnv) {
@@ -828,6 +835,8 @@ class FLIE(MkArg, 2, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), prom_);
     }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLI(Seq, 3, Effects::None()) {
@@ -849,6 +858,8 @@ class FLIE(MkCls, 4, Effects::None()) {
 
     Value* lexicalEnv() const { return env(); }
 
+    bool needsReferenceCount() const override { return false; }
+
   private:
     using FixedLenInstructionWithEnvSlot::env;
 };
@@ -865,6 +876,8 @@ class FLIE(MkFunCls, 1, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), cls);
     }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(Force, 2, Effects::Any()) {
@@ -1491,6 +1504,8 @@ class VLIE(MkEnv, Effects::None()) {
     size_t nLocals() { return nargs() - 1; }
 
     size_t gvnBase() const override { return (size_t)this; }
+
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLI(IsObject, 1, Effects::None()) {

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -49,6 +49,10 @@ class Value {
         return type != PirType::voyd() &&
                (type.isRType() || type == NativeType::test);
     }
+
+    virtual bool needsReferenceCount() const {
+        return type.maybeReferenceCounted();
+    }
 };
 
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -4,6 +4,7 @@
 #include "../../transform/bb.h"
 #include "../../util/cfg.h"
 #include "../../util/visitor.h"
+#include "compiler/analysis/refrence_count.h"
 #include "compiler/analysis/verifier.h"
 #include "interpreter/instance.h"
 #include "ir/CodeStream.h"
@@ -707,93 +708,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
     std::unordered_map<Instruction*, bool> needsEnsureNamed;
     {
-        std::unordered_map<Instruction*, SmallSet<Instruction*>> alias;
-        Visitor::run(code->entry, [&](Instruction* i) {
-            if (Phi::Cast(i)) {
-                i->eachArg([&](Value* v) {
-                    if (auto a = Instruction::Cast(v))
-                        alias[i].insert(a);
-                });
-            }
-        });
-
-        struct AUses {
-            std::unordered_map<Instruction*, size_t> uses;
-            AbstractResult mergeExit(const AUses& other) {
-                return merge(other);
-            }
-            AbstractResult merge(const AUses& other) {
-                AbstractResult res;
-                for (auto u : other.uses) {
-                    // used in both branches, use count is the maximum
-                    if (!uses.count(u.first)) {
-                        uses.emplace(u);
-                        res.update();
-                    } else if (uses.at(u.first) < u.second) {
-                        uses.at(u.first) = u.second;
-                        res.update();
-                    }
-                }
-                return res;
-            }
-            void print(std::ostream&, bool) const {
-                // TODO
-            }
-        };
-
-        class UseAnalysis : public StaticAnalysis<AUses> {
-          public:
-            UseAnalysis(ClosureVersion* cls,
-                        const std::unordered_map<Instruction*,
-                                                 SmallSet<Instruction*>>& alias,
-                        LogStream& log)
-                : StaticAnalysis("UseAnalysis", cls, cls, log), alias(alias) {}
-
-          protected:
-            const std::unordered_map<Instruction*, SmallSet<Instruction*>>&
-                alias;
-
-            AbstractResult apply(AUses& state, Instruction* i) const override {
-                AbstractResult res;
-                if (Phi::Cast(i))
-                    return res;
-
-                if (i->needsReferenceCount()) {
-                    // This value was used only once in a loop, we can thus
-                    // reset the count on
-                    // redefinition.
-                    if (state.uses.count(i) && state.uses.at(i) == 1) {
-                        state.uses[i] = 0;
-                        res.update();
-                    }
-                }
-
-                auto count = [&](Instruction* i) {
-                    auto& use = state.uses[i];
-                    if (use < 2) {
-                        use++;
-                        res.update();
-                    }
-                };
-
-                auto apply = [&](Value* v) {
-                    if (auto j = Instruction::Cast(v)) {
-                        if (!j->needsReferenceCount())
-                            return;
-                        if (alias.count(j))
-                            for (auto a : alias.at(j))
-                                count(a);
-                        else
-                            count(j);
-                    }
-                };
-
-                i->eachArg(apply);
-                return res;
-            }
-        };
-
-        UseAnalysis analysis(cls, alias, log);
+        StaticReferenceCount analysis(cls, log);
         for (auto& u : analysis.result().uses) {
             if (u.second > 1)
                 needsEnsureNamed[u.first] = u.second;

--- a/rir/src/utils/EnumSet.h
+++ b/rir/src/utils/EnumSet.h
@@ -69,7 +69,7 @@ class EnumSet {
         return !EnumSet(s.set_ & set_).empty();
     }
 
-    RIR_INLINE bool includes(const EnumSet& s) const {
+    RIR_INLINE bool constexpr includes(const EnumSet& s) const {
         return (s.set_ & set_) == s.set_;
     }
 

--- a/rir/src/utils/Set.h
+++ b/rir/src/utils/Set.h
@@ -60,6 +60,8 @@ class SmallSet {
     iterator end() { return container.end(); }
     const_iterator cbegin() const { return container.cbegin(); }
     const_iterator cend() const { return container.cend(); }
+    const_iterator begin() const { return container.cbegin(); }
+    const_iterator end() const { return container.cend(); }
 };
 }
 


### PR DESCRIPTION
fix and improve static reference count

to compute the static reference count we need a static analysis. The
reason is that in

    create a
    loop {
      consume a
    }

we must know that a is used multiple times. Our old one-pass analysis
would think that it is used only once, even though it is in a loop.

on the other hand we can improve the precision with this commit. In both
cases:

    create a
    if (...)
       consume a
    else
       consume a

and

    loop {
      create a
      ...
      consume a
    }

the value a can have only one use at runtime