### PR TITLE
Refactor liveness

### DIFF
--- a/rir/src/compiler/analysis/liveness.cpp
+++ b/rir/src/compiler/analysis/liveness.cpp
@@ -1,6 +1,6 @@
 #include "liveness.h"
-#include "../../pir/bb.h"
-#include "../../pir/instruction.h"
+#include "../pir/bb.h"
+#include "../pir/instruction.h"
 
 #include <map>
 #include <set>

--- a/rir/src/compiler/analysis/liveness.cpp
+++ b/rir/src/compiler/analysis/liveness.cpp
@@ -148,5 +148,20 @@ bool LivenessIntervals::live(Instruction* where, Value* what) const {
     return bbLiveness.begin <= idx && idx < bbLiveness.end;
 }
 
+bool LivenessIntervals::interfere(Value* v1, Value* v2) const {
+    const auto& l1 = at(v1);
+    const auto& l2 = at(v2);
+    assert(l1.size() == l2.size());
+
+    for (size_t i = 0; i < l1.size(); ++i) {
+        const auto& int1 = l1[i];
+        const auto& int2 = l2[i];
+        if (int1.live && int2.live) {
+            return int1.begin <= int2.end && int2.begin <= int1.end;
+        }
+    }
+    return false;
+}
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/analysis/liveness.h
+++ b/rir/src/compiler/analysis/liveness.h
@@ -50,26 +50,12 @@ struct BBLiveness {
     unsigned end = -1;
 };
 
-struct Liveness : public std::vector<BBLiveness> {
-    bool interfere(const Liveness& other) const {
-        assert(size() == other.size());
-        for (size_t i = 0; i < size(); ++i) {
-            const BBLiveness& mine = (*this)[i];
-            const BBLiveness& their = other[i];
-            if (mine.live && their.live) {
-                if (mine.begin == their.begin ||
-                    (mine.begin < their.begin && mine.end >= their.begin) ||
-                    (mine.begin > their.begin && their.end >= mine.begin))
-                    return true;
-            }
-        }
-        return false;
-    }
-};
+typedef std::vector<BBLiveness> Liveness;
 
 struct LivenessIntervals : public std::unordered_map<Value*, Liveness> {
     LivenessIntervals(unsigned bbsSize, CFG const& cfg);
     bool live(Instruction* where, Value* what) const;
+    bool interfere(Value* v1, Value* v2) const;
 };
 
 } // namespace pir

--- a/rir/src/compiler/analysis/liveness.h
+++ b/rir/src/compiler/analysis/liveness.h
@@ -50,12 +50,14 @@ struct BBLiveness {
     unsigned end = -1;
 };
 
-typedef std::vector<BBLiveness> Liveness;
+class LivenessIntervals {
+    std::unordered_map<Value*, std::vector<BBLiveness>> intervals;
 
-struct LivenessIntervals : public std::unordered_map<Value*, Liveness> {
+  public:
     LivenessIntervals(unsigned bbsSize, CFG const& cfg);
     bool live(Instruction* where, Value* what) const;
     bool interfere(Value* v1, Value* v2) const;
+    size_t count(Value* v) const { return intervals.count(v); }
 };
 
 } // namespace pir

--- a/rir/src/compiler/analysis/liveness.h
+++ b/rir/src/compiler/analysis/liveness.h
@@ -6,6 +6,41 @@
 #include <unordered_map>
 #include <vector>
 
+/*
+ * The liveness analysis _does not_ use the static analysis framework. This is
+ * intentional:
+ *
+ *   1. The framework does not handle phis properly in this case.
+ *   2. The framework can compute liveness sets, but not liveness intervals.
+ *   3. Because we're in SSA, we don't actually need to compute a fixed point.
+ *
+ * Liveness intervals are stored as:
+ *   Instruction* -> BB id -> { Dead | Live [start, end) }
+ *
+ * An instruction maps to a vector, where each entry represents a BB's liveness
+ * interval. `start` is included, `end` is excluded. Liveness is for the
+ * position _after_ an instruction. E.g., for the range [0, 2), the variable is
+ * live after the first (index 0) and second (index 1) instructions.
+ *
+ * Because of SSA, definitions are guaranteed to dominate uses. Therefore, the
+ * basic idea of the algorithm is:
+ *   - run the analysis backwards
+ *   - the first use of a variable is the end of the interval
+ *   - the definition of a variable is the beginning of the interval
+ *   - phi inputs are only propagated into their corresponding predecessors
+ *
+ * This is roughly Algorithm 4 ("ByUse") and Algorithm 5 in:
+ *   Computing Liveness Sets for SSA-Form Programs
+ *   https://hal.inria.fr/inria-00558509v1/document
+ *
+ * That paper also describes other, fancier algorithms, but it may be more
+ * difficult to construct the liveness intervals.
+ *
+ * Another fancy algorithm is:
+ *   Fast Liveness Checking for SSA-Form Programs
+ *   http://www.rw.cdl.uni-saarland.de/~grund/papers/cgo08-liveness.pdf
+ */
+
 namespace rir {
 namespace pir {
 

--- a/rir/src/compiler/analysis/liveness.h
+++ b/rir/src/compiler/analysis/liveness.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../pir/pir.h"
-#include "../../util/cfg.h"
+#include "../pir/pir.h"
+#include "../util/cfg.h"
 
 #include <unordered_map>
 #include <vector>

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -32,11 +32,7 @@ namespace {
  * stack. It uses the following algorithm:
  *
  * 1. Split phis with moves. This translates the IR to CSSA (see toCSSA).
- * 2. Compute liveness (see computeLiveness):
- *    Liveness intervals are stored as:
- *        Instruction* -> BB id -> { start : pos, end : pos, live : bool}
- *    Two Instructions interfere iff there is a BB where they are both live
- *    and the start-end overlap.
+ * 2. Compute liveness (see liveness.h):
  * 3. For now, just put everything on stack. (step 4 is thus skipped...)
  * 4. Assign the remaining Instructions to local RIR variable numbers
  *    (see computeAllocation):

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -102,8 +102,7 @@ class SSAAllocator {
         std::unordered_map<SlotNumber, std::unordered_set<Value*>> reverseAlloc;
         auto slotIsAvailable = [&](SlotNumber slot, Value* i) {
             for (auto other : reverseAlloc[slot])
-                if (livenessIntervals.at(other).interfere(
-                        livenessIntervals.at(i)))
+                if (livenessIntervals.interfere(other, i))
                     return false;
             return true;
         };

--- a/rir/src/compiler/translations/pir_2_rir/stack_use.h
+++ b/rir/src/compiler/translations/pir_2_rir/stack_use.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "../../analysis/generic_static_analysis.h"
+#include "../../analysis/liveness.h"
 #include "../../pir/pir.h"
-#include "liveness.h"
 
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
I moved the liveness analysis because I'll need it for loop peeling.

I also added more documentation, to prevent other people from going on a wild goose chase like I did.

I did not fix the "you can only query after an instruction" because there is no need for it (yet); it'll be in the loop peeling PR.

You can look at the individual commits to separate the move from the changes.