### PR TITLE
type inference pass

### DIFF
--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -76,7 +76,7 @@ class TheCleanup {
                     }
                 } else if (auto lgl = AsLogical::Cast(i)) {
                     auto arg = lgl->arg<0>().val();
-                    if (arg->type.isA(RType::logical)) {
+                    if (arg->type.isA(PirType::simpleScalarLogical())) {
                         lgl->replaceUsesWith(arg);
                         removed = true;
                         next = bb->remove(ip);

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -211,18 +211,26 @@ class TheInliner {
                         if (ld) {
                             Value* a = arguments[ld->id];
                             if (auto mk = MkArg::Cast(a)) {
-                                // We need to cast from a promise to a lazy
-                                // value
-                                auto cast =
-                                    new CastType(a, RType::prom,
-                                                 mk->isEager()
-                                                     ? mk->eagerArg()
-                                                           ->type.forced()
-                                                           .promiseWrappedVal()
-                                                     : ld->type);
-                                ip = bb->insert(ip + 1, cast);
-                                ip--;
-                                a = cast;
+                                if (!ld->type.maybePromiseWrapped()) {
+                                    // This load already expects to load an
+                                    // eager value. We can just discard the
+                                    // promise altogether.
+                                    assert(mk->isEager());
+                                    a = mk->eagerArg();
+                                } else {
+                                    // We need to cast from a promise to a lazy
+                                    // value
+                                    auto type = mk->isEager()
+                                                    ? mk->eagerArg()
+                                                          ->type.forced()
+                                                          .orPromiseWrapped()
+                                                    : ld->type;
+                                    auto cast =
+                                        new CastType(a, RType::prom, type);
+                                    ip = bb->insert(ip + 1, cast);
+                                    ip--;
+                                    a = cast;
+                                }
                             }
                             ld->replaceUsesWith(a);
                             next = bb->remove(ip);

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -129,6 +129,8 @@ class PASS(GVN);
 
 class PASS(LoadElision);
 
+class PASS(TypeInference);
+
 class PhaseMarker : public PirTranslator {
   public:
     explicit PhaseMarker(const std::string& name) : PirTranslator(name) {}

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -1,0 +1,82 @@
+#include "../pir/pir_impl.h"
+#include "../translations/pir_translator.h"
+#include "../util/cfg.h"
+#include "../util/visitor.h"
+
+#include "../analysis/abstract_value.h"
+
+#include "pass_definitions.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rir {
+namespace pir {
+
+void TypeInference::apply(RirCompiler&, ClosureVersion* function,
+                          LogStream& log) const {
+
+    std::unordered_map<Instruction*, PirType> types;
+    {
+        bool done = false;
+        auto apply = [&]() {
+            Visitor::run(function->entry, [&](Instruction* i) {
+                if (!i->producesRirResult())
+                    return;
+
+                PirType infered = PirType::bottom();
+                switch (i->tag) {
+                case Tag::Mul:
+                case Tag::Div:
+                case Tag::IDiv:
+                case Tag::Mod:
+                case Tag::Add:
+                case Tag::Pow:
+                case Tag::Sub:
+                case Tag::Not:
+                case Tag::Plus:
+                case Tag::Minus:
+                case Tag::Phi: {
+                    i->eachArg([&](Value* v) {
+                        if (i->mayHaveEnv() && v == i->env())
+                            return;
+                        if (auto arg = Instruction::Cast(v)) {
+                            if (types.count(arg))
+                                infered = infered | types.at(arg);
+                            else
+                                done = false;
+                        } else {
+                            infered = infered | v->type;
+                        }
+                    });
+                    if (i->tag == Tag::Div && infered.isA(RType::integer)) {
+                        infered = infered | RType::real;
+                    }
+                    break;
+                }
+                default:
+                    infered = i->type;
+                }
+
+                if (!types.count(i) || types.at(i) != infered) {
+                    done = false;
+                    types[i] = infered;
+                }
+            });
+        };
+        while (!done) {
+            done = true;
+            apply();
+        }
+    }
+
+    Visitor::run(function->entry, [&](Instruction* i) {
+        if (!i->producesRirResult())
+            return;
+        if (types.count(i))
+            i->type = types.at(i);
+    });
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -54,6 +54,19 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                     }
                     break;
                 }
+                case Tag::Assume: {
+                    auto assumption = Assume::Cast(i);
+                    if (!assumption->assumeTrue)
+                        if (auto isO = IsObject::Cast(assumption->condition()))
+                            if (auto val =
+                                    Instruction::Cast(isO->arg<0>().val())) {
+                                if (types.count(val))
+                                    infered = types.at(val).notObject();
+                                else
+                                    infered = val->type.notObject();
+                            }
+                    break;
+                }
                 default:
                     infered = i->type;
                 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -182,7 +182,7 @@ static void checkReplace(Instruction* origin, Value* replace) {
         std::cerr << " with a ";
         replace->type.print(std::cerr);
         std::cerr << "\n";
-        printBacktrace();
+        origin->bb()->owner->printCode(std::cout, true, false);
         assert(false);
     }
 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -427,7 +427,7 @@ void PirCopy::print(std::ostream& out, bool tty) const {
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
                                  unsigned srcIdx)
-    : VarLenInstruction(PirType::val(), srcIdx), blt(builtin),
+    : VarLenInstruction(PirType::val().notObject(), srcIdx), blt(builtin),
       builtin(getBuiltin(builtin)), builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
         this->pushArg(args[i], PirType::val());

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -182,6 +182,8 @@ class Instruction : public Value {
                                                        Effect::Visibility) {
         bool maybeObj = false;
         eachArg([&](Value* v) {
+            if (mayHaveEnv() && env() == v)
+                return;
             if (v->type.maybeObj())
                 maybeObj = true;
         });
@@ -196,6 +198,8 @@ class Instruction : public Value {
             return;
         bool scalar = true;
         eachArg([&](Value* v) {
+            if (mayHaveEnv() && env() == v)
+                return;
             if (!v->type.isScalar())
                 scalar = false;
         });
@@ -684,7 +688,7 @@ class FLIE(Missing, 1, Effects() | Effect::ReadsEnv) {
   public:
     SEXP varName;
     explicit Missing(SEXP varName, Value* env)
-        : FixedLenInstructionWithEnvSlot(RType::logical, env),
+        : FixedLenInstructionWithEnvSlot(PirType::simpleScalarLogical(), env),
           varName(varName) {}
     void printArgs(std::ostream& out, bool tty) const override;
 
@@ -843,10 +847,14 @@ class FLI(Seq, 3, Effects::None()) {
   public:
     Seq(Value* start, Value* end, Value* step)
         : FixedLenInstruction(
-              PirType::num(),
+              PirType::any(),
               // TODO: require scalars, but this needs some cast support
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{start, end, step}}) {}
+
+    void updateType() override final {
+        maskEffectsAndTypeOnNonObjects(PirType::num().notObject());
+    }
 };
 
 class FLIE(MkCls, 4, Effects::None()) {
@@ -906,8 +914,8 @@ class FLI(CastType, 1, Effects::None()) {
 class FLI(AsLogical, 1, Effect::Warn) {
   public:
     AsLogical(Value* in, unsigned srcIdx)
-        : FixedLenInstruction(RType::logical, {{PirType::val()}}, {{in}},
-                              srcIdx) {}
+        : FixedLenInstruction(PirType::simpleScalarLogical(),
+                              {{PirType::val()}}, {{in}}, srcIdx) {}
 };
 
 class FLI(AsTest, 1, Effect::Error) {
@@ -928,7 +936,7 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* lhs() { return arg(1).val(); }
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
     }
 };
 
@@ -944,7 +952,7 @@ class FLIE(Subassign2_1D, 4, Effects::Any()) {
     Value* lhs() { return arg(1).val(); }
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
     }
 };
 
@@ -962,7 +970,7 @@ class FLIE(Subassign1_2D, 5, Effects::Any()) {
     Value* idx1() { return arg(2).val(); }
     Value* idx2() { return arg(3).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
     }
 };
 
@@ -980,7 +988,7 @@ class FLIE(Subassign2_2D, 5, Effects::Any()) {
     Value* idx1() { return arg(2).val(); }
     Value* idx2() { return arg(3).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
     }
 };
 
@@ -991,7 +999,10 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        auto t = arg<0>().val()->type;
+        if (arg<1>().val()->type.isScalar())
+            t.setScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 
@@ -1002,7 +1013,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val().scalar());
+        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
     }
 };
 
@@ -1015,7 +1026,10 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val());
+        auto t = arg<0>().val()->type;
+        if (arg<1>().val()->type.isScalar())
+            t.setScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 
@@ -1028,7 +1042,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(PirType::val().scalar());
+        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
     }
 };
 
@@ -1043,7 +1057,7 @@ class FLI(Inc, 1, Effects::None()) {
 class FLI(Is, 1, Effects::None()) {
   public:
     Is(uint32_t sexpTag, Value* v)
-        : FixedLenInstruction(PirType(RType::logical).scalar(),
+        : FixedLenInstruction(PirType::simpleScalarLogical(),
                               {{PirType::val()}}, {{v}}),
           sexpTag(sexpTag) {}
     uint32_t sexpTag;
@@ -1122,21 +1136,23 @@ SIMPLE_INSTRUCTIONS(V, _)
             maskEffectsAndTypeOnNonObjects(Type);                              \
             updateScalarOnScalarInputs();                                      \
         }                                                                      \
+        Value* lhs() const { return arg<0>().val(); }                          \
+        Value* rhs() const { return arg<1>().val(); }                          \
     }
 
-BINOP(Mul, PirType::val());
-BINOP(Div, PirType::val());
-BINOP(IDiv, PirType::val());
-BINOP(Mod, PirType::val());
-BINOP(Add, PirType::val());
-BINOP(Pow, PirType::val());
-BINOP(Sub, PirType::val());
-BINOP(Gte, RType::logical);
-BINOP(Lte, RType::logical);
-BINOP(Gt, RType::logical);
-BINOP(Lt, RType::logical);
-BINOP(Neq, RType::logical);
-BINOP(Eq, RType::logical);
+BINOP(Mul, lhs()->type | rhs()->type);
+BINOP(Div, PirType::val().notObject());
+BINOP(IDiv, lhs()->type | rhs()->type);
+BINOP(Mod, lhs()->type | rhs()->type);
+BINOP(Add, lhs()->type | rhs()->type);
+BINOP(Pow, lhs()->type | rhs()->type);
+BINOP(Sub, lhs()->type | rhs()->type);
+BINOP(Gte, PirType(RType::logical).notObject());
+BINOP(Lte, PirType(RType::logical).notObject());
+BINOP(Gt, PirType(RType::logical).notObject());
+BINOP(Lt, PirType(RType::logical).notObject());
+BINOP(Neq, PirType(RType::logical).notObject());
+BINOP(Eq, PirType(RType::logical).notObject());
 
 #undef BINOP
 
@@ -1148,8 +1164,8 @@ BINOP(Eq, RType::logical);
                                   {{lhs, rhs}}) {}                             \
     }
 
-BINOP_NOENV(LAnd, RType::logical);
-BINOP_NOENV(LOr, RType::logical);
+BINOP_NOENV(LAnd, PirType::simpleScalarLogical());
+BINOP_NOENV(LOr, PirType::simpleScalarLogical());
 
 #undef BINOP_NOENV
 
@@ -1161,7 +1177,7 @@ BINOP_NOENV(LOr, RType::logical);
                                              {{PirType::val()}}, {{v}}, env,   \
                                              srcIdx) {}                        \
         void updateType() override final {                                     \
-            maskEffectsAndTypeOnNonObjects(PirType::val());                    \
+            maskEffectsAndTypeOnNonObjects(arg<0>().val()->type);              \
             updateScalarOnScalarInputs();                                      \
         }                                                                      \
     }
@@ -1169,9 +1185,15 @@ BINOP_NOENV(LOr, RType::logical);
 UNOP(Not);
 UNOP(Plus);
 UNOP(Minus);
-UNOP(Length);
 
 #undef UNOP
+
+class FLI(Length, 1, Effects::None()) {
+  public:
+    explicit Length(Value* v)
+        : FixedLenInstruction(PirType::simpleScalarInt(), {{PirType::val()}},
+                              {{v}}) {}
+};
 
 struct RirStack {
   private:

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -187,9 +187,22 @@ struct PirType {
     static constexpr PirType vecs() { return num() | RType::str | RType::vec; }
     static constexpr PirType closure() { return RType::closure; }
 
+    static constexpr PirType simpleScalarInt() {
+        return PirType(RType::integer).notObject().scalar();
+    }
+
+    static constexpr PirType simpleScalarReal() {
+        return PirType(RType::real).notObject().scalar();
+    }
+
+    static constexpr PirType simpleScalarLogical() {
+        return PirType(RType::logical).notObject().scalar();
+    }
+
     static constexpr PirType promiseWrappedVal() {
         return val().orPromiseWrapped();
     }
+
     static constexpr PirType valOrLazy() { return val().orLazy(); }
     static constexpr PirType list() {
         return PirType(RType::cons) | RType::nil;
@@ -261,25 +274,19 @@ struct PirType {
         return isRType() && t_.r.intersects(refcount);
     }
 
-    PirType notObject() const {
+    PirType constexpr notObject() const {
         assert(isRType());
-        PirType t = *this;
-        t.flags_.reset(TypeFlags::maybeObject);
-        return t;
+        return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeObject));
     }
 
-    PirType notMissing() const {
+    PirType constexpr notMissing() const {
         assert(isRType());
-        PirType t = *this;
-        t.t_.r.reset(RType::missing);
-        return t;
+        return PirType(t_.r & ~RTypeSet(RType::missing), flags_);
     }
 
-    RIR_INLINE PirType scalar() const {
+    RIR_INLINE constexpr PirType scalar() const {
         assert(isRType());
-        PirType t = *this;
-        t.flags_.reset(TypeFlags::maybeNotScalar);
-        return t;
+        return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeNotScalar));
     }
 
     RIR_INLINE constexpr PirType orPromiseWrapped() const {
@@ -315,7 +322,7 @@ struct PirType {
     RIR_INLINE void setScalar() { *this = scalar(); }
 
     static const PirType voyd() { return PirType(NativeTypeSet()); }
-    static const PirType bottom() { return PirType(RTypeSet()); }
+    static const PirType bottom() { return optimistic(); }
 
     RIR_INLINE bool operator==(const NativeType& o) const {
         return !isRType() && t_.n == o;

--- a/rir/src/compiler/translations/pir_2_rir/liveness.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/liveness.cpp
@@ -9,6 +9,7 @@ namespace rir {
 namespace pir {
 
 LivenessIntervals::LivenessIntervals(unsigned bbsSize, CFG const& cfg) {
+    maxLive = 0;
 
     // temp list of live out sets for every BB
     std::unordered_map<BB*, std::set<Value*>> liveAtEnd(bbsSize);
@@ -69,8 +70,9 @@ LivenessIntervals::LivenessIntervals(unsigned bbsSize, CFG const& cfg) {
                     });
                 } else {
                     i->eachArg([&](Value* v) {
-                        if (markIfNotSeen(v))
+                        if (markIfNotSeen(v)) {
                             accumulated.insert(v);
+                        }
                     });
                 }
 
@@ -82,6 +84,9 @@ LivenessIntervals::LivenessIntervals(unsigned bbsSize, CFG const& cfg) {
                     liveRange.begin = pos;
                     accumulated.erase(accumulated.find(i));
                 }
+
+                if (accumulated.size() > maxLive)
+                    maxLive = accumulated.size();
             } while (ip != bb->begin());
         }
         assert(pos == 0);

--- a/rir/src/compiler/translations/pir_2_rir/liveness.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/liveness.cpp
@@ -9,8 +9,6 @@ namespace rir {
 namespace pir {
 
 LivenessIntervals::LivenessIntervals(unsigned bbsSize, CFG const& cfg) {
-    maxLive = 0;
-
     // temp list of live out sets for every BB
     std::unordered_map<BB*, std::set<Value*>> liveAtEnd(bbsSize);
 
@@ -85,8 +83,6 @@ LivenessIntervals::LivenessIntervals(unsigned bbsSize, CFG const& cfg) {
                     accumulated.erase(accumulated.find(i));
                 }
 
-                if (accumulated.size() > maxLive)
-                    maxLive = accumulated.size();
             } while (ip != bb->begin());
         }
         assert(pos == 0);

--- a/rir/src/compiler/translations/pir_2_rir/liveness.h
+++ b/rir/src/compiler/translations/pir_2_rir/liveness.h
@@ -33,7 +33,6 @@ struct Liveness : public std::vector<BBLiveness> {
 };
 
 struct LivenessIntervals : public std::unordered_map<Value*, Liveness> {
-    size_t maxLive;
     LivenessIntervals(unsigned bbsSize, CFG const& cfg);
     bool live(Instruction* where, Value* what) const;
 };

--- a/rir/src/compiler/translations/pir_2_rir/liveness.h
+++ b/rir/src/compiler/translations/pir_2_rir/liveness.h
@@ -33,6 +33,7 @@ struct Liveness : public std::vector<BBLiveness> {
 };
 
 struct LivenessIntervals : public std::unordered_map<Value*, Liveness> {
+    size_t maxLive;
     LivenessIntervals(unsigned bbsSize, CFG const& cfg);
     bool live(Instruction* where, Value* what) const;
 };

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -699,7 +699,6 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
 
     LastEnv lastEnv(cls, code, log);
     std::unordered_map<Value*, BC::Label> pushContexts;
-    std::unordered_map<Promise*, unsigned> promMap;
 
     std::deque<unsigned> order;
     LoweringVisitor::run(code->entry, [&](BB* bb) {
@@ -966,9 +965,7 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
 
             case Tag::MkArg: {
                 auto p = MkArg::Cast(instr)->prom();
-                unsigned id = ctx.cs().addPromise(
-                    getPromise(ctx, MkArg::Cast(instr)->prom()));
-                promMap[p] = id;
+                unsigned id = ctx.cs().addPromise(getPromise(ctx, p));
                 cb.add(BC::promise(id));
                 break;
             }

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -489,7 +489,7 @@ class Pir2Rir {
     Pir2Rir(Pir2RirCompiler& cmp, ClosureVersion* cls, bool dryRun,
             LogStream& log)
         : compiler(cmp), cls(cls), dryRun(dryRun), log(log) {}
-    size_t compileCode(Context& ctx, Code* code);
+    rir::Code* compileCode(Context& ctx, Code* code);
     rir::Code* getPromise(Context& ctx, Promise* code);
 
     void lower(Code* code);
@@ -624,6 +624,7 @@ class Pir2Rir {
             } while (changed && steam-- > 0);
         }
 
+      public:
         void flush() {
             peephole();
             for (auto const& instr : code) {
@@ -642,9 +643,8 @@ class Pir2Rir {
             code.clear();
         }
 
-      public:
         explicit CodeBuffer(CodeStream& cs) : cs(cs) {}
-        ~CodeBuffer() { flush(); }
+        ~CodeBuffer() { assert(code.empty()); }
 
         void add(BC&& bc) {
             Src s;
@@ -673,7 +673,7 @@ class Pir2Rir {
     };
 };
 
-size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
+rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
     lower(code);
     toCSSA(code);
 #ifdef ENABLE_SLOWASSERT
@@ -699,6 +699,7 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
 
     LastEnv lastEnv(cls, code, log);
     std::unordered_map<Value*, BC::Label> pushContexts;
+    std::unordered_map<Promise*, unsigned> promMap;
 
     std::deque<unsigned> order;
     LoweringVisitor::run(code->entry, [&](BB* bb) {
@@ -964,8 +965,11 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
 
             case Tag::MkArg: {
-                cb.add(BC::promise(ctx.cs().addPromise(
-                    getPromise(ctx, MkArg::Cast(instr)->prom()))));
+                auto p = MkArg::Cast(instr)->prom();
+                unsigned id = ctx.cs().addPromise(
+                    getPromise(ctx, MkArg::Cast(instr)->prom()));
+                promMap[p] = id;
+                cb.add(BC::promise(id));
                 break;
             }
 
@@ -1258,8 +1262,11 @@ size_t Pir2Rir::compileCode(Context& ctx, Code* code) {
         auto next = jumpThroughEmpty(bb->trueBranch());
         cb.add(BC::br(bbLabels[next]));
     });
+    cb.flush();
 
-    return alloc.slots();
+    auto localsCnt = alloc.slots();
+    auto res = ctx.finalizeCode(localsCnt);
+    return res;
 }
 
 static bool DEBUG_DEOPTS = getenv("PIR_DEBUG_DEOPTS") &&
@@ -1394,8 +1401,7 @@ void Pir2Rir::toCSSA(Code* code) {
 rir::Code* Pir2Rir::getPromise(Context& ctx, Promise* p) {
     if (!promises.count(p)) {
         ctx.push(src_pool_at(globalContext(), p->srcPoolIdx()));
-        size_t localsCnt = compileCode(ctx, p);
-        promises[p] = ctx.finalizeCode(localsCnt);
+        promises[p] = compileCode(ctx, p);
     }
     return promises.at(p);
 }
@@ -1420,9 +1426,8 @@ rir::Function* Pir2Rir::finalize() {
 
     assert(signature.formalNargs() == cls->nargs());
     ctx.push(R_NilValue);
-    size_t localsCnt = compileCode(ctx, cls);
+    auto body = compileCode(ctx, cls);
     log.finalPIR(cls);
-    auto body = ctx.finalizeCode(localsCnt);
     function.finalize(body, signature);
 #ifdef ENABLE_SLOWASSERT
     CodeVerifier::verifyFunctionLayout(function.function()->container(),

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -692,7 +692,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         UNOP(Plus, uplus_);
         UNOP(Minus, uminus_);
         UNOP(Not, not_);
-        UNOP(Length, length_);
 #undef UNOP
 
 #define UNOP_NOENV(Name, Op)                                                   \
@@ -701,6 +700,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         push(insert(new Name(v)));                                             \
         break;                                                                 \
     }
+        UNOP_NOENV(Length, length_);
         UNOP_NOENV(Inc, inc_);
 #undef UNOP_NOENV
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1267,30 +1267,6 @@ static void cachedSetVar(SEXP val, SEXP env, Immediate idx,
 // terrible, can't find out where in the evalRirCode function
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
 
-RCNTXT* getFunctionContext(size_t pos = 0, RCNTXT* cptr = R_GlobalContext) {
-    while (cptr->nextcontext != NULL) {
-        if (cptr->callflag & CTXT_FUNCTION) {
-            if (pos == 0)
-                return cptr;
-            pos--;
-        }
-        cptr = cptr->nextcontext;
-    }
-    assert(false);
-    return nullptr;
-}
-
-RCNTXT* findFunctionContextFor(SEXP e) {
-    auto cptr = R_GlobalContext;
-    while (cptr->nextcontext != NULL) {
-        if (cptr->callflag & CTXT_FUNCTION && cptr->cloenv == e) {
-            return cptr;
-        }
-        cptr = cptr->nextcontext;
-    }
-    return nullptr;
-}
-
 /*
  * This function takes some deopt metadata and stack frame contents on the
  * interpreter stack. It first recursively reconstructs a context for each

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -15,4 +15,32 @@
 #define THREADED_CODE
 #endif
 
+namespace rir {
+
+inline RCNTXT* getFunctionContext(size_t pos = 0,
+                                  RCNTXT* cptr = R_GlobalContext) {
+    while (cptr->nextcontext != NULL) {
+        if (cptr->callflag & CTXT_FUNCTION) {
+            if (pos == 0)
+                return cptr;
+            pos--;
+        }
+        cptr = cptr->nextcontext;
+    }
+    assert(false);
+    return nullptr;
+}
+
+inline RCNTXT* findFunctionContextFor(SEXP e) {
+    auto cptr = R_GlobalContext;
+    while (cptr->nextcontext != NULL) {
+        if (cptr->callflag & CTXT_FUNCTION && cptr->cloenv == e) {
+            return cptr;
+        }
+        cptr = cptr->nextcontext;
+    }
+    return nullptr;
+}
+}
+
 #endif // RIR_INTERPRETER_C_H

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -60,6 +60,7 @@ void Configurations::defaultOptimizations() {
         optimizations.push_back(new pir::GVN());
         optimizations.push_back(new pir::OptimizeAssumptions());
         optimizations.push_back(new pir::Cleanup());
+        optimizations.push_back(new pir::TypeInference());
     };
 
     phasemarker("Initial");


### PR DESCRIPTION
Add a type inference pass that can deal with recursive dependencies
introduced by phis.

Also improve and fix the type annotations on some instructions.

The improved types do not change much yet, but they are important for
native compilation.