### PR TITLE
Allow phis which take themselves as input

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -187,9 +187,25 @@ class TheVerifier {
         if (auto phi = Phi::Cast(i)) {
             phi->eachArg([&](BB* input, Value* v) {
                 if (auto iv = Instruction::Cast(v)) {
-                    if (iv == phi) {
+                    if (slow && iv == phi && phi->nargs() == 2) {
                         // Note: can happen in a one-block loop, but only if it
                         // is not edge-split
+                        //
+                        // nargs == 2 because this is OK:
+                        // a   b
+                        //  \ /
+                        //   m<-.
+                        //   \_/
+                        // but this:
+                        //   a
+                        //   |
+                        //   m<-.
+                        //   \_/
+                        // should be cleaned up to
+                        //   a
+                        //   |
+                        //   /<-.
+                        //   \_/
                         std::cerr << "Error at instruction '";
                         i->print(std::cerr);
                         std::cerr << "': input '";

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -187,7 +187,7 @@ class TheVerifier {
         if (auto phi = Phi::Cast(i)) {
             phi->eachArg([&](BB* input, Value* v) {
                 if (auto iv = Instruction::Cast(v)) {
-                    if (input == phi->bb() && iv != phi) {
+                    if (input == phi->bb()) {
                         // Note: can happen in a one-block loop, but only if it
                         // is not edge-split
                         std::cerr << "Error at instruction '";

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -187,34 +187,7 @@ class TheVerifier {
         if (auto phi = Phi::Cast(i)) {
             phi->eachArg([&](BB* input, Value* v) {
                 if (auto iv = Instruction::Cast(v)) {
-                    if (slow && iv == phi && phi->nargs() == 2) {
-                        // Note: can happen in a one-block loop, but only if it
-                        // is not edge-split
-                        //
-                        // nargs == 2 because this is OK:
-                        // a   b
-                        //  \ /
-                        //   m<-.
-                        //   \_/
-                        // but this:
-                        //   a
-                        //   |
-                        //   m<-.
-                        //   \_/
-                        // should be cleaned up to
-                        //   a
-                        //   |
-                        //   /<-.
-                        //   \_/
-                        std::cerr << "Error at instruction '";
-                        i->print(std::cerr);
-                        std::cerr << "': input '";
-                        iv->printRef(std::cerr);
-                        std::cerr << "' phi has itself as input\n";
-                        ok = false;
-                    }
-
-                    if (input == phi->bb()) {
+                    if (input == phi->bb() && iv != phi) {
                         // Note: can happen in a one-block loop, but only if it
                         // is not edge-split
                         std::cerr << "Error at instruction '";

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -151,7 +151,6 @@ class TheCleanup {
                 bool block = false;
                 // Prevent this removal from merging a phi input block with the
                 // block the phi resides in
-                // TODO: Is this necessary anymore?
                 for (auto phi : usedBB[bb]) {
                     phi->eachArg([&](BB* in, Value*) {
                         if (in == bb && bb->next0 == phi->bb())

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -57,7 +57,10 @@ class TheCleanup {
                     }
                 } else if (auto phi = Phi::Cast(i)) {
                     std::unordered_set<Value*> phin;
-                    phi->eachArg([&](BB*, Value* v) { phin.insert(v); });
+                    phi->eachArg([&](BB*, Value* v) {
+                        if (v != phi)
+                            phin.insert(v);
+                    });
                     if (phin.size() == 1) {
                         removed = true;
                         phi->replaceUsesWith(*phin.begin());
@@ -148,6 +151,7 @@ class TheCleanup {
                 bool block = false;
                 // Prevent this removal from merging a phi input block with the
                 // block the phi resides in
+                // TODO: Is this necessary anymore?
                 for (auto phi : usedBB[bb]) {
                     phi->eachArg([&](BB* in, Value*) {
                         if (in == bb && bb->next0 == phi->bb())

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -93,9 +93,7 @@ void State::mergeIn(const State& incom, BB* incomBB) {
         Phi* p = Phi::Cast(stack.at(i));
         assert(p);
         Value* in = incom.stack.at(i);
-        if (in != p) {
-            p->addInput(incomBB, in);
-        }
+        p->addInput(incomBB, in);
     }
     incomBB->setNext(entryBB);
 }


### PR DESCRIPTION
I also tried to ensure that cleanup would remove phis which take themselves and one other value, since they could just be replaced with the other value. I'm not sure if it fully works, but at least in this example:

```r
f <- rir.compile(function(a) {
  x <- a
  y <- 0
  while (y < 10) {
    y <- y + x
  }
  y
})
```

the variable x doesn't create a self-referencing phi. Also in this example:

```r
f <- rir.compile(function(a) {
  y <- 0
  if (a == 1)
    x <- 2
  else
    x <- 3
  while (y < 10)
    y <- y + x
  y
})
```

The variable x is merged in a BB before the loop, and that phi (not self-referencing) is reused in the loop.