### PR TITLE
Fixed static_cast_ assertion

### DIFF
--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -233,6 +233,9 @@ struct PirType {
     RIR_INLINE constexpr bool isRType() const {
         return flags_.includes(TypeFlags::rtype);
     }
+    RIR_INLINE bool isRType(const RType& o) const {
+        return isRType() && t_.r == o;
+    }
     RIR_INLINE constexpr bool maybe(RType type) const {
         return isRType() && t_.r.includes(type);
     }
@@ -329,10 +332,6 @@ struct PirType {
 
     static const PirType voyd() { return PirType(NativeTypeSet()); }
     static const PirType bottom() { return optimistic(); }
-
-    RIR_INLINE bool operator==(const RType& o) const {
-        return isRType() && t_.r == o;
-    }
 
     RIR_INLINE bool operator==(const NativeType& o) const {
         return !isRType() && t_.n == o;

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -35,9 +35,9 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
         if (assumptions.isEager(i) && assumptions.isNotObj(i) &&
             value->type.isScalar()) {
             assert(value->type.isRType());
-            if (value->type == RType::real)
+            if (value->type.isRType(RType::real))
                 assumptions.setSimpleReal(i);
-            if (value->type == RType::integer)
+            if (value->type.isRType(RType::integer))
                 assumptions.setSimpleInt(i);
         }
     }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -570,11 +570,11 @@ static void addDynamicAssumptionsFromContext(CallContext& call) {
                     notObj = false;
                     isEager = false;
                 }
+            } else if (arg == R_MissingArg) {
+                given.remove(Assumption::NoExplicitlyMissingArgs);
             }
             if (isObject(arg)) {
                 notObj = false;
-            } else if (arg == R_MissingArg) {
-                given.remove(Assumption::NoExplicitlyMissingArgs);
             }
             if (isEager)
                 given.setEager(i);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2119,6 +2119,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 fun = dispatch(call, dt);
                 // Patch inline cache
                 (*(Immediate*)pc) = Pool::insert(fun->container());
+                assert(fun != dt->baseline());
             }
             advanceImmediate();
 

--- a/rir/tests/pir_dispatch.R
+++ b/rir/tests/pir_dispatch.R
@@ -1,0 +1,23 @@
+options(error=expression(NULL)) # don't stop on error in batch
+
+##  cacheMethod  :
+c0 <- character(0)
+l0 <- logical(0)
+m0 <- matrix(1,0,0)
+df0 <- as.data.frame(c0)
+f <- rir.compile(get("cacheMethod", pos = 'package:methods'))
+f()
+f(NULL)
+f(,NULL)
+f(NULL,NULL)
+f(list())
+f(l0)
+f(c0)
+f(m0)
+f(df0)
+f(FALSE)
+f(list(),list())
+f(l0,l0)
+f(c0,c0)
+f(df0,df0)
+f(FALSE,FALSE)


### PR DESCRIPTION
Previously, if we had a promise which resolved to a missing, we wouldn't remove `NoExplicitlyMissingArgs`. The problem was, my old branch changed that. This changes it back.

However, that could actually be a bug. If a promise resolves to a missing arg, wouldn't that assumption be wrong?

Another potential problem, I overloaded `PirType == RType`, and that was used in some places to get `PirType == PirType(RType)`, which might've had different behavior. I changed my overload to `PirType.isRType(RType)` to prevent confusion and in case that was the bug.