### PR TITLE
scope analysis uses wrong state for recursive lookup

### DIFF
--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -297,8 +297,10 @@ class StaticAnalysis {
                             extra.emplace(i, state);
                         }
                         recursiveTodo.push_back(Position(bb, i));
-                    } else if (res.keepSnapshot) {
-                        snapshots[bb->id].extra.emplace(i, state);
+                    }
+
+                    if (res.keepSnapshot || snapshots[bb->id].extra.count(i)) {
+                        snapshots[bb->id].extra[i] = state;
                     }
                 }
 
@@ -653,8 +655,11 @@ class BackwardStaticAnalysis {
                                 extra.emplace(i, state);
                             }
                             recursiveTodo.push_back(Position(bb, i));
-                        } else if (res.keepSnapshot) {
-                            snapshots[bb->id].extra.emplace(i, state);
+                        }
+
+                        if (res.keepSnapshot ||
+                            snapshots[bb->id].extra.count(i)) {
+                            snapshots[bb->id].extra[i] = state;
                         }
                     }
 

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -140,7 +140,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
         }
 
         if (!handled) {
-            lookup(state, arg->followCastsAndForce(),
+            lookup(state, arg->followCasts(),
                    [&](const AbstractPirValue& analysisRes) {
                        if (!analysisRes.type.maybeLazy()) {
                            if (!analysisRes.type.maybePromiseWrapped())
@@ -162,7 +162,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
             // We are certain that we do force something here. Let's peek
             // through the argument and see if we find a promise. If so, we
             // will analyze it.
-            if (auto mkarg = MkArg::Cast(arg->followCastsAndForce())) {
+            if (auto mkarg = MkArg::Cast(arg->followCasts())) {
                 ScopeAnalysis prom(closure, mkarg->prom(), mkarg->env(), state,
                                    depth + 1, log);
                 prom();
@@ -237,7 +237,7 @@ AbstractResult ScopeAnalysis::apply(ScopeAnalysisState& state,
                 if (SafeBuiltinsList::nonObject(builtin->blt)) {
                     safe = true;
                     builtin->eachCallArg([&](Value* arg) {
-                        lookup(state, arg->followCastsAndForce(),
+                        lookup(state, arg->followCasts(),
                                [&](const AbstractPirValue& analysisRes) {
                                    if (analysisRes.type.maybeObj())
                                        safe = false;

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -23,11 +23,6 @@ void ScopeAnalysis::lookup(const ScopeAnalysisState& state, Value* v,
     // value from the inter-procedural analysis.
     if (state.returnValues.count(instr)) {
         auto& res = state.returnValues.at(instr);
-        if (res.isSingleValue()) {
-            lookup(state, res.singleValue().val, action,
-                   [&]() { action(AbstractLoad(res)); });
-            return;
-        }
         action(AbstractLoad(res));
         return;
     }

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -141,30 +141,15 @@ class ScopeAnalysis : public StaticAnalysis<
 
     AbstractLoad loadFun(const ScopeAnalysisState& state, SEXP name,
                          Value* env) const {
-        auto aLoad = state.envs.getFun(env, name);
-        // recurse into the result
-        if (aLoad.result.isSingleValue())
-            lookup(state, aLoad.result.singleValue().val,
-                   [&](const AbstractLoad& ld) { aLoad = ld; });
-        return aLoad;
+        return state.envs.getFun(env, name);
     }
     AbstractLoad load(const ScopeAnalysisState& state, SEXP name,
                       Value* env) const {
-        auto aLoad = state.envs.get(env, name);
-        // recurse into the result
-        if (aLoad.result.isSingleValue())
-            lookup(state, aLoad.result.singleValue().val,
-                   [&](const AbstractLoad& ld) { aLoad = ld; });
-        return aLoad;
+        return state.envs.get(env, name);
     }
     AbstractLoad superLoad(const ScopeAnalysisState& state, SEXP name,
                            Value* env) const {
-        auto aLoad = state.envs.get(env, name);
-        // recurse into the result
-        if (aLoad.result.isSingleValue())
-            lookup(state, aLoad.result.singleValue().val,
-                   [&](const AbstractLoad& ld) { aLoad = ld; });
-        return aLoad;
+        return state.envs.get(env, name);
     }
 
     typedef std::function<void(

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -107,3 +107,9 @@ if (Sys.getenv("PIR_ENABLE") == "") {
   stopifnot(length(.Call("rir_invocation_count", p)) > 3)
   compiler::enableJIT(old)
 }
+
+# scope analysis bug
+f <- function() {a <- r(); b <- a; a[[1]] <- 2; a+b}
+r <- function() 22
+for (i in 1:5)
+  stopifnot(f() == 24)


### PR DESCRIPTION
recursive lookup in scope analysis is bogus, since the state of the
initial instruction is used to query the state of earlier instructions.

for example in:

  a <- 1
  b <- a
  a <- 2
  a + b

we would resolve "b" in the last line to "ldvar a", then we use the same
state again to lookup "a", which would return 2 instead of 1.

Thus the recursive lookup is bogus and needs to be removed.