### PR TITLE
Fixed `put` in rir2pir

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -731,7 +731,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 
     case Opcode::put_: {
         x = top();
-        for (size_t i = 0; i < bc.immediate.i - 1; ++i)
+        for (size_t i = 0; i < bc.immediate.i; ++i)
             set(i, at(i + 1));
         set(bc.immediate.i, x);
         break;


### PR DESCRIPTION
Example: `put(1)` should be equivalent to `swap`, but in rir_2_pir it wouldn't move the item below the top-of-stack, it would simply replace that item with the top-of-stack