### PR TITLE
Prevent stvar from bumping named count and fix static reference counts

### DIFF
--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -8,29 +8,92 @@ namespace rir {
 namespace pir {
 
 struct AUses {
+
+    /*
+     * Lattice:
+     *
+     *                    Multiple
+     *                     /      \
+     *   AlreadyIncremented        Once
+     *                     \      /
+     *                       None
+     *
+     * Definitions:
+     *   reuse            :=   override if refcount is == 0
+     */
+
     enum Kind {
-        None = 0,
-        Once = 1,
-        Multiple = 2,
-        Destructive = 3,
+        // 1) Static refcount is safe
+        None,
+        Once,               // At least one use, which reuses input
+        AlreadyIncremented, // Refcount is known to be 1 (ie. used by stvar)
+
+        // 2) Need an ensureNamed
+        Multiple, // At least two uses, at least one (but the last) is reusing
     };
 
-    std::unordered_map<Instruction*, Kind> uses;
+    static Kind merge(Kind a, Kind b) {
+        if (a == b)
+            return a;
+
+        Kind bigger = a > b ? a : b;
+        Kind smaller = a < b ? a : b;
+        if (smaller == None)
+            return bigger;
+
+        if (bigger == Multiple || bigger == AlreadyIncremented)
+            return Multiple;
+
+        assert(false);
+        return Multiple;
+    };
+
+    bool overflow = false;
+    std::map<Instruction*, Kind> uses;
     AbstractResult mergeExit(const AUses& other) { return merge(other); }
     AbstractResult merge(const AUses& other) {
         AbstractResult res;
-        for (auto u : other.uses) {
-            if (!uses.count(u.first)) {
-                uses.emplace(u);
+
+        if (overflow)
+            return res;
+
+        if (other.overflow) {
+            uses.clear();
+            overflow = true;
+            res.taint();
+            return res;
+        }
+
+        auto myPos = uses.begin();
+        auto theirPos = other.uses.begin();
+
+        while (theirPos != other.uses.end()) {
+            if (myPos == uses.end() || myPos->first > theirPos->first) {
+                // we are missing this entry
+                auto updated = uses.insert(*theirPos);
+                myPos = updated.first;
                 res.update();
-            } else if (uses.at(u.first) < u.second) {
-                // used in both branches, use count is the maximum
-                uses.at(u.first) = u.second;
-                res.update();
+                myPos++;
+                theirPos++;
+            } else if (myPos->first == theirPos->first) {
+                if (myPos->second != theirPos->second) {
+                    auto m = merge(myPos->second, theirPos->second);
+                    if (m != myPos->second) {
+                        myPos->second = m;
+                        res.update();
+                    }
+                }
+                myPos++;
+                theirPos++;
+            } else {
+                assert(myPos->first < theirPos->first);
+                // other branch does not have this entry
+                myPos++;
             }
         }
         return res;
     }
+
     void print(std::ostream&, bool) const {
         // TODO
     }
@@ -51,14 +114,14 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
                         if (auto a = Instruction::Cast(v)) {
                             if (Phi::Cast(a)) {
                                 for (auto otherAlias : alias[a]) {
-                                    if (otherAlias->needsReferenceCount() &&
+                                    if (otherAlias->minReferenceCount() < 1 &&
                                         !alias[i].includes(otherAlias)) {
                                         changed = true;
                                         alias[i].insert(otherAlias);
                                     }
                                 }
                             } else {
-                                if (a->needsReferenceCount() &&
+                                if (a->minReferenceCount() < 1 &&
                                     !alias[i].includes(a)) {
                                     changed = true;
                                     alias[i].insert(a);
@@ -76,68 +139,125 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
 
     AbstractResult apply(AUses& state, Instruction* i) const override {
         AbstractResult res;
-        if (Phi::Cast(i))
+
+        if (state.overflow || Phi::Cast(i) || PirCopy::Cast(i) ||
+            CastType::Cast(i))
             return res;
 
-        if (i->needsReferenceCount()) {
+        if (i->minReferenceCount() < 1) {
             // This value was used only once in a loop, we can thus
             // reset the count on redefinition.
-            if (state.uses.count(i) && state.uses.at(i) == AUses::Once) {
-                state.uses[i] = AUses::None;
+            auto u = state.uses.find(i);
+            if (u != state.uses.end() && u->second == AUses::Once) {
+                u->second = AUses::None;
                 res.update();
             }
         }
 
-        auto count = [&](Instruction* i) {
-            auto& use = state.uses[i];
-            switch (use) {
-            case AUses::None:
-                use = AUses::Once;
-                res.update();
-                break;
-            case AUses::Once:
-                use = AUses::Multiple;
-                res.update();
-                break;
-            default: {}
-            }
-        };
-
-        auto apply = [&](Value* v) {
-            if (auto j = Instruction::Cast(v)) {
-                if (!j->needsReferenceCount())
-                    return;
-                if (alias.count(j))
-                    for (auto a : alias.at(j))
-                        count(a);
-                else
-                    count(j);
-            }
-        };
-        i->eachArg(apply);
-
-        switch (i->tag) {
-        // Loop sequence needs to stay constant for the whole loop duration.
-        case Tag::ForSeqSize:
-        // Those instructions -- at the rir level -- are allowed to override
-        // inputs, even if the refcount is 1. Therefore if they are used
-        // multiple times, we need to bump the refcount even further.
-        case Tag::Subassign1_1D:
-        case Tag::Subassign2_1D:
-        case Tag::Subassign1_2D:
-        case Tag::Subassign2_2D:
-            if (auto input = Instruction::Cast(i->arg(0).val())) {
-                if (input->needsReferenceCount() && state.uses.count(input) &&
-                    state.uses.at(input) == AUses::Multiple) {
-                    state.uses[input] = AUses::Destructive;
+        auto count = [&](Instruction* i, bool constantUse) {
+            auto use = state.uses.find(i);
+            if (use == state.uses.end()) {
+                if (!constantUse) {
+                    // duplicate case AUses::None from below. This avoids
+                    // creating an entry if not needed
+                    state.uses[i] = AUses::Once;
                     res.update();
                 }
+                return;
             }
+            switch (use->second) {
+            case AUses::None:
+                // multiple non-reusing uses are ok, as long as the are not
+                // preceeded by a reusing use (in which case we are at Once)
+                if (!constantUse) {
+                    use->second = AUses::Once;
+                    res.update();
+                }
+                break;
+            case AUses::Once:
+                use->second = AUses::Multiple;
+                res.update();
+                break;
+            case AUses::AlreadyIncremented:
+            case AUses::Multiple:
+                break;
+            }
+        };
+
+        std::function<void(Value*, bool)> apply = [&](Value* v,
+                                                      bool constantUse) {
+            if (auto j = Instruction::Cast(v)) {
+                if (j->minReferenceCount() >= 1)
+                    return;
+
+                if (auto cp = PirCopy::Cast(v))
+                    return apply(cp->arg<0>().val(), constantUse);
+                if (auto cp = CastType::Cast(v))
+                    return apply(cp->arg<0>().val(), constantUse);
+
+                if (alias.count(j))
+                    for (auto a : alias.at(j))
+                        count(a, constantUse);
+                else
+                    count(j, constantUse);
+            }
+        };
+
+        switch (i->tag) {
+        // (1) Instructions which never reuse SEXPS
+        //
+        case Tag::Return:
+        case Tag::Length:
+        case Tag::Seq:
+        case Tag::Colon:
+        case Tag::IsObject:
+        case Tag::IsEnvStub:
+        case Tag::Deopt:
+        case Tag::AsTest:
+        case Tag::Identical:
+        case Tag::Is:
+        case Tag::LOr:
+        case Tag::LAnd:
+        case Tag::MkArg:
+        case Tag::MkCls:
+        case Tag::MkFunCls:
+            i->eachArg([&](Value* v) { apply(v, true); });
             break;
 
+        // (2) Instructions which update the named count
+        //
+        case Tag::StVar:
+        case Tag::StVarSuper:
+        case Tag::MkEnv:
+            i->eachArg([&](Value* v) {
+                if (v == i->env())
+                    return;
+                if (auto val = Instruction::Cast(v)) {
+                    apply(val, false);
+                    if (!state.uses.count(val) ||
+                        state.uses.at(val) <= AUses::Once) {
+                        state.uses[val] = AUses::AlreadyIncremented;
+                        res.update();
+                    }
+                }
+            });
+            break;
+
+        // (3) Default: instructions which might update in-place, if named
+        // count is 0
+        //
         default:
+            i->eachArg([&](Value* v) { apply(v, false); });
             break;
         };
+
+        // The abstract state is expensive to merge. To lift this limit, we'd
+        // need to find a better strategy, or a less expensive analysis...
+        if (state.uses.size() > 1000) {
+            state.uses.clear();
+            state.overflow = true;
+            res.taint();
+        }
 
         return res;
     }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -605,7 +605,7 @@ class FLI(LdConst, 0, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), c());
     }
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLIE(LdFun, 2, Effects::Any()) {
@@ -640,7 +640,7 @@ class FLIE(LdFun, 2, Effects::Any()) {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
 
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLIE(LdVar, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
@@ -660,6 +660,8 @@ class FLIE(LdVar, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
+
+    int minReferenceCount() const override { return 1; }
 };
 
 class FLI(ForSeqSize, 1, Effect::Error) {
@@ -680,7 +682,7 @@ class FLI(LdArg, 0, Effects::None()) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), id);
     }
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLIE(Missing, 1, Effects() | Effect::ReadsEnv) {
@@ -748,6 +750,8 @@ class FLIE(LdVarSuper, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     size_t gvnBase() const override {
         return hash_combine(InstructionImplementation::gvnBase(), varName);
     }
+
+    int minReferenceCount() const override { return 1; }
 };
 
 class FLIE(StVar, 2, Effect::WritesEnv) {
@@ -837,7 +841,7 @@ class FLIE(MkArg, 2, Effects::None()) {
         return hash_combine(InstructionImplementation::gvnBase(), prom_);
     }
 
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLI(Seq, 3, Effects::None()) {
@@ -863,7 +867,7 @@ class FLIE(MkCls, 4, Effects::None()) {
 
     Value* lexicalEnv() const { return env(); }
 
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 
   private:
     using FixedLenInstructionWithEnvSlot::env;
@@ -882,7 +886,7 @@ class FLIE(MkFunCls, 1, Effects::None()) {
         return hash_combine(InstructionImplementation::gvnBase(), cls);
     }
 
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLIE(Force, 2, Effects::Any()) {
@@ -900,7 +904,7 @@ class FLIE(Force, 2, Effects::Any()) {
             effects.reset();
         }
     }
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLI(CastType, 1, Effects::None()) {
@@ -1106,8 +1110,8 @@ class FLI(PirCopy, 1, Effects::None()) {
         : FixedLenInstruction(v->type, {{v->type}}, {{v}}) {}
     void print(std::ostream& out, bool tty) const override;
     void updateType() override final { type = arg<0>().val()->type; }
-    bool needsReferenceCount() const override {
-        return arg<0>().val()->needsReferenceCount();
+    int minReferenceCount() const override {
+        return arg<0>().val()->minReferenceCount();
     }
 };
 
@@ -1543,7 +1547,7 @@ class VLIE(MkEnv, Effects::None()) {
 
     size_t gvnBase() const override { return (size_t)this; }
 
-    bool needsReferenceCount() const override { return false; }
+    int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 
 class FLI(IsObject, 1, Effects::None()) {

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -50,8 +50,10 @@ class Value {
                (type.isRType() || type == NativeType::test);
     }
 
-    virtual bool needsReferenceCount() const {
-        return type.maybeReferenceCounted();
+    static constexpr int MAX_REFCOUNT = 2;
+
+    virtual int minReferenceCount() const {
+        return type.maybeReferenceCounted() ? 0 : MAX_REFCOUNT;
     }
 };
 

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -701,13 +701,57 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             order.push_back(bb->id);
     });
 
-    std::unordered_map<Instruction*, AUses::Kind> needsRefcount;
+    std::unordered_set<Instruction*> needsEnsureNamed;
+    std::unordered_set<Instruction*> needsSetShared;
+    std::unordered_set<Instruction*> needsLdVarForUpdate;
+    bool refcountAnalysisOverflow = false;
     {
+        Visitor::run(code->entry, [&](Instruction* i) {
+            switch (i->tag) {
+            case Tag::ForSeqSize:
+                if (auto arg = Instruction::Cast(i->arg(0).val()))
+                    if (arg->minReferenceCount() < Value::MAX_REFCOUNT)
+                        needsSetShared.insert(arg);
+                break;
+            case Tag::Subassign1_1D:
+            case Tag::Subassign2_1D:
+            case Tag::Subassign1_2D:
+            case Tag::Subassign2_2D:
+                // Subassigns override the vector, even if the named count
+                // is 1. This is only valid, if we are sure that the vector
+                // is local, ie. vector and subassign operation come from
+                // the same lexical scope.
+                if (auto vec = Instruction::Cast(
+                        i->arg(1).val()->followCastsAndForce())) {
+                    if (auto ld = LdVar::Cast(vec)) {
+                        if (auto su = vec->hasSingleUse()) {
+                            if (auto st = StVar::Cast(su)) {
+                                if (ld->env() != st->env())
+                                    needsLdVarForUpdate.insert(vec);
+                                break;
+                            }
+                        }
+                        if (ld->env() != i->env())
+                            needsLdVarForUpdate.insert(vec);
+                    } else {
+                        if (vec->minReferenceCount() < 2 &&
+                            !vec->hasSingleUse())
+                            needsSetShared.insert(vec);
+                    }
+                }
+                break;
+            default: {}
+            }
+        });
+
         StaticReferenceCount analysis(cls, log);
-        for (auto& u : analysis.result().uses) {
-            if (u.second > AUses::Once)
-                needsRefcount[u.first] = u.second;
-        }
+        if (analysis.result().overflow)
+            refcountAnalysisOverflow = true;
+        else
+            for (auto& u : analysis.result().uses) {
+                if (u.second == AUses::Multiple)
+                    needsEnsureNamed.insert(u.first);
+            }
     }
 
     CodeBuffer cb(ctx.cs());
@@ -917,7 +961,10 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
 
             case Tag::LdVar: {
                 auto ldvar = LdVar::Cast(instr);
-                cb.add(BC::ldvarNoForce(ldvar->varName));
+                if (needsLdVarForUpdate.count(instr))
+                    cb.add(BC::ldvarNoForce(ldvar->varName));
+                else
+                    cb.add(BC::ldvarForUpdate(ldvar->varName));
                 break;
             }
 
@@ -1243,12 +1290,12 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
             }
 
-            if (instr->needsReferenceCount()) {
-                if (needsRefcount[instr] == AUses::Multiple)
-                    cb.add(BC::ensureNamed());
-                else if (needsRefcount[instr] == AUses::Destructive)
-                    cb.add(BC::setShared());
-            }
+            if (instr->minReferenceCount() < 2 && needsSetShared.count(instr))
+                cb.add(BC::setShared());
+            else if (instr->minReferenceCount() < 1 &&
+                     (refcountAnalysisOverflow ||
+                      needsEnsureNamed.count(instr)))
+                cb.add(BC::ensureNamed());
 
             // Store the result
             if (alloc.sa.dead(instr)) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -202,6 +202,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
 
     case Opcode::ldvar_:
+    case Opcode::ldvar_for_update_:
         v = insert(new LdVar(bc.immediateConst(), env));
         // Checkpoint might be useful if we end up inlining this force
         if (!inPromise())

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -39,6 +39,7 @@ BC_NOARGS(V, _)
     case Opcode::ldfun_:
     case Opcode::ldddvar_:
     case Opcode::ldvar_:
+    case Opcode::ldvar_for_update_:
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:
@@ -233,6 +234,7 @@ void BC::print(std::ostream& out) const {
         break;
     case Opcode::ldfun_:
     case Opcode::ldvar_:
+    case Opcode::ldvar_for_update_:
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -70,6 +70,13 @@ BC BC::ldvar(SEXP sym) {
     i.pool = Pool::insert(sym);
     return BC(Opcode::ldvar_, i);
 }
+BC BC::ldvarForUpdate(SEXP sym) {
+    assert(TYPEOF(sym) == SYMSXP);
+    assert(strlen(CHAR(PRINTNAME(sym))));
+    ImmediateArguments i;
+    i.pool = Pool::insert(sym);
+    return BC(Opcode::ldvar_for_update_, i);
+}
 BC BC::ldvarNoForce(SEXP sym) {
     assert(TYPEOF(sym) == SYMSXP);
     assert(strlen(CHAR(PRINTNAME(sym))));

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -335,6 +335,7 @@ BC_NOARGS(V, _)
     inline static BC push_code(FunIdx i);
     inline static BC ldfun(SEXP sym);
     inline static BC ldvar(SEXP sym);
+    inline static BC ldvarForUpdate(SEXP sym);
     inline static BC ldvarNoForce(SEXP sym);
     inline static BC ldvarSuper(SEXP sym);
     inline static BC ldvarNoForceSuper(SEXP sym);
@@ -596,6 +597,7 @@ BC_NOARGS(V, _)
         case Opcode::push_:
         case Opcode::ldfun_:
         case Opcode::ldvar_:
+        case Opcode::ldvar_for_update_:
         case Opcode::ldvar_noforce_:
         case Opcode::ldvar_super_:
         case Opcode::ldvar_noforce_super_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -110,6 +110,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::ldfun_:
     case Opcode::ldddvar_:
     case Opcode::ldvar_:
+    case Opcode::ldvar_for_update_:
     case Opcode::ldvar_noforce_:
     case Opcode::ldvar_super_:
     case Opcode::ldvar_noforce_super_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -142,8 +142,8 @@ class CompilerContext {
 };
 
 Code* compilePromise(CompilerContext& ctx, SEXP exp);
-void compileExpr(CompilerContext& ctx, SEXP exp);
-void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args);
+void compileExpr(CompilerContext& ctx, SEXP exp, bool voidContext = false);
+void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidContext);
 
 void compileWhile(CompilerContext& ctx, std::function<void()> compileCond,
                   std::function<void()> compileBody) {
@@ -280,7 +280,7 @@ assert(false);
 // Inline some specials
 // TODO: once we have sufficiently powerful analysis this should (maybe?) go
 //       away and move to an optimization phase.
-bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
+bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_, bool voidContext) {
     // `true` if an argument isn't missing, labeled, or `...`.
     auto isRegularArg = [](RListIter& arg) {
         return *arg != R_DotsSymbol && *arg != R_MissingArg && !arg.hasTag();
@@ -484,9 +484,8 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
             Case(SYMSXP) {
                 cs << BC::guardNamePrimitive(fun);
                 compileExpr(ctx, rhs);
+                // No ensureNamed needed, stvar already ensures named
                 cs << BC::dup();
-                if (!isConstant(rhs))
-                    cs << BC::ensureNamed();
                 cs << (superAssign ? BC::stvarSuper(lhs) : BC::stvar(lhs))
                    << BC::invisible();
                 return true;
@@ -547,11 +546,24 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
         compileExpr(ctx, rhs);
         // Keep a copy of rhs since it's the result of this expression
         cs << BC::dup();
-        if (!isConstant(rhs))
-            cs << BC::ensureNamed();
+        if (!voidContext && !isConstant(rhs))
+            cs << BC::setShared();
 
-        // Now load index and target
-        cs << (superAssign ? BC::ldvarSuper(target) : BC::ldvar(target));
+        // Again, subassign bytecodes override objects with named count of 1. If
+        // the target is from the outer scope that would be wrong. For example
+        //
+        //     a <- 1
+        //     f <- function()
+        //         a[[1]] <- 2
+        //
+        // the f function should not override a.
+        // The ldvarForUpdate BC increments the named count if the target is
+        // not local to the current environment.
+
+        cs << (superAssign ? BC::ldvarSuper(target)
+                           : BC::ldvarForUpdate(target));
+
+        // And index
         compileExpr(ctx, *idx);
         if (is2d) {
             compileExpr(ctx, *idx2);
@@ -592,9 +604,12 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
         }
 
         for (RListIter e = args.begin(); e != args.end(); ++e) {
-            compileExpr(ctx, *e);
-            if (e + 1 != args.end())
+            if (e + 1 != args.end()) {
+                compileExpr(ctx, *e, true);
                 cs << BC::pop();
+            } else {
+                compileExpr(ctx, *e);
+            }
         }
 
         return true;
@@ -615,12 +630,12 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
             cs << BC::push(R_NilValue)
                << BC::invisible();
         } else {
-            compileExpr(ctx, args[2]);
+            compileExpr(ctx, args[2], voidContext);
         }
         cs << BC::br(nextBranch);
 
         cs << trueBranch;
-        compileExpr(ctx, args[1]);
+        compileExpr(ctx, args[1], voidContext);
 
         cs << nextBranch;
         return true;
@@ -729,7 +744,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
                          compileExpr(ctx, cond);
                          cs << BC::asbool();
                      },
-                     [&ctx, &body]() { compileExpr(ctx, body); });
+                     [&ctx, &body]() { compileExpr(ctx, body, true); });
 
         return true;
     }
@@ -751,7 +766,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
         cs << BC::beginloop(nextBranch)
            << loopBranch;
 
-        compileExpr(ctx, body);
+        compileExpr(ctx, body, true);
         cs << BC::pop()
            << BC::br(loopBranch)
            << nextBranch;
@@ -814,7 +829,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_) {
         // Set the loop variable
         cs << BC::stvar(sym);
 
-        compileExpr(ctx, body);
+        compileExpr(ctx, body, true);
         cs << BC::pop()
            << BC::br(loopBranch);
 
@@ -931,7 +946,7 @@ SIMPLE_INSTRUCTIONS(V, _)
 }
 
 // function application
-void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args) {
+void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidContext) {
     CodeStream& cs = ctx.cs();
 
     // application has the form:
@@ -940,7 +955,7 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args) {
     // LHS can either be an identifier or an expression
     Match(fun) {
         Case(SYMSXP) {
-            if (compileSpecialCall(ctx, ast, fun, args))
+            if (compileSpecialCall(ctx, ast, fun, args, voidContext))
                 return;
 
             cs << BC::ldfun(fun);
@@ -1011,11 +1026,11 @@ void compileConst(CodeStream& cs, SEXP constant) {
     cs << BC::push(constant) << BC::visible();
 }
 
-void compileExpr(CompilerContext& ctx, SEXP exp) {
+void compileExpr(CompilerContext& ctx, SEXP exp, bool voidContext) {
     // Dispatch on the current type of AST node
     Match(exp) {
         // Function application
-        Case(LANGSXP, fun, args) { compileCall(ctx, exp, fun, args); }
+        Case(LANGSXP, fun, args) { compileCall(ctx, exp, fun, args, voidContext); }
         // Variable lookup
         Case(SYMSXP) { compileGetvar(ctx.cs(), exp); }
         Case(PROMSXP, value, expr) {

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -51,6 +51,12 @@ DEF_INSTR(ldfun_, 1, 0, 1, 0)
 
 /**
  * ldvar_:: take immediate CP index of symbol, finding binding in env and push.
+ * Increment named count if the variable is not local.
+ */
+DEF_INSTR(ldvar_for_update_, 1, 0, 1, 0)
+
+/**
+ * ldvar_:: take immediate CP index of symbol, finding binding in env and push.
  */
 DEF_INSTR(ldvar_, 1, 0, 1, 0)
 


### PR DESCRIPTION
The main changes here are:

### Fix named count for stvar

this was completely bogus. in ir/compiler.cpp we used to emit an `BC::ensureNamed()` before `stvar`. This means before stvar, the named count was already 1 and the stvar would *always* bump it to 2...

I changed this with the following consequences:

* the static refcount analysis was revealed to be broken
* the subassign case in ir/compiler.cpp was revealed to be broken

### Issues with subassign in RIR

In this case:

```
     a <- 1
     f <- function()
         a[[1]] <- 2
```
in the inner function, we load `a`, then do an `subassign`, which will override in-place, because the named count is 1. Only after the subassign, we store back `a` in the inner scope and realize that named is now 2 (too late).

To fix this problem I added a `ldVarForUpdate` bytecode that bumps the named count if the variable is loaded from an outer scope.

The same needs to be done in Pir2Rir, when we cannot statically rule out that the vector is from an outer scope.

### Issues with static refcount analysis

1. the merge was not forming a lattice, taking long to converge in some cases
2. trying to figure out if subassign is changing a value is bound to be doomed. a simple counterexample produced by jakobeha for the inc_ bytecode shows this (see comment below). the problem is we would have to also track bindings, which we don't want to do outside of the scope analysis. Therefore we completely remove that part from the refcount analysis.
3. it was very imprecise, often way too conservative (e.g. ensureNamed for values which flow into stvar, which is guaranteed to increment refcount)
4. the abstract states get huge for big functions. we need an upper limit where we give up to not take forever on gitlab-ci.