### PR TITLE
Safe force args in RIR -> RIR/PIR calls

### DIFF
--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -8,7 +8,7 @@
 
 namespace rir {
 
-static RIR_INLINE SEXP safeEval(SEXP e, SEXP rho) {
+SEXP safeEval(SEXP e, SEXP rho) {
     SEXPTYPE t = TYPEOF(e);
     if (t == LANGSXP || t == SYMSXP || t == PROMSXP || t == BCODESXP ||
         t == EXTERNALSXP) {

--- a/rir/src/interpreter/safe_force.h
+++ b/rir/src/interpreter/safe_force.h
@@ -5,6 +5,9 @@
 
 namespace rir {
 
+// Will try to evaluate the SEXP if it definitely doesn't cause side effects,
+// rho can be nullptr if the environment is unknown
+SEXP safeEval(SEXP e, SEXP rho);
 // Will try to evaluate the promise if it definitely doesn't cause side effects
 SEXP safeForcePromise(SEXP e);
 

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1029,9 +1029,12 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidC
     if (Compiler::profile) {
         cs << BC::recordCall();
     }
-    if (!hasNames)
+    if (hasNames) {
+        cs << BC::callImplicit(callArgs, names, ast, assumptions);
+    } else {
         assumptions.add(Assumption::CorrectOrderOfArguments);
-    cs << BC::callImplicit(callArgs, names, ast, assumptions);
+        cs << BC::callImplicit(callArgs, ast, assumptions);
+    }
     if (voidContext)
         cs << BC::pop();
 }

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -9,6 +9,7 @@
 #include "R/Symbols.h"
 #include "R/Funtab.h"
 
+#include "../interpreter/safe_force.h"
 #include "utils/Pool.h"
 
 #include "CodeVerifier.h"
@@ -981,9 +982,11 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidC
     // Arguments can be optionally named
     std::vector<BC::FunIdx> callArgs;
     std::vector<SEXP> names;
+    Assumptions assumptions;
 
     bool hasNames = false;
-    for (RListIter arg = RList(args).begin(); arg != RList::end(); ++arg) {
+    int i = 0;
+    for (RListIter arg = RList(args).begin(); arg != RList::end(); ++i, ++arg) {
         if (*arg == R_DotsSymbol) {
             callArgs.push_back(DOTS_ARG_IDX);
             names.push_back(R_NilValue);
@@ -1005,18 +1008,30 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidC
         names.push_back(arg.tag());
         if (arg.tag() != R_NilValue)
             hasNames = true;
+
+        // (3) "safe force" the argument to get static assumptions
+        SEXP known = safeEval(*arg, nullptr);
+        // TODO: If we add more assumptions should probably abstract with
+        // testArg in interp.cpp. For now they're both much different though
+        if (known != R_UnboundValue) {
+            assumptions.setEager(i);
+            if (!isObject(known)) {
+                assumptions.setNotObj(i);
+                if (IS_SIMPLE_SCALAR(known, REALSXP))
+                    assumptions.setSimpleReal(i);
+                if (IS_SIMPLE_SCALAR(known, INTSXP))
+                    assumptions.setSimpleInt(i);
+            }
+        }
     }
     assert(callArgs.size() < BC::MAX_NUM_ARGS);
 
     if (Compiler::profile) {
         cs << BC::recordCall();
     }
-    if (hasNames) {
-        cs << BC::callImplicit(callArgs, names, ast, {});
-    } else {
-        cs << BC::callImplicit(
-            callArgs, ast, Assumptions(Assumption::CorrectOrderOfArguments));
-    }
+    if (!hasNames)
+        assumptions.add(Assumption::CorrectOrderOfArguments);
+    cs << BC::callImplicit(callArgs, names, ast, assumptions);
     if (voidContext)
         cs << BC::pop();
 }


### PR DESCRIPTION
This lets us infer assumptions for implicit calls made in RIR, so now we can infer simple arguments like constants at any callsite.

Modifies how `callImplicit`s are compiled, so that now a "safe forced" version of the compiled `SEXP` is pushed into the promise pool after each promise. Then the interpreter uses this to generate assumptions