### PR TITLE
get rid of unobserved visibility effects

### DIFF
--- a/rir/src/compiler/analysis/visibility.cpp
+++ b/rir/src/compiler/analysis/visibility.cpp
@@ -30,9 +30,16 @@ AbstractResult VisibilityAnalysis::apply(LastVisibilityUpdate& vis,
 
         if (builtinUpdatesVisibility(builtinId)) {
             isVisibilityChanging();
+            break;
         }
-        break;
+    // fall through
     default:
+        // This instruction might change visibility, thus it's visibility effect
+        // might be observable. But it does not clear previous visibility
+        // instructions, because it might also not change it.
+        if (i->effects.contains(Effect::Visibility))
+            vis.observable.insert(i);
+
         if (i->exits() && vis.last) {
             vis.observable.insert(vis.last);
             res.update();

--- a/rir/src/compiler/analysis/visibility.cpp
+++ b/rir/src/compiler/analysis/visibility.cpp
@@ -7,17 +7,24 @@ namespace pir {
 AbstractResult VisibilityAnalysis::apply(LastVisibilityUpdate& vis,
                                          Instruction* i) const {
     AbstractResult res;
-    auto isVisibilityChanging = [&]() {
-        if (vis.last != i) {
-            vis.last = i;
-            vis.observable.clear();
+    auto changesVisibility = [&]() {
+        if (vis.observable.size() == 1 && *vis.observable.begin() == i)
+            return;
+        vis.observable.clear();
+        vis.observable.insert(i);
+        res.update();
+    };
+    auto maybeChangesVisibility = [&]() {
+        if (!vis.observable.count(i)) {
+            vis.observable.insert(i);
             res.update();
         }
     };
+
     switch (i->tag) {
     case Tag::Invisible:
     case Tag::Visible:
-        isVisibilityChanging();
+        changesVisibility();
         break;
     case Tag::CallBuiltin:
     case Tag::CallSafeBuiltin:
@@ -28,22 +35,18 @@ AbstractResult VisibilityAnalysis::apply(LastVisibilityUpdate& vis,
             builtinId = CallSafeBuiltin::Cast(i)->builtinId;
         }
 
-        if (builtinUpdatesVisibility(builtinId)) {
-            isVisibilityChanging();
-            break;
-        }
-    // fall through
+        if (builtinUpdatesVisibility(builtinId))
+            changesVisibility();
+        break;
+
     default:
         // This instruction might change visibility, thus it's visibility effect
         // might be observable. But it does not clear previous visibility
-        // instructions, because it might also not change it.
+        // instructions, because it might also preserve the previous visibility
+        // setting.
         if (i->effects.contains(Effect::Visibility))
-            vis.observable.insert(i);
-
-        if (i->exits() && vis.last) {
-            vis.observable.insert(vis.last);
-            res.update();
-        }
+            maybeChangesVisibility();
+        break;
     }
     return res;
 };

--- a/rir/src/compiler/analysis/visibility.h
+++ b/rir/src/compiler/analysis/visibility.h
@@ -10,7 +10,6 @@ namespace pir {
 class LastVisibilityUpdate {
   public:
     std::unordered_set<Instruction*> observable;
-    Instruction* last;
 
     AbstractResult mergeExit(const LastVisibilityUpdate& other) {
         return merge(other);
@@ -24,25 +23,10 @@ class LastVisibilityUpdate {
                 res.update();
             }
         }
-        if (last != other.last) {
-            if (last && !observable.count(last)) {
-                observable.insert(last);
-                res.update();
-            }
-            if (other.last && !observable.count(other.last)) {
-                observable.insert(other.last);
-                res.update();
-            }
-        }
         return res;
     }
 
     void print(std::ostream& out, bool tty) const {
-        if (last) {
-            out << "Last Update : ";
-            last->printRef(std::cout);
-            out << "\n";
-        }
         out << "Observable: ";
         for (auto& o : observable) {
             o->printRef(out);

--- a/rir/src/compiler/opt/visibility.cpp
+++ b/rir/src/compiler/opt/visibility.cpp
@@ -31,6 +31,10 @@ void OptimizeVisibility::apply(RirCompiler&, ClosureVersion* function,
                 if (!visible.observed(vis)) {
                     next = bb->remove(ip);
                 }
+            } else if (instr->effects.contains(Effect::Visibility)) {
+                if (!visible.observed(vis)) {
+                    instr->effects.reset(Effect::Visibility);
+                }
             }
 
             ip = next;

--- a/rir/src/compiler/opt/visibility.cpp
+++ b/rir/src/compiler/opt/visibility.cpp
@@ -32,7 +32,7 @@ void OptimizeVisibility::apply(RirCompiler&, ClosureVersion* function,
                     next = bb->remove(ip);
                 }
             } else if (instr->effects.contains(Effect::Visibility)) {
-                if (!visible.observed(vis)) {
+                if (!visible.observed(instr)) {
                     instr->effects.reset(Effect::Visibility);
                 }
             }


### PR DESCRIPTION
this slight tweaking of the visibility optimization should actually get rid of most visibility effect flags on random instructions, by just removing all the ones which are shadowed by a later effect.