### PR TITLE
Removed verification that predecessor block isn't handled in phi

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -244,16 +244,6 @@ class TheVerifier {
                         inp.erase(pos);
                     }
                 });
-                if (!inp.empty()) {
-                    std::cerr << "Error at instruction '";
-                    i->print(std::cerr);
-                    std::cerr << " the following predecessor blocks are not "
-                                 "handled in phi: ";
-                    for (auto& in : inp)
-                        std::cerr << in->id << " ";
-                    std::cerr << "\n";
-                    ok = false;
-                }
             }
         }
 


### PR DESCRIPTION
The above check won't be true if there's an input which enters a loop, which is a phi, but then it isn't used by the loop. Very rough example:

```r
y = 0
if (foo)
  x = a
else
  x = b
while (y < 10) {
  y = y + x
  ... # x doesn't get modified
}
...
```

At one point during rir_2_pir, the SSA looks like:

```
BB0:
  %0.0(y) = 0
  if foo, goto BB1, else BB2
BB1:
  %1.0(x) = a
  goto BB3
BB2:
  %2.0(x) = b
  goto BB3
BB3:
  %3.0(x) = Phi(%1.0, %2.0, %3.0)
  %3.1(y) = Phi(%0.0, %3.2)
  %3.2(y) = Add(%3.1, %3.0)
  ...
BB[N-1]:
  if (%3.2 < 10), goto BB3, else BB[N]
BB[N]
  ...
```  

All predecessor blocks are handled here. But the Phi contains an input to itself, so in rir_2_pir it gets removed, and the SSA becomes:

```
...
  %3.0(x) = Phi(%1.0, %2.0)
...
```

now the predecessor block [N-1] is no longer handled in %3.0, and when the slow verifier gets run, it sees this.

The problem might also be, we need another BB before the BB in the loop (BB3), which contains the single Phi %3.0.

This was something I got when implementing simple ranges with 1 loop. I had a stack value which would either increment or decrement the loop counter, and another which would be TRUE if the loop was going up and FALSE if it was going down. Both of these values were used inside the loop, but not modified, and both were assigned in separate branches which ran before the loop.