### PR TITLE
fix inc_ and setShared_

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -768,7 +768,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     case Opcode::push_code_:
     case Opcode::set_names_:
     case Opcode::names_:
-    case Opcode::make_unique_:
 
     // Invalid opcodes:
     case Opcode::invalid_:

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2190,13 +2190,13 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP val = ostack_top(ctx);
             assert(TYPEOF(val) == INTSXP);
             int i = INTEGER(val)[0];
-            if (MAYBE_SHARED(val)) {
+            if (NO_REFERENCES(val)) {
+                INTEGER(val)[0]++;
+            } else {
                 ostack_pop(ctx);
                 SEXP n = Rf_allocVector(INTSXP, 1);
                 INTEGER(n)[0] = i + 1;
                 ostack_push(ctx, n);
-            } else {
-                INTEGER(val)[0]++;
             }
             NEXT();
         }
@@ -3324,17 +3324,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(set_shared_) {
             SEXP val = ostack_top(ctx);
-            INCREMENT_NAMED(val);
-            NEXT();
-        }
-
-        INSTRUCTION(make_unique_) {
-            SEXP val = ostack_top(ctx);
-            if (MAYBE_SHARED(val)) {
-                val = Rf_shallow_duplicate(val);
-                ostack_set(ctx, 0, val);
-                SET_NAMED(val, 1);
-            }
+            if (NAMED(val) < 2)
+                SET_NAMED(val, 2);
             NEXT();
         }
 

--- a/rir/src/ir/BC_noarg_list.h
+++ b/rir/src/ir/BC_noarg_list.h
@@ -50,7 +50,6 @@
     V(NESTED, ne, ne)                                                          \
     V(NESTED, seq, seq)                                                        \
     V(NESTED, colon, colon)                                                    \
-    V(NESTED, makeUnique, make_unique)                                         \
     V(NESTED, setShared, set_shared)                                           \
     V(NESTED, ensureNamed, ensure_named)                                       \
     V(NESTED, asLogical, aslogical)                                            \

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -156,7 +156,6 @@ static Sources hasSources(Opcode bc) {
     case Opcode::dup2_:
     case Opcode::for_seq_size_:
     case Opcode::swap_:
-    case Opcode::make_unique_:
     case Opcode::set_shared_:
     case Opcode::ensure_named_:
     case Opcode::return_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -444,11 +444,6 @@ DEF_INSTR(set_shared_, 0, 1, 1, 1)
 DEF_INSTR(ensure_named_, 0, 1, 1, 1)
 
 /**
- * make_unique_:: duplicates tos if it is shared (ie. named > 1)
- */
-DEF_INSTR(make_unique_, 0, 1, 1, 1)
-
-/**
  * beginloop_:: begins loop context, break and continue target immediate (this is the target for break and next long jumps)
  */
 DEF_INSTR(beginloop_, 1, 0, 0, 0)


### PR DESCRIPTION
inc can only modify in-place if the reference count is zero. Thanks
@Jakobeha for spotting the bug.

Also setShared should (as the name suggests) not randomly increment, but
actually just ensure that named is at least 2.

also remove unused bc makeUnique