### PR TITLE
inc is intended to increment in-place

### DIFF
--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -51,13 +51,15 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
                         if (auto a = Instruction::Cast(v)) {
                             if (Phi::Cast(a)) {
                                 for (auto otherAlias : alias[a]) {
-                                    if (!alias[i].includes(otherAlias)) {
+                                    if (otherAlias->needsReferenceCount() &&
+                                        !alias[i].includes(otherAlias)) {
                                         changed = true;
                                         alias[i].insert(otherAlias);
                                     }
                                 }
                             } else {
-                                if (!alias[i].includes(a)) {
+                                if (a->needsReferenceCount() &&
+                                    !alias[i].includes(a)) {
                                     changed = true;
                                     alias[i].insert(a);
                                 }
@@ -126,7 +128,7 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
         case Tag::Subassign2_2D:
         case Tag::Inc:
             if (auto input = Instruction::Cast(i->arg(0).val())) {
-                if (state.uses.count(input) &&
+                if (input->needsReferenceCount() && state.uses.count(input) &&
                     state.uses.at(input) == AUses::Multiple) {
                     state.uses[input] = AUses::Destructive;
                     res.update();

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -313,6 +313,9 @@ LdConst::LdConst(SEXP c, PirType t)
     : FixedLenInstruction(t), idx(Pool::insert(c)) {}
 LdConst::LdConst(SEXP c)
     : FixedLenInstruction(PirType(c)), idx(Pool::insert(c)) {}
+LdConst::LdConst(int num)
+    : FixedLenInstruction(PirType(RType::integer).scalar().notObject()),
+      idx(Pool::getInt(num)) {}
 
 SEXP LdConst::c() const { return Pool::get(idx); }
 

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -276,8 +276,6 @@ bool Instruction::usesDoNotInclude(BB* target, std::unordered_set<Tag> tags) {
 const Value* Instruction::cFollowCasts() const {
     if (auto cast = CastType::Cast(this))
         return cast->arg<0>().val()->followCasts();
-    if (auto shared = SetShared::Cast(this))
-        return shared->arg<0>().val()->followCasts();
     if (auto chk = ChkClosure::Cast(this))
         return chk->arg<0>().val()->followCasts();
     return this;
@@ -291,8 +289,6 @@ const Value* Instruction::cFollowCastsAndForce() const {
     if (auto mkarg = MkArg::Cast(this))
         if (mkarg->isEager())
             return mkarg->eagerArg()->followCastsAndForce();
-    if (auto shared = SetShared::Cast(this))
-        return shared->arg<0>().val()->followCastsAndForce();
     if (auto chk = ChkClosure::Cast(this))
         return chk->arg<0>().val()->followCastsAndForce();
     return this;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1047,6 +1047,14 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     }
 };
 
+class FLI(Inc, 1, Effects::None()) {
+  public:
+    explicit Inc(Value* v)
+        : FixedLenInstruction(PirType(RType::integer).scalar().notObject(),
+                              {{PirType(RType::integer).scalar().notObject()}},
+                              {{v}}) {}
+};
+
 class FLI(Is, 1, Effects::None()) {
   public:
     Is(uint32_t sexpTag, Value* v)

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -661,8 +661,6 @@ class FLIE(LdVar, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
-
-    bool needsReferenceCount() const override { return false; }
 };
 
 class FLI(ForSeqSize, 1, Effect::Error) {
@@ -683,6 +681,7 @@ class FLI(LdArg, 0, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), id);
     }
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(Missing, 1, Effects() | Effect::ReadsEnv) {
@@ -750,8 +749,6 @@ class FLIE(LdVarSuper, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
-
-    bool needsReferenceCount() const override { return false; }
 };
 
 class FLIE(StVar, 2, Effect::WritesEnv) {
@@ -904,6 +901,7 @@ class FLIE(Force, 2, Effects::Any()) {
             effects.reset();
         }
     }
+    bool needsReferenceCount() const override { return false; }
 };
 
 class FLI(CastType, 1, Effects::None()) {
@@ -1087,6 +1085,9 @@ class FLI(PirCopy, 1, Effects::None()) {
         : FixedLenInstruction(v->type, {{v->type}}, {{v}}) {}
     void print(std::ostream& out, bool tty) const override;
     void updateType() override final { type = arg<0>().val()->type; }
+    bool needsReferenceCount() const override {
+        return arg<0>().val()->needsReferenceCount();
+    }
 };
 
 // Effects::Any() prevents this instruction from being optimized away

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -601,6 +601,7 @@ class FLI(LdConst, 0, Effects::None()) {
     SEXP c() const;
     LdConst(SEXP c, PirType t);
     explicit LdConst(SEXP c);
+    explicit LdConst(int i);
     void printArgs(std::ostream& out, bool tty) const override;
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), c());
@@ -1044,14 +1045,6 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
     }
-};
-
-class FLI(Inc, 1, Effects::None()) {
-  public:
-    explicit Inc(Value* v)
-        : FixedLenInstruction(PirType(RType::integer).scalar().notObject(),
-                              {{PirType(RType::integer).scalar().notObject()}},
-                              {{v}}) {}
 };
 
 class FLI(Is, 1, Effects::None()) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1071,13 +1071,6 @@ class FLI(LdFunctionEnv, 0, Effects::None()) {
     LdFunctionEnv() : FixedLenInstruction(RType::env) {}
 };
 
-class FLI(SetShared, 1, Effects::None()) {
-  public:
-    explicit SetShared(Value* v)
-        : FixedLenInstruction(v->type, {{v->type}}, {{v}}) {}
-    void updateType() override final { type = arg<0>().val()->type; }
-};
-
 class FLI(Visible, 0, Effect::Visibility) {
   public:
     explicit Visible() : FixedLenInstruction(PirType::voyd()) {}

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -83,7 +83,6 @@
     V(ScheduledDeopt)                                                          \
     V(Force)                                                                   \
     V(CastType)                                                                \
-    V(SetShared)                                                               \
     V(Missing)                                                                 \
     V(Visible)                                                                 \
     V(Invisible)                                                               \

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -68,7 +68,6 @@
     V(LdFunctionEnv)                                                           \
     V(LAnd)                                                                    \
     V(LOr)                                                                     \
-    V(Inc)                                                                     \
     V(Not)                                                                     \
     V(Is)                                                                      \
     V(Plus)                                                                    \

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -69,6 +69,7 @@
     V(LAnd)                                                                    \
     V(LOr)                                                                     \
     V(Not)                                                                     \
+    V(Inc)                                                                     \
     V(Is)                                                                      \
     V(Plus)                                                                    \
     V(Minus)                                                                   \

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1017,7 +1017,6 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE(IsEnvStub, isstubenv);
                 SIMPLE(LOr, lglOr);
                 SIMPLE(LAnd, lglAnd);
-                SIMPLE(Inc, inc);
                 SIMPLE(Force, force);
                 SIMPLE(AsTest, asbool);
                 SIMPLE(Length, length);

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -706,12 +706,12 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             order.push_back(bb->id);
     });
 
-    std::unordered_map<Instruction*, size_t> needsRefcount;
+    std::unordered_map<Instruction*, AUses::Kind> needsRefcount;
     {
         StaticReferenceCount analysis(cls, log);
         for (auto& u : analysis.result().uses) {
-            if (u.second > 1)
-                needsRefcount[u.first] = u.second - 1;
+            if (u.second > AUses::Once)
+                needsRefcount[u.first] = u.second;
         }
     }
 
@@ -1239,9 +1239,9 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
 
             if (instr->needsReferenceCount()) {
-                if (needsRefcount[instr] == 1)
+                if (needsRefcount[instr] == AUses::Multiple)
                     cb.add(BC::ensureNamed());
-                else if (needsRefcount[instr] == 2)
+                else if (needsRefcount[instr] == AUses::Destructive)
                     cb.add(BC::setShared());
             }
 

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1025,7 +1025,6 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE(ChkClosure, isfun);
                 SIMPLE(Seq, seq);
                 SIMPLE(MkCls, close);
-                SIMPLE(SetShared, setShared);
 #define V(V, name, Name) SIMPLE(Name, name);
                 SIMPLE_INSTRUCTIONS(V, _);
 #undef V

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -4,7 +4,7 @@
 #include "../../transform/bb.h"
 #include "../../util/cfg.h"
 #include "../../util/visitor.h"
-#include "compiler/analysis/refrence_count.h"
+#include "compiler/analysis/reference_count.h"
 #include "compiler/analysis/verifier.h"
 #include "interpreter/instance.h"
 #include "ir/CodeStream.h"

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -694,6 +694,13 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         UNOP(Not, not_);
 #undef UNOP
 
+    case Opcode::inc_: {
+        auto one = insert(new LdConst(1));
+        auto inc = insert(new Add(one, pop(), Env::elided(), -1));
+        push(inc);
+        break;
+    }
+
 #define UNOP_NOENV(Name, Op)                                                   \
     case Opcode::Op: {                                                         \
         v = pop();                                                             \
@@ -701,7 +708,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;                                                                 \
     }
         UNOP_NOENV(Length, length_);
-        UNOP_NOENV(Inc, inc_);
 #undef UNOP_NOENV
 
     case Opcode::missing_:

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -694,13 +694,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         UNOP(Not, not_);
 #undef UNOP
 
-    case Opcode::inc_: {
-        auto one = insert(new LdConst(1));
-        auto inc = insert(new Add(one, pop(), Env::elided(), -1));
-        push(inc);
-        break;
-    }
-
 #define UNOP_NOENV(Name, Op)                                                   \
     case Opcode::Op: {                                                         \
         v = pop();                                                             \
@@ -708,6 +701,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;                                                                 \
     }
         UNOP_NOENV(Length, length_);
+        UNOP_NOENV(Inc, inc_);
 #undef UNOP_NOENV
 
     case Opcode::missing_:

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -735,11 +735,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     }
 
     case Opcode::ensure_named_:
-        // Recomputed automatically in the backend
-        break;
-
     case Opcode::set_shared_:
-        push(insert(new SetShared(pop())));
+        // Recomputed automatically in the backend
         break;
 
     case Opcode::invisible_:

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2814,6 +2814,9 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP vec = ostack_at(ctx, 1);
             SEXP val = ostack_at(ctx, 2);
 
+            // Destructively modifies TOS, even if the refcount is 1. This is
+            // intended, to avoid copying. Care need to be taken if `vec` is
+            // used multiple times as a temporary.
             if (MAYBE_SHARED(vec)) {
                 vec = Rf_duplicate(vec);
                 ostack_set(ctx, 1, vec);
@@ -2852,6 +2855,9 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SEXP mtx = ostack_at(ctx, 2);
             SEXP val = ostack_at(ctx, 3);
 
+            // Destructively modifies TOS, even if the refcount is 1. This is
+            // intended, to avoid copying. Care need to be taken if `vec` is
+            // used multiple times as a temporary.
             if (MAYBE_SHARED(mtx)) {
                 mtx = Rf_duplicate(mtx);
                 ostack_set(ctx, 2, mtx);
@@ -2943,6 +2949,9 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 }
             }
 
+            // Destructively modifies TOS, even if the refcount is 1. This is
+            // intended, to avoid copying. Care need to be taken if `vec` is
+            // used multiple times as a temporary.
             if (MAYBE_SHARED(vec)) {
                 vec = Rf_duplicate(vec);
                 ostack_set(ctx, 1, vec);
@@ -3051,6 +3060,9 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 }
             }
 
+            // Destructively modifies TOS, even if the refcount is 1. This is
+            // intended, to avoid copying. Care need to be taken if `vec` is
+            // used multiple times as a temporary.
             if (MAYBE_SHARED(mtx)) {
                 mtx = Rf_duplicate(mtx);
                 ostack_set(ctx, 2, mtx);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2164,15 +2164,19 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(inc_) {
             SEXP val = ostack_top(ctx);
-            assert(TYPEOF(val) == INTSXP);
-            int i = INTEGER(val)[0];
-            if (NO_REFERENCES(val)) {
-                INTEGER(val)[0]++;
-            } else {
+            SLOWASSERT(TYPEOF(val) == INTSXP);
+            // Inc_ destructively modifies TOS, even if the refcount is 1. This
+            // can be used to perform `++i` on a value on the stack. The old i
+            // value will be overwritten (generally only do this if you are sure
+            // that this is the last copy on the stack).
+            if (MAYBE_SHARED(val)) {
+                int i = INTEGER(val)[0];
                 ostack_pop(ctx);
                 SEXP n = Rf_allocVector(INTSXP, 1);
                 INTEGER(n)[0] = i + 1;
                 ostack_push(ctx, n);
+            } else {
+                INTEGER(val)[0]++;
             }
             NEXT();
         }

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -242,7 +242,7 @@ DEF_INSTR(add_, 0, 2, 1, 0)
 DEF_INSTR(uplus_, 0, 1, 1, 0)
 
 /**
- * inc_ :: increment tos integer
+ * inc_ :: increment tos integer (destructive! ignores refcount)
  */
 DEF_INSTR(inc_, 0, 1, 1, 1)
 

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -355,11 +355,21 @@ DEF_INSTR(extract1_2_, 0, 3, 1, 1)
 
 /**
  * subassign1_1_ :: a[b] <- c
+ *
+ * this instruction creates the rhs part of a <- `[<-(a,b,c)` and still needs
+ * to be assigned.
+ *
+ * Warning: on named == 1 it updates the array in-place!
  */
 DEF_INSTR(subassign1_1_, 0, 3, 1, 1)
 
 /**
  * subassign1_2_ :: a[b,c] <- d
+ *
+ * this instruction creates the rhs part of a <- `[<-(a,b,c,d)` and still needs
+ * to be assigned.
+ *
+ * Warning: on named == 1 it updates the array in-place!
  */
 DEF_INSTR(subassign1_2_, 0, 4, 1, 1)
 
@@ -375,11 +385,21 @@ DEF_INSTR(extract2_2_, 0, 3, 1, 1)
 
 /**
  * subassign2_1 :: a[[b]] <- c
+ *
+ * this instruction creates the rhs part of a <- `[[<-(a,b,c)` and still needs
+ * to be assigned.
+ *
+ * Warning: on named == 1 it updates the array in-place!
  */
 DEF_INSTR(subassign2_1_, 0, 3, 1, 1)
 
 /**
  * subassign2_2_ :: a[[b,c]] <- d
+ *
+ * this instruction creates the rhs part of a <- `[[<-(a,b,c,c)` and still needs
+ * to be assigned.
+ *
+ * Warning: on named == 1 it updates the array in-place!
  */
 DEF_INSTR(subassign2_2_, 0, 4, 1, 1)
 


### PR DESCRIPTION
I remembered, that inc_ is supposed to update in-place, even if the
refcount is 1.

That was a feature, not a bug, to be able to increment the loop counter
without creating a new vector all the time.

So the idea is we compile the for loop as follows:

    %i = 0
    while (%i < size(seq))
      ...
      %i++

now, we need to mark the (stack) value %i ensureNamed, because
otherwise the < comparison might override it (values with refcount 0
can be reused). But then the i++ at the end of the loop, should
still be able to increment i without duplicating it. so the inc
bytecode is allowed to destructively modify it

but, the pir version of inc was broken, because the pir optimizer did
not preserve this invariant, that an inc'd value is not used anymore
after the operation.

for now I replaced it by a normal add. this might have potential
performance issues, but we need to solve them differently.