### PR TITLE
revert the overriding semantics of inc again

### DIFF
--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -126,7 +126,6 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
         case Tag::Subassign2_1D:
         case Tag::Subassign1_2D:
         case Tag::Subassign2_2D:
-        case Tag::Inc:
             if (auto input = Instruction::Cast(i->arg(0).val())) {
                 if (input->needsReferenceCount() && state.uses.count(input) &&
                     state.uses.at(input) == AUses::Multiple) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2165,11 +2165,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
         INSTRUCTION(inc_) {
             SEXP val = ostack_top(ctx);
             SLOWASSERT(TYPEOF(val) == INTSXP);
-            // Inc_ destructively modifies TOS, even if the refcount is 1. This
-            // can be used to perform `++i` on a value on the stack. The old i
-            // value will be overwritten (generally only do this if you are sure
-            // that this is the last copy on the stack).
-            if (MAYBE_SHARED(val)) {
+            if (MAYBE_REFERENCED(val)) {
                 int i = INTEGER(val)[0];
                 ostack_pop(ctx);
                 SEXP n = Rf_allocVector(INTSXP, 1);

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -242,7 +242,7 @@ DEF_INSTR(add_, 0, 2, 1, 0)
 DEF_INSTR(uplus_, 0, 1, 1, 0)
 
 /**
- * inc_ :: increment tos integer (destructive! ignores refcount)
+ * inc_ :: increment tos integer
  */
 DEF_INSTR(inc_, 0, 1, 1, 1)
 


### PR DESCRIPTION
this is just microoptimizing for dubious gain.
The solution was broken. Thanks @Jakobeha for pointing out the
counterexample:

    %0.0 = LdVar i
    %0.1 = Inc %0.0
    %0.2 = LdVar i