### PR TITLE
Disabled recompiling in static call

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2130,18 +2130,9 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             if (fun->invocationCount() % PIR_WARMUP == 0) {
                 Assumptions assumptions =
                     addDynamicAssumptionsForOneTarget(call, fun->signature());
-                if (assumptions != fun->signature().assumptions) {
+                if (assumptions != fun->signature().assumptions)
                     // We have more assumptions available, let's recompile
                     dispatchFail = true;
-
-#ifdef DEBUG_DISPATCH
-                    std::cout << "Optimizing static for new context:";
-                    std::cout << given << " vs " << fun->signature().assumptions
-                              << "\n";
-#endif
-                    SEXP name = CAR(call.ast);
-                    ctx->closureOptimizer(callee, assumptions, name);
-                }
             }
 
             if (dispatchFail) {


### PR DESCRIPTION
This might be the reason `pidgits` slowed down. I added this in my "scalar assumptions" PR but didn't mention it. I thought that it was a bug, because we had more assumptions but didn't seem like we were creating a closure for those extra assumptions. But it could explain why we recompiled a lot.