### PR TITLE
fix performance regressions introduced in #417

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -32,6 +32,7 @@ struct ValOrig {
         return val == other.val && origin == other.origin &&
                recursionLevel == other.recursionLevel;
     }
+    bool operator!=(const ValOrig& other) const { return !(*this == other); }
 };
 }
 }
@@ -128,6 +129,17 @@ struct AbstractPirValue {
     }
 
     void print(std::ostream& out, bool tty = false) const;
+
+    bool operator==(const AbstractPirValue& other) const {
+        if (unknown && other.unknown)
+            return true;
+        return type == other.type && vals == other.vals &&
+               unknown == other.unknown;
+    }
+
+    bool operator!=(const AbstractPirValue& other) const {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -255,6 +267,14 @@ struct AbstractLoad {
     AbstractLoad(Value* env, const AbstractPirValue& val)
         : env(env), result(val) {
         assert(env);
+    }
+
+    bool operator==(const AbstractLoad& other) const {
+        return env == other.env && result == other.result;
+    }
+
+    bool operator!=(const AbstractLoad& other) const {
+        return !(*this == other);
     }
 };
 

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -20,9 +20,16 @@ namespace pir {
  * all loads (`LdVar`).
  *
  */
+struct ScopeAnalysisResults {
+    std::unordered_map<Instruction*, AbstractLoad> results;
+    std::unordered_map<Instruction*, AbstractPirValue> returnValues;
+    bool _changed;
+    void resetChanged() { _changed = false; }
+    bool changed() const { return _changed; }
+};
+
 class ScopeAnalysisState {
     AbstractREnvironmentHierarchy envs;
-    std::unordered_map<Instruction*, AbstractPirValue> returnValues;
     AbstractPirValue returnValue;
 
     bool mayUseReflection = false;
@@ -46,15 +53,7 @@ class ScopeAnalysisState {
 
   public:
     AbstractResult merge(const ScopeAnalysisState& other) {
-        AbstractResult res;
-
-        // Return values are only useful within one function. No need to merge
-        // across interprocedural invocations. That's why this part is not in
-        // mergeGeneric.
-        for (const auto& f : other.returnValues)
-            res.max(returnValues[f.first].merge(f.second));
-
-        return res.max(mergeGeneric(other));
+        return mergeGeneric(other);
     }
 
     AbstractResult mergeExit(const ScopeAnalysisState& other) {
@@ -69,16 +68,6 @@ class ScopeAnalysisState {
 
     void print(std::ostream& out, bool tty) const {
         envs.print(out, tty);
-        if (returnValues.size() > 0) {
-            out << "== Infered call/force result:\n";
-            for (auto& t : returnValues) {
-                out << "* ";
-                t.first->printRef(out);
-                out << " : ";
-                t.second.print(out, tty);
-                out << "\n";
-            }
-        }
         out << "== Result: ";
         returnValue.print(out, tty);
         out << "\n";
@@ -87,66 +76,86 @@ class ScopeAnalysisState {
     }
 };
 
-class ScopeAnalysis : public StaticAnalysis<
-                          ScopeAnalysisState /*, AnalysisDebugLevel::Taint */> {
+class ScopeAnalysis
+    : public StaticAnalysis<
+          ScopeAnalysisState,
+          ScopeAnalysisResults /*, AnalysisDebugLevel::Instruction */> {
   private:
     const std::vector<Value*> args;
 
     static constexpr size_t MAX_DEPTH = 2;
-    static constexpr size_t MAX_SIZE = 200;
+    static constexpr size_t MAX_SIZE = 1000;
+    static constexpr size_t MAX_RESULTS = 1000;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();
     using StaticAnalysis::PositioningStyle;
 
+    AbstractResult doCompute(ScopeAnalysisState& state, Instruction* i,
+                             bool updateGlobalState);
+
+    ScopeAnalysisResults* globalStateStore = nullptr;
+
   protected:
+    AbstractResult compute(ScopeAnalysisState& state, Instruction* i) override {
+        return doCompute(state, i, true);
+    }
     AbstractResult apply(ScopeAnalysisState& state,
-                         Instruction* i) const override;
+                         Instruction* i) const override {
+        return const_cast<ScopeAnalysis*>(this)->doCompute(state, i, false);
+    }
 
   public:
     // Default
     ScopeAnalysis(ClosureVersion* cls, LogStream& log)
-        : StaticAnalysis("Scope", cls, cls, log), depth(0) {}
+        : StaticAnalysis("Scope", cls, cls, log), depth(0) {
+        globalState = globalStateStore = new ScopeAnalysisResults;
+    }
+
+    ~ScopeAnalysis() {
+        if (globalStateStore)
+            delete globalStateStore;
+    }
 
     // For interprocedural analysis of a function
     ScopeAnalysis(ClosureVersion* cls, const std::vector<Value*>& args,
                   Value* staticClosureEnv,
-                  const ScopeAnalysisState& initialState, size_t depth,
+                  const ScopeAnalysisState& initialState,
+                  ScopeAnalysisResults* globalState, size_t depth,
                   LogStream& log)
-        : StaticAnalysis("Scope", cls, cls, initialState, log), depth(depth),
-          staticClosureEnv(staticClosureEnv) {
+        : StaticAnalysis("Scope", cls, cls, initialState, globalState, log),
+          depth(depth), staticClosureEnv(staticClosureEnv) {
         assert(args.size() == cls->nargs());
     }
 
     // For interprocedural analysis of a promise
     ScopeAnalysis(ClosureVersion* cls, Promise* prom, Value* promEnv,
-                  const ScopeAnalysisState& initialState, size_t depth,
+                  const ScopeAnalysisState& initialState,
+                  ScopeAnalysisResults* globalState, size_t depth,
                   LogStream& log);
 
     typedef std::function<void(const AbstractLoad&)> LoadMaybe;
     typedef std::function<void(const AbstractPirValue&)> ValueMaybe;
     typedef std::function<void()> Maybe;
 
+  public:
     // Lookup what the analysis knows about the result of executing
     // instruction i. This recursively queries all available ressources,
     // such as binding structure, inter-procedural return values, function
     // arguments and so on.
-    //
-    // global version, can be called if the state does not correspond with i
-    void lookupGlobal(const ScopeAnalysisState&, Value*, const LoadMaybe&,
-                      const Maybe& notFound = []() {}) const;
-    void lookupGlobal(const ScopeAnalysisState& state, Value* v,
-                      const ValueMaybe& action,
-                      const Maybe& notFound = []() {}) const {
-        lookupGlobal(state, v, [&](AbstractLoad load) { action(load.result); },
-                     notFound);
+    void lookup(Value*, const LoadMaybe&,
+                const Maybe& notFound = []() {}) const;
+    void lookup(Value* v, const ValueMaybe& action,
+                const Maybe& notFound = []() {}) const {
+        lookup(v, [&](AbstractLoad load) { action(load.result); }, notFound);
     }
-    // state MUST correspond with the position of "i"
-    void lookupAt(const ScopeAnalysisState&, Value*, const LoadMaybe&,
+    // lookupAt must be called with a state that is valid at the instruction
+    // position!
+    void lookupAt(const ScopeAnalysisState&, Instruction*, const LoadMaybe&,
                   const Maybe& notFound = []() {}) const;
-    void lookupAt(const ScopeAnalysisState& state, Value* v,
+    void lookupAt(const ScopeAnalysisState& state, Instruction* i,
                   const ValueMaybe& action,
                   const Maybe& notFound = []() {}) const {
-        lookupAt(state, v, [&](AbstractLoad load) { action(load.result); },
+        lookupAt(state, i, [&](AbstractLoad load) { action(load.result); },
                  notFound);
     }
 
@@ -154,24 +163,24 @@ class ScopeAnalysis : public StaticAnalysis<
                          Value* env) const {
         auto aLoad = state.envs.getFun(env, name);
         if (aLoad.result.isSingleValue())
-            lookupGlobal(state, aLoad.result.singleValue().val,
-                         [&](const AbstractLoad& ld) { aLoad = ld; });
+            lookup(aLoad.result.singleValue().val,
+                   [&](const AbstractLoad& ld) { aLoad = ld; });
         return aLoad;
     }
     AbstractLoad load(const ScopeAnalysisState& state, SEXP name,
                       Value* env) const {
         auto aLoad = state.envs.get(env, name);
         if (aLoad.result.isSingleValue())
-            lookupGlobal(state, aLoad.result.singleValue().val,
-                         [&](const AbstractLoad& ld) { aLoad = ld; });
+            lookup(aLoad.result.singleValue().val,
+                   [&](const AbstractLoad& ld) { aLoad = ld; });
         return aLoad;
     }
     AbstractLoad superLoad(const ScopeAnalysisState& state, SEXP name,
                            Value* env) const {
         auto aLoad = state.envs.get(env, name);
         if (aLoad.result.isSingleValue())
-            lookupGlobal(state, aLoad.result.singleValue().val,
-                         [&](const AbstractLoad& ld) { aLoad = ld; });
+            lookup(aLoad.result.singleValue().val,
+                   [&](const AbstractLoad& ld) { aLoad = ld; });
         return aLoad;
     }
 

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -262,7 +262,7 @@ class TheScopeResolution {
                     }
                 }
 
-                analysis.lookup(after, i, [&](const AbstractLoad& aLoad) {
+                analysis.lookupAt(after, i, [&](const AbstractLoad& aLoad) {
                     auto& res = aLoad.result;
 
                     // In case the scope analysis is sure that this is
@@ -341,7 +341,7 @@ class TheScopeResolution {
                             // TODO: if !guess->maybe(closure) we know that the
                             // guess is wrong and could try the next binding.
                             if (!guess->type.isA(PirType::closure())) {
-                                analysis.lookup(
+                                analysis.lookupAt(
                                     before, guess,
                                     [&](const AbstractPirValue& res) {
                                         if (auto val = getSingleLocalValue(res))

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -341,12 +341,15 @@ class TheScopeResolution {
                             // TODO: if !guess->maybe(closure) we know that the
                             // guess is wrong and could try the next binding.
                             if (!guess->type.isA(PirType::closure())) {
-                                analysis.lookupAt(
-                                    before, guess,
-                                    [&](const AbstractPirValue& res) {
-                                        if (auto val = getSingleLocalValue(res))
-                                            guess = val;
-                                    });
+                                if (auto i = Instruction::Cast(guess)) {
+                                    analysis.lookupAt(
+                                        before, i,
+                                        [&](const AbstractPirValue& res) {
+                                            if (auto val =
+                                                    getSingleLocalValue(res))
+                                                guess = val;
+                                        });
+                                }
                             }
                             if (guess->type.isA(PirType::closure()) &&
                                 guess->validIn(function)) {

--- a/rir/src/compiler/translations/pir_2_rir/stack_use.h
+++ b/rir/src/compiler/translations/pir_2_rir/stack_use.h
@@ -46,9 +46,7 @@ struct StackUseAnalysisState {
  * executed. Also get a set of values that need to be removed from the stack
  * after each instruction.
  */
-class StackUseAnalysis
-    : public StaticAnalysis<StackUseAnalysisState, AnalysisDebugLevel::None> {
-
+class StackUseAnalysis : public StaticAnalysis<StackUseAnalysisState> {
   private:
     LivenessIntervals const& liveness;
 


### PR DESCRIPTION
some part of the scope analysis state can be queried at any position and only the actual bindings are flow-sensitive.