### PR TITLE
PIR tests in R

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -1,4 +1,6 @@
-## Debugging PIR
+# Debugging PIR
+
+## Command Line
 
 PIR comes with a variety of options to analyze the output of the compiler in different
 stages. To manage the different options we use environment variables. For instance
@@ -83,3 +85,28 @@ completely disables the PIR optimizer. As follows are the different Options avai
 * `~` : May be wrapped in a promise (but evaluated)
 * `?` : May be missing
 * `'` : May not be an object
+
+## Within R
+
+PIR also adds some functions to the global environment, for the sole purpose of
+debugging:
+
+* `rir.markOptimize`: Tells the compiler to optimize the function
+* `rir.isValidFunction`: Returns TRUE if the argument is a rir-compiled closure
+* `rir.disassemble`: prints the disassembled rir function
+* `rir.printInvocation`: prints how many times the (optimized) rir function was
+  called
+* `rir.compile`: compiles the given closure or expression, returns the compiled
+  version
+* `pir.compile`: expects a rir-compiled closure, optimizes it
+* `pir.tests`: runs some internal regression tests
+* `pir.check`: returns TRUE if f, when PIR compiled, satisfies the given checks.
+* `pir.debugFlags`: creates a bitset with pir debug options
+* `pir.setDebugFlags`: sets the default debug options for pir compiler
+* `rir.compile.program`: compiles code of the given file all in a function, and
+  returns the functon
+* `rir.eval`: evaluates the code in RIR
+* `rir.body`: returns the body of rir-compiled function. The body is the vector
+  containing its ast maps and code objects
+* `.printInvocation`: prints invocation during evaluation
+* `.int3`: breakpoint during evaluation

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -64,18 +64,17 @@ pir.tests <- function() {
 # Returns TRUE f is a PIR compiled function with the given check (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
 # warmup=TRUE will call the function with 0 args to get better assumptions.
-pir.check <- function(f, check, warmup=FALSE) {
-    check <-
-      if (missing(check))
-        NULL
-      else
-        as.name(as.character(substitute(check)))
+pir.check <- function(f, ..., warmup=FALSE) {
+    checks <- 
+        as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))
+    if (length(checks) == 0)
+        stop("pir.check: needs at least 1 check")
     if (warmup) {
       rir.compile(f)
       f()
       f()
     }
-    .Call("pir_check", f, check)
+    .Call("pir_check", f, checks)
 }
 
 # creates a bitset with pir debug options

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -61,6 +61,17 @@ pir.tests <- function() {
     invisible(.Call("pir_tests"))
 }
 
+# Returns TRUE f is a PIR compiled function with the given check (e.g.
+# environment was elided)
+pir.check <- function(f, check) {
+    check <-
+      if (missing(check))
+        NULL
+      else
+        as.name(as.character(substitute(check)))
+    .Call("pir_check", f, check)
+}
+
 # creates a bitset with pir debug options
 pir.debugFlags <- function(ShowWarnings = FALSE,
                            DryRun = FALSE,

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -63,16 +63,16 @@ pir.tests <- function() {
 
 # Returns TRUE f is a PIR compiled function with the given check (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
-# warmup=TRUE will call the function with 0 args to get better assumptions.
-pir.check <- function(f, ..., warmup=FALSE) {
+# warmup=list(...) will call the function with ... to get better assumptions.
+pir.check <- function(f, ..., warmup=NULL) {
     checks <- 
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))
     if (length(checks) == 0)
         stop("pir.check: needs at least 1 check")
-    if (warmup) {
-      rir.compile(f)
-      f()
-      f()
+    if (is.list(warmup)) {
+        do.call(f, warmup)
+        do.call(f, warmup)
+        do.call(f, warmup)
     }
     .Call("pir_check", f, checks)
 }

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -61,7 +61,7 @@ pir.tests <- function() {
     invisible(.Call("pir_tests"))
 }
 
-# Returns TRUE f is a PIR compiled function with the given check (e.g.
+# returns TRUE f, when PIR compiled, satisfies the the given checks (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
 # warmup=list(...) will call the function with ... to get better assumptions.
 pir.check <- function(f, ..., warmup=NULL) {
@@ -70,9 +70,8 @@ pir.check <- function(f, ..., warmup=NULL) {
     if (length(checks) == 0)
         stop("pir.check: needs at least 1 check")
     if (is.list(warmup)) {
-        do.call(f, warmup)
-        do.call(f, warmup)
-        do.call(f, warmup)
+        for (i in 1:as.numeric(Sys.getenv("PIR_WARMUP", unset="3")))
+            do.call(f, warmup)
     }
     .Call("pir_check", f, checks)
 }

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -62,13 +62,19 @@ pir.tests <- function() {
 }
 
 # Returns TRUE f is a PIR compiled function with the given check (e.g.
-# environment was elided)
-pir.check <- function(f, check) {
+# environment was elided). Max assumptions compiled (+ minimal) are used, if
+# warmup=TRUE will call the function with 0 args to get better assumptions.
+pir.check <- function(f, check, warmup=FALSE) {
     check <-
       if (missing(check))
         NULL
       else
         as.name(as.character(substitute(check)))
+    if (warmup) {
+      rir.compile(f)
+      f()
+      f()
+    }
     .Call("pir_check", f, check)
 }
 

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -19,6 +19,8 @@
 
 using namespace rir;
 
+int R_ENABLE_JIT = getenv("R_ENABLE_JIT") ? atoi(getenv("R_ENABLE_JIT")) : 3;
+
 bool parseDebugStyle(const char* str, pir::DebugStyle& s) {
 #define V(style)                                                               \
     if (strcmp(str, #style) == 0) {                                            \

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -9,12 +9,16 @@
 #define REXPORT extern "C"
 
 extern int R_ENABLE_JIT;
+extern rir::pir::DebugOptions PirDebug;
 
 REXPORT SEXP rir_invocation_count(SEXP what);
 REXPORT SEXP rir_eval(SEXP exp, SEXP env);
 REXPORT SEXP pir_compile(SEXP closure, SEXP name, SEXP debugFlags,
                          SEXP debugStyle);
 REXPORT SEXP rir_compile(SEXP what, SEXP env);
+REXPORT SEXP pir_tests();
+REXPORT SEXP pir_check(SEXP f, SEXP check, SEXP env);
+REXPORT SEXP pir_setDebugFlags(SEXP debugFlags);
 SEXP pirCompile(SEXP closure, const rir::Assumptions& assumptions,
                 const std::string& name, const rir::pir::DebugOptions& debug);
 extern SEXP rirOptDefaultOpts(SEXP closure, const rir::Assumptions&, SEXP name);

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -116,16 +116,20 @@ bool PirCheck::run(SEXP f) {
     ClosureVersion* pir = compilePir(f, &m);
     if (pir == nullptr)
         return false;
-    switch (type) {
+    for (PirCheck::Type type : types) {
+        switch (type) {
 #define V(Check)                                                               \
     case PirCheck::Type::Check:                                                \
-        return test##Check(pir);
-        LIST_OF_PIR_CHECKS(V)
+        if (!test##Check(pir))                                                 \
+            return false;                                                      \
+        break;
+            LIST_OF_PIR_CHECKS(V)
 #undef V
-    default:
-        assert(false);
+        default:
+            assert(false);
+        }
     }
-    return false;
+    return true;
 }
 
 } // namespace rir

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -1,0 +1,126 @@
+#include "PirCheck.h"
+#include "../../ir/Compiler.h"
+#include "../analysis/query.h"
+#include "../analysis/verifier.h"
+#include "../pir/pir_impl.h"
+#include "../translations/pir_2_rir/pir_2_rir.h"
+#include "../translations/rir_2_pir/rir_2_pir.h"
+#include "../util/visitor.h"
+#include "api.h"
+#include <string>
+#include <vector>
+
+namespace rir {
+
+using namespace pir;
+
+static ClosureVersion* compilePir(SEXP f) {
+    if (TYPEOF(f) != CLOSXP) {
+        Rf_warning("pir check failed: not a closure");
+        return nullptr;
+    }
+    if (!isValidClosureSEXP(f)) {
+        Rf_warning("pir check failed: not a RIR closure");
+        return nullptr;
+    }
+    assert(DispatchTable::check(f));
+    auto table = DispatchTable::unpack(f);
+    auto assumptions = table->best()->signature().assumptions;
+
+    Module m;
+    StreamLogger logger(PirDebug);
+    logger.title("Pir Check");
+    Rir2PirCompiler cmp(&m, logger);
+    ClosureVersion* res = nullptr;
+    cmp.compileClosure(
+        f, "pir_check", assumptions, [&](ClosureVersion* r) { res = r; },
+        []() { Rf_warning("pir check failed: couldn't compile"); });
+
+    cmp.optimizeModule();
+    cmp.optimizeModule(); // TODO: Why is this needed twice?
+    return res;
+}
+
+static bool testIsPirCompilable(ClosureVersion* f) {
+    // Always true if we get here
+    return true;
+}
+
+static bool testNoLoad(ClosureVersion* f) {
+    return Visitor::check(f->entry, [&](Instruction* i) {
+        return !LdVar::Cast(i) && !LdFun::Cast(i) && !LdArg::Cast(i);
+    });
+};
+
+static bool testNoStore(ClosureVersion* f) {
+    return Visitor::check(f->entry, [&](Instruction* i) {
+        return !StVar::Cast(i) && !StVarSuper::Cast(i);
+    });
+}
+
+static bool testNoStSuper(ClosureVersion* f) {
+    return Visitor::check(f->entry,
+                          [&](Instruction* i) { return !StVarSuper::Cast(i); });
+}
+
+static bool testNoEnvForAdd(ClosureVersion* f) {
+    return Visitor::check(f->entry, [&](BB* bb) -> bool {
+        for (auto& i : *bb) {
+            if (auto a = Add::Cast(i)) {
+                if (a->env() != Env::elided()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    });
+}
+
+static bool testNoEnvSpec(ClosureVersion* f) { return Query::noEnvSpec(f); }
+
+static bool testNoEnv(ClosureVersion* f) { return Query::noEnv(f); }
+
+static bool testNoExternalCalls(ClosureVersion* f) {
+    return Visitor::check(f->entry, [&](Instruction* i) {
+        return !CallInstruction::CastCall(i) || CallSafeBuiltin::Cast(i);
+    });
+}
+
+static bool testReturns42L(ClosureVersion* f) {
+    if (!Query::noEnv(f))
+        return false;
+    auto r = Query::returned(f);
+    if (r.size() != 1)
+        return false;
+    auto ld = LdConst::Cast((*r.begin()));
+    if (ld == nullptr || TYPEOF(ld->c()) != INTSXP || *INTEGER(ld->c()) != 42)
+        return false;
+    return true;
+};
+
+PirCheck::Type PirCheck::parseType(const char* str) {
+#define V(Check)                                                               \
+    if (strcmp(str, #Check) == 0)                                              \
+        return PirCheck::Type::Check;                                          \
+    else
+    LIST_OF_PIR_CHECKS(V)
+#undef V
+    return PirCheck::Type::Invalid;
+}
+
+bool PirCheck::run(SEXP f) {
+    ClosureVersion* pir = compilePir(f);
+    if (pir == nullptr)
+        return false;
+    switch (type) {
+#define V(Check)                                                               \
+    case PirCheck::Type::Check:                                                \
+        return test##Check(pir);
+        LIST_OF_PIR_CHECKS(V)
+#undef V
+    default:
+        assert(false);
+    }
+}
+
+} // namespace rir

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -23,6 +23,9 @@ static ClosureVersion* compilePir(SEXP f, Module* m) {
         Rf_warning("pir check failed: not a RIR closure");
         return nullptr;
     }
+    if (atoi(getenv("R_ENABLE_JIT")) == 0) {
+        Rf_warning("R JIT disabled, this will prevent some optimizations");
+    }
     assert(DispatchTable::check(BODY(f)));
     auto table = DispatchTable::unpack(BODY(f));
     auto assumptions = table->best()->signature().assumptions |

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -122,6 +122,7 @@ bool PirCheck::run(SEXP f) {
     default:
         assert(false);
     }
+    return false;
 }
 
 } // namespace rir

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -23,7 +23,7 @@ static ClosureVersion* compilePir(SEXP f, Module* m) {
         Rf_warning("pir check failed: not a RIR closure");
         return nullptr;
     }
-    if (atoi(getenv("R_ENABLE_JIT")) == 0) {
+    if (R_ENABLE_JIT == 0) {
         Rf_warning("R JIT disabled, this will prevent some optimizations");
     }
     assert(DispatchTable::check(BODY(f)));

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -51,7 +51,7 @@ static bool testIsPirCompilable(ClosureVersion* f) {
 
 static bool testNoLoad(ClosureVersion* f) {
     return Visitor::check(f->entry, [&](Instruction* i) {
-        return !LdVar::Cast(i) && !LdFun::Cast(i) && !LdArg::Cast(i);
+        return !LdVar::Cast(i) && !LdFun::Cast(i);
     });
 };
 

--- a/rir/src/compiler/test/PirCheck.h
+++ b/rir/src/compiler/test/PirCheck.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "R/Symbols.h"
+#include "common.h"
 #include <list>
 
 namespace rir {
@@ -28,8 +29,10 @@ struct PirCheck {
 
     static Type parseType(const char* str);
     explicit PirCheck(std::list<Type> types) : types(types) {
+#ifdef ENABLE_SLOWASSERT
         for (Type type : types)
             assert(type != Type::Invalid);
+#endif
     }
     bool run(SEXP f);
 };

--- a/rir/src/compiler/test/PirCheck.h
+++ b/rir/src/compiler/test/PirCheck.h
@@ -26,7 +26,7 @@ struct PirCheck {
     Type type;
 
     static Type parseType(const char* str);
-    PirCheck(Type type) : type(type) { assert(type != Type::Invalid); }
+    explicit PirCheck(Type type) : type(type) { assert(type != Type::Invalid); }
     bool run(SEXP f);
 };
 

--- a/rir/src/compiler/test/PirCheck.h
+++ b/rir/src/compiler/test/PirCheck.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "R/Symbols.h"
+#include <list>
 
 namespace rir {
 
@@ -23,10 +24,13 @@ struct PirCheck {
             Invalid
     };
 
-    Type type;
+    std::list<Type> types;
 
     static Type parseType(const char* str);
-    explicit PirCheck(Type type) : type(type) { assert(type != Type::Invalid); }
+    explicit PirCheck(std::list<Type> types) : types(types) {
+        for (Type type : types)
+            assert(type != Type::Invalid);
+    }
     bool run(SEXP f);
 };
 

--- a/rir/src/compiler/test/PirCheck.h
+++ b/rir/src/compiler/test/PirCheck.h
@@ -28,7 +28,7 @@ struct PirCheck {
     std::list<Type> types;
 
     static Type parseType(const char* str);
-    explicit PirCheck(std::list<Type> types) : types(types) {
+    explicit PirCheck(std::list<Type>& types) : types(types) {
 #ifdef ENABLE_SLOWASSERT
         for (Type type : types)
             assert(type != Type::Invalid);

--- a/rir/src/compiler/test/PirCheck.h
+++ b/rir/src/compiler/test/PirCheck.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "R/Symbols.h"
+
+namespace rir {
+
+#define LIST_OF_PIR_CHECKS(V)                                                  \
+    V(IsPirCompilable)                                                         \
+    V(NoLoad)                                                                  \
+    V(NoStore)                                                                 \
+    V(NoStSuper)                                                               \
+    V(NoEnvForAdd)                                                             \
+    V(NoEnvSpec)                                                               \
+    V(NoEnv)                                                                   \
+    V(NoExternalCalls)                                                         \
+    V(Returns42L)
+
+struct PirCheck {
+    enum class Type : unsigned {
+#define V(Check) Check,
+        LIST_OF_PIR_CHECKS(V)
+#undef V
+            Invalid
+    };
+
+    Type type;
+
+    static Type parseType(const char* str);
+    PirCheck(Type type) : type(type) { assert(type != Type::Invalid); }
+    bool run(SEXP f);
+};
+
+} // namespace rir

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -1,15 +1,15 @@
-#include "pir_tests.h"
+#include "PirTests.h"
+#include "../../ir/Compiler.h"
+#include "../analysis/query.h"
+#include "../analysis/verifier.h"
+#include "../pir/pir_impl.h"
+#include "../translations/pir_2_rir/pir_2_rir.h"
+#include "../translations/rir_2_pir/rir_2_pir.h"
+#include "../util/visitor.h"
 #include "R/Protect.h"
 #include "R/RList.h"
 #include "R_ext/Parse.h"
-#include "analysis/query.h"
-#include "analysis/verifier.h"
 #include "api.h"
-#include "ir/Compiler.h"
-#include "pir/pir_impl.h"
-#include "translations/pir_2_rir/pir_2_rir.h"
-#include "translations/rir_2_pir/rir_2_pir.h"
-#include "util/visitor.h"
 #include <string>
 #include <vector>
 
@@ -46,9 +46,9 @@ SEXP compileToRir(const std::string& context, const std::string& expr,
     eval(expr, env);
     return env;
 }
-typedef std::unordered_map<std::string, pir::ClosureVersion*> closuresByName;
+typedef std::unordered_map<std::string, pir::ClosureVersion*> ClosuresByName;
 
-closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
+ClosuresByName compileRir2Pir(SEXP env, pir::Module* m) {
     pir::StreamLogger logger({pir::DebugOptions::DebugFlags() |
                                   // pir::DebugFlag::PrintIntoStdout |
                                   // pir::DebugFlag::PrintEarlyPir |
@@ -59,7 +59,7 @@ closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
     pir::Rir2PirCompiler cmp(m, logger);
 
     // Compile every function in the environment
-    closuresByName results;
+    ClosuresByName results;
     auto envlist = RList(FRAME(env));
     for (auto f = envlist.begin(); f != envlist.end(); ++f) {
         auto fun = *f;
@@ -78,7 +78,7 @@ closuresByName compileRir2Pir(SEXP env, pir::Module* m) {
     return results;
 }
 
-closuresByName compile(const std::string& context, const std::string& expr,
+ClosuresByName compile(const std::string& context, const std::string& expr,
                        pir::Module* m, SEXP super = R_GlobalEnv) {
     SEXP env = compileToRir(context, expr, super);
     return compileRir2Pir(env, m);

--- a/rir/src/compiler/test/PirTests.h
+++ b/rir/src/compiler/test/PirTests.h
@@ -1,11 +1,10 @@
-#ifndef PIR_TESTS_H
-#define PIR_TESTS_H
+#pragma once
 
 namespace rir {
+
 class PirTests {
   public:
     static void run();
 };
-}
 
-#endif
+} // namespace rir

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -76,6 +76,10 @@ struct Assumptions {
 
     RIR_INLINE size_t count() const { return flags.count(); }
 
+    constexpr Assumptions operator|(const Flags& other) const {
+        return Assumptions(flags | other, missing);
+    }
+
     constexpr Assumptions operator|(const Assumptions& other) const {
         assert(missing == other.missing);
         return Assumptions(other.flags | flags, missing);

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -27,6 +27,7 @@ struct DispatchTable
     }
 
     Function* baseline() { return Function::unpack(getEntry(0)); }
+    Function* best() { return get(size() - 1); }
 
     void baseline(Function* f) {
         assert(f->signature().optimization ==

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -1,4 +1,5 @@
-jitOn <- getenv("R_ENABLE_JIT") != 0
+jitOn <- as.numeric(Sys.getenv("R_ENABLE_JIT")) != 0
+fullOptim <- jitOn && Sys.getenv("PIR_ENABLE", unset="on") == "on"
 
 # Copied / cross-validated from pir_tests
 
@@ -204,13 +205,13 @@ stopifnot(tryCatch({
 
 # New tests
 
-stopifnot(!jitOn || pir.check(function() {
+stopifnot(!fullOptim || pir.check(function() {
   x <- 1
   while (x < 10)
     x <- x + 1
   x
 }, NoLoad, NoStore))
-stopifnot(!jitOn || pir.check(function(n) {
+stopifnot(!fullOptim || pir.check(function(n) {
   x <- 1
   while (x < n)
     x <- x + 1

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -198,5 +198,7 @@ mandelbrot()
 stopifnot(tryCatch({
   pir.check(mandelbrot, NoExternalCalls)
 }, warning = function(w) {
-  conditionMessage(w) == "pir check failed: couldn't compile"
+  cat("Couldn't run:", conditionMessage(w), "\n")
+  conditionMessage(w) == "pir check failed: couldn't compile" ||
+  conditionMessage(w) == "R JIT disabled, this will prevent some optimizations"
 }))

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -1,3 +1,5 @@
+jitOn <- getenv("R_ENABLE_JIT") != 0
+
 # Copied / cross-validated from pir_tests
 
 stopifnot(pir.check(function(x, y) print("Test"), IsPirCompilable))
@@ -194,22 +196,21 @@ mandelbrot <- function() {
 }
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(tryCatch({
-  pir.check(mandelbrot, NoExternalCalls, warmup=list())
+  !jitOn || pir.check(mandelbrot, NoExternalCalls, warmup=list())
 }, warning = function(w) {
   cat("Couldn't run:", conditionMessage(w), "\n")
-  conditionMessage(w) == "pir check failed: couldn't compile" ||
-  conditionMessage(w) == "R JIT disabled, this will prevent some optimizations"
+  conditionMessage(w) == "pir check failed: couldn't compile"
 }))
 
 # New tests
 
-stopifnot(pir.check(function() {
+stopifnot(!jitOn || pir.check(function() {
   x <- 1
   while (x < 10)
     x <- x + 1
   x
 }, NoLoad, NoStore))
-stopifnot(pir.check(function(n) {
+stopifnot(!jitOn || pir.check(function(n) {
   x <- 1
   while (x < n)
     x <- x + 1

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -145,7 +145,7 @@ stopifnot(pir.check(function() {
   f(x, y(), z)
 }, NoEnv))
 
-mandelbrot <- function() {
+stopifnot(pir.check(function() {
     size = 30
     sum = 0
     byteAcc = 0
@@ -191,7 +191,4 @@ mandelbrot <- function() {
       y = y + 1
     }
     return (sum)
-}
-mandelbrot()
-mandelbrot()
-stopifnot(pir.check(mandelbrot, NoExternalCalls))
+}, NoExternalCalls, warmup=TRUE))

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -1,3 +1,5 @@
+# Copied / cross-validated from pir_tests
+
 stopifnot(pir.check(function(x, y) print("Test"), IsPirCompilable))
 stopifnot(!pir.check(function(x = 4) {
   print("PIR doesn't support default args")

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -43,11 +43,9 @@ stopifnot(pir.check(function(depth) {
 }, NoEnvSpec))
 
 xxx <- 12
-f <- rir.compile(function() {
+stopifnot(pir.check(function() {
   1 + xxx
-})
-f()
-stopifnot(pir.check(f, NoEnvForAdd))
+}, NoEnvForAdd, warmup=list()))
 
 stopifnot(pir.check(function() {
   1 + yyy
@@ -194,13 +192,26 @@ mandelbrot <- function() {
     }
     return (sum)
 }
-mandelbrot()
-mandelbrot()
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(tryCatch({
-  pir.check(mandelbrot, NoExternalCalls)
+  pir.check(mandelbrot, NoExternalCalls, warmup=list())
 }, warning = function(w) {
   cat("Couldn't run:", conditionMessage(w), "\n")
   conditionMessage(w) == "pir check failed: couldn't compile" ||
   conditionMessage(w) == "R JIT disabled, this will prevent some optimizations"
 }))
+
+# New tests
+
+stopifnot(pir.check(function() {
+  x <- 1
+  while (x < 10)
+    x <- x + 1
+  x
+}, NoLoad, NoStore))
+stopifnot(pir.check(function(n) {
+  x <- 1
+  while (x < n)
+    x <- x + 1
+  x
+}, NoLoad, NoStore, warmup=list(10)))

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -30,10 +30,9 @@ stopifnot(pir.check(function() {
   f()
   x
 }, Returns42L))
-# TODO This fails, why?
-# stopifnot(pir.check(function() {
-#   f <- function() 123
-# }, NoEnv, warmup=TRUE))
+stopifnot(pir.check(function() {
+  123
+}, NoEnv))
 stopifnot(pir.check(function(depth) {
   if (depth == 0)
     1

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -1,0 +1,198 @@
+stopifnot(pir.check(function(x, y) print("Test"), IsPirCompilable))
+stopifnot(!pir.check(function(x = 4) {
+  print("PIR doesn't support default args")
+}, IsPirCompilable))
+stopifnot(pir.check(function() 42L, Returns42L))
+stopifnot(pir.check(function() {
+  f <- function() 42L
+  f()
+}, Returns42L))
+stopifnot(pir.check(function() {
+  f <- function(val) (function(x) x)(val)
+  f(42L)
+}, Returns42L))
+stopifnot(pir.check(function() {
+  f <- function(x) x
+  f(42L)
+}, Returns42L))
+stopifnot(pir.check(function() {
+  y <- 42L
+  t <- FALSE
+  if (t)
+    x <- y
+  else
+    x <- y
+  x
+}, Returns42L))
+stopifnot(pir.check(function() {
+  x <- 0
+  f <- function() x <<- 42L
+  f()
+  x
+}, Returns42L))
+# TODO This fails, why?
+# stopifnot(pir.check(function() {
+#   f <- function() 123
+# }, NoEnv, warmup=TRUE))
+stopifnot(pir.check(function(depth) {
+  if (depth == 0)
+    1
+  else
+    0
+}, NoEnvSpec))
+
+xxx <- 12
+f <- rir.compile(function() {
+  1 + xxx
+})
+f()
+stopifnot(pir.check(f, NoEnvForAdd))
+
+stopifnot(pir.check(function() {
+  1 + yyy
+}, NoEnvForAdd))
+stopifnot(pir.check(function(x) {
+  y <- 2
+}, NoStore))
+stopifnot(pir.check(function(x) {
+  if (x)
+    y <- 1
+  else
+    y <- 2
+  y
+}, NoStore))
+stopifnot(pir.check(function(x) {
+  y <- 1
+  y <- 2
+  leak()
+}, NoStore))
+stopifnot(!pir.check(function(x) {
+  leak()
+  y <- 1
+  y <- 2
+}, NoStore))
+stopifnot(pir.check(function(x) {
+  leak()
+  y <- 1
+  y <- 2
+}, NoStSuper))
+stopifnot(pir.check(function(x) {
+  a <- 1
+  (function() a <<- 1)()
+}, NoStSuper))
+stopifnot(pir.check(function(x) {
+  a <- 1
+  (function() a <<- 1)()
+}, NoStore))
+stopifnot(!pir.check(function(x) {
+  (function() a <<- 1)()
+}, NoStSuper))
+stopifnot(!pir.check(function(x) {
+  (function() a <<- 1)()
+}, NoStore))
+stopifnot(pir.check(function(x) {
+  a <- 1
+  (function() {
+     a <<- 1
+     asdf()
+  })()
+}, NoStSuper))
+stopifnot(!pir.check(function(x) {
+  a <- 1
+  asdf()
+  (function() a <<- 1)()
+}, NoStSuper))
+stopifnot(pir.check(function() {
+  a <- FALSE
+  if (a)
+    q <- 1
+  else {
+    if (a)
+      q <- 3 
+    else 
+      q <- 2
+  }
+  q
+}, NoLoad))
+stopifnot(!pir.check(function(a) {
+  if (a)
+    q <- 1
+  else {
+    if (a)
+      q <- 3 
+    else 
+      q <- 2
+  }
+  q
+}, NoLoad))
+stopifnot(pir.check(function() {
+  f <- function() 42L
+  (function(x) x())(f)
+}, Returns42L))
+stopifnot(pir.check(function() {
+  a <- function() 41L
+  b <- function() 1L
+  f <- function(x, y) x() + y
+  f(a, b())
+}, Returns42L))
+stopifnot(pir.check(function() {
+  x <- function() 32
+  y <- function() 31
+  z <- 1
+  f <- function(a, b, c) {
+    if (a() == (b + c))
+      42L
+  }
+  f(x, y(), z)
+}, NoEnv))
+
+mandelbrot <- function() {
+    size = 30
+    sum = 0
+    byteAcc = 0
+    bitNum  = 0
+    y = 0
+    while (y < size) {
+      ci = (2.0 * y / size) - 1.0
+      x = 0
+      while (x < size) {
+        zr   = 0.0
+        zrzr = 0.0
+        zi   = 0.0
+        zizi = 0.0
+        cr = (2.0 * x / size) - 1.5
+        z = 0
+        notDone = TRUE
+        escape = 0
+        while (notDone && (z < 50)) {
+          zr = zrzr - zizi + cr
+          zi = 2.0 * zr * zi + ci
+          zrzr = zr * zr
+          zizi = zi * zi
+          if ((zrzr + zizi) > 4.0) {
+            notDone = FALSE
+            escape  = 1
+          }
+          z = z + 1
+        }
+        byteAcc = bitwShiftL(byteAcc, 1) + escape
+        bitNum = bitNum + 1
+        if (bitNum == 8) {
+          sum = bitwXor(sum, byteAcc)
+          byteAcc = 0
+          bitNum  = 0
+        } else if (x == (size - 1)) {
+          byteAcc = bitwShiftL(byteAcc, 8 - bitNum)
+          sum = bitwXor(sum, byteAcc)
+          byteAcc = 0
+          bitNum  = 0
+        }
+        x = x + 1
+      }
+      y = y + 1
+    }
+    return (sum)
+}
+mandelbrot()
+mandelbrot()
+stopifnot(pir.check(mandelbrot, NoExternalCalls))

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -145,7 +145,7 @@ stopifnot(pir.check(function() {
   f(x, y(), z)
 }, NoEnv))
 
-stopifnot(pir.check(function() {
+mandelbrot <- function() {
     size = 30
     sum = 0
     byteAcc = 0
@@ -191,4 +191,12 @@ stopifnot(pir.check(function() {
       y = y + 1
     }
     return (sum)
-}, NoExternalCalls, warmup=TRUE))
+}
+mandelbrot()
+mandelbrot()
+# This can't be run if PIR_MAX_INPUT_SIZE is too low
+stopifnot(tryCatch({
+  pir.check(mandelbrot, NoExternalCalls)
+}, warning = function(w) {
+  conditionMessage(w) == "pir check failed: couldn't compile"
+}))


### PR DESCRIPTION
Adds a new function, `pir.check(f, CheckType...)`, which will compile `f` and inspect the PIR to make sure it adheres to each `CheckType`.

For example, `pir.check(f, NoLoad, NoStore)` returns `TRUE` if `f` is a closure which can be compiled and its PIR doesn't have any loads or stores, `FALSE` otherwise. So `stopifnot(pir.check(f, NoLoad, NoStore))` fails if `f`'s loads/stores can't be eliminated.

I tested this by reusing most of the `pir_tests`, I also added a few new tests.