### PR TITLE
No longer optimizes modules unless a new closure is compiled

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -222,8 +222,13 @@ SEXP pirCompile(SEXP what, const Assumptions& assumptions,
     logger.title("Compiling " + name);
     pir::Rir2PirCompiler cmp(m, logger);
     cmp.compileClosure(what, name, assumptions,
-                       [&](pir::ClosureVersion* c) {
+                       [&](pir::ClosureVersion* c, bool isNew) {
                            logger.flush();
+                           if (!isNew) {
+                               logger.debug("Reused already compiled version");
+                               return;
+                           }
+
                            cmp.optimizeModule();
 
                            // compile back to rir

--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -173,6 +173,14 @@ void LogStream::unsupportedBC(const std::string& warning, const rir::BC& bc) {
     }
 }
 
+void StreamLogger::debug(const std::string& msg) {
+    if (!options.includes(DebugFlag::PrintIntoFiles) &&
+        (options.intersects(PrintDebugPasses) ||
+         options.includes(DebugFlag::ShowWarnings))) {
+        std::cout << msg << "\n";
+    }
+}
+
 void StreamLogger::warn(const std::string& msg) {
     if (options.includes(DebugFlag::ShowWarnings)) {
         std::cerr << "Warning: " << msg << "\n";

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -40,6 +40,7 @@ class LogStream {
     void pirOptimizations(ClosureVersion*, const PirTranslator*);
     void afterAllocator(Code*, std::function<void(std::ostream&)>);
     void CSSA(Code*);
+    void reusedPIR(ClosureVersion*);
     void finalPIR(ClosureVersion*);
     void finalRIR(Function*);
     void unsupportedBC(const std::string&, const rir::BC&);
@@ -149,6 +150,7 @@ class StreamLogger {
         return *streams.at(cls);
     }
 
+    void debug(const std::string& msg);
     void warn(const std::string& msg);
 
     void title(const std::string& msg);

--- a/rir/src/compiler/debugging/stream_logger.h
+++ b/rir/src/compiler/debugging/stream_logger.h
@@ -40,7 +40,6 @@ class LogStream {
     void pirOptimizations(ClosureVersion*, const PirTranslator*);
     void afterAllocator(Code*, std::function<void(std::ostream&)>);
     void CSSA(Code*);
-    void reusedPIR(ClosureVersion*);
     void finalPIR(ClosureVersion*);
     void finalRIR(Function*);
     void unsupportedBC(const std::string&, const rir::BC&);

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -36,7 +36,7 @@ static ClosureVersion* compilePir(SEXP f, Module* m) {
     Rir2PirCompiler cmp(m, logger);
     ClosureVersion* res = nullptr;
     cmp.compileClosure(
-        f, "pir_check", assumptions, [&](ClosureVersion* r) { res = r; },
+        f, "pir_check", assumptions, [&](ClosureVersion* r, bool) { res = r; },
         []() { Rf_warning("pir check failed: couldn't compile"); });
 
     cmp.optimizeModule();

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -66,7 +66,8 @@ ClosuresByName compileRir2Pir(SEXP env, pir::Module* m) {
         if (TYPEOF(fun) == CLOSXP) {
             assert(isValidClosureSEXP(fun));
             cmp.compileClosure(fun, "test_function",
-                               [&](pir::ClosureVersion* cls) {
+                               [&](pir::ClosureVersion* cls, bool isNew) {
+                                   assert(isNew);
                                    results[CHAR(PRINTNAME(f.tag()))] = cls;
                                },
                                []() { assert(false); });

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -452,7 +452,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             given.add(Assumption::CorrectOrderOfArguments);
             compiler.compileClosure(
                 monomorphic, name, given,
-                [&](ClosureVersion* f) {
+                [&](ClosureVersion* f, bool) {
                     pop();
                     auto fs =
                         insert.registerFrameState(srcCode, nextPos, stack);
@@ -1020,7 +1020,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
             inner << (pos - srcCode->code());
 
             compiler.compileFunction(function, inner.str(), formals, srcRef,
-                                     [&](ClosureVersion* innerF) {
+                                     [&](ClosureVersion* innerF, bool) {
                                          cur.stack.push(insert(new MkFunCls(
                                              innerF->owner(), dt, insert.env)));
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -109,7 +109,7 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
     }
 
     if (auto existing = closure->findCompatibleVersion(ctx))
-        return success(existing);
+        return success(existing, false);
 
     auto version = closure->declareVersion(ctx);
 
@@ -156,7 +156,7 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
         log.compilationEarlyPir(version);
         Verify::apply(version);
         log.flush();
-        return success(version);
+        return success(version, true);
 
         log.failed("rir2pir failed to verify");
         log.flush();

--- a/rir/src/compiler/translations/rir_compiler.h
+++ b/rir/src/compiler/translations/rir_compiler.h
@@ -21,7 +21,7 @@ class RirCompiler {
     RirCompiler& operator=(const RirCompiler&) = delete;
 
     typedef std::function<void()> Maybe;
-    typedef std::function<void(ClosureVersion*)> MaybeCls;
+    typedef std::function<void(ClosureVersion*, bool)> MaybeCls;
 
     void preserve(SEXP c) { preserve_(c); }
 


### PR DESCRIPTION
Sometimes when we "compile" a closure we actually just reuse a previously compiled one. But `optimizeModule` was still being run. This PR disables it, and also logs that the closure was reused.