### PR TITLE
if a call instruction was never called, remove it

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -389,6 +389,18 @@ void ScopeAnalysis::tryMaterializeEnv(const ScopeAnalysisState& state,
     for (auto& e : envState.entries) {
         if (e.second.isUnknown())
             return;
+        // If any of the stores are StArg, then we cannot do this trick. The
+        // reason is in the following case:
+        //   e = MKEnv         x=missingArg
+        //       StVar (StArg) x, ...
+        // in this case starg must be preserved, since it does not override the
+        // missing flag on the environment binding
+        auto maybeMissing = e.second.checkEachSource([&](const ValOrig& src) {
+            auto st = StVar::Cast(src.origin);
+            return st && st->isStArg;
+        });
+        if (maybeMissing)
+            return;
         theEnv[e.first] = e.second;
     }
 

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -201,6 +201,11 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
         toDelete.insert(deadBranch);
     }
 
+    Visitor::run(function->entry, [&](Instruction* i) {
+        if (auto phi = Phi::Cast(i))
+            phi->removeInputs(toDelete);
+    });
+
     for (auto e : branchRemoval) {
         auto branch = e.first;
         auto condition = e.second;
@@ -211,60 +216,6 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
             branch->next0 = branch->next1;
             branch->next1 = nullptr;
         }
-    }
-
-    // If we deleted a branch, then it can happen that some phi inputs are
-    // now dead. We need to take care of them and remove them. The canonical
-    // case is the following:
-    //
-    //    BB0:
-    //      a <- 1
-    //      branch TRUE -> BB1 | BB2
-    //    BB1:
-    //      b <- 2
-    //      goto BB3
-    //    BB2:
-    //      goto BB3
-    //    BB3:
-    //      phi(BB0:a, BB1:b)
-    //
-    // In this case removing the branch BB2, also kills the input `BB0:a`.
-    //
-    // TODO: currently the algorithm is very slow. For each phi that comes
-    // after a removed branch, we check if (in the modified CFG) we have two
-    // inputs, both dominating the phi. If so we will remove the one that
-    // comes earlier (ie. the one that dominates the other).
-    if (!branchRemoval.empty()) {
-        DominanceGraph dom(function);
-        CFG cfg(function);
-        Visitor::run(function->entry, [&](BB* bb) {
-            bool afterARemovedBranch = false;
-            for (auto& d : branchRemoval)
-                if (!afterARemovedBranch && cfg.isPredecessor(d.first, bb))
-                    afterARemovedBranch = true;
-
-            if (afterARemovedBranch) {
-                for (auto it = bb->begin(); it != bb->end(); ++it) {
-                    auto i = *it;
-                    if (auto phi = Phi::Cast(i)) {
-                        std::unordered_set<BB*> deadInput;
-                        phi->eachArg([&](BB* a, Value* va) {
-                            if (toDelete.find(a) != toDelete.end()) {
-                                deadInput.insert(a);
-                            } else if (dom.dominates(a, phi->bb())) {
-                                phi->eachArg([&](BB* b, Value* vb) {
-                                    if (va != vb &&
-                                        dom.dominates(b, phi->bb()) &&
-                                        dom.dominates(a, b))
-                                        deadInput.insert(a);
-                                });
-                            }
-                        });
-                        phi->removeInputs(deadInput);
-                    }
-                }
-            }
-        });
     }
 
     for (auto bb : toDelete)

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -19,7 +19,8 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
     auto nonObjectArgs = [&](Instruction* i) {
         auto answer = true;
         i->eachArg([&](Value* arg) {
-            if (arg->type.maybeObj() && arg->typeFeedback.maybeObj())
+            if (arg->type.maybeObj() &&
+                (arg->typeFeedback.isVoid() || arg->typeFeedback.maybeObj()))
                 answer = false;
         });
         return answer;

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -1,0 +1,19 @@
+#ifndef PIR_PARAMETER_H
+#define PIR_PARAMETER_H
+
+#include <stddef.h>
+
+namespace rir {
+namespace pir {
+
+struct Parameter {
+    static bool DEBUG_DEOPTS;
+    static bool DEOPT_CHAOS;
+    static bool DEOPT_CHAOS_SEED;
+    static size_t MAX_INPUT_SIZE;
+    static unsigned RIR_WARMUP;
+};
+} // namespace pir
+} // namespace rir
+
+#endif

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -59,7 +59,13 @@ void printPaddedInstructionName(std::ostream& out, const std::string& name) {
 void printPaddedTypeAndRef(std::ostream& out, const Instruction* i) {
     std::ostringstream buf;
     buf << i->type;
-    out << std::left << std::setw(7) << buf.str() << " ";
+    if (!i->typeFeedback.isVoid()) {
+        if (i->type == i->typeFeedback)
+            buf << "<>";
+        else
+            buf << "<" << i->typeFeedback << ">";
+    }
+    out << std::left << std::setw(15) << buf.str() << " ";
     buf.str("");
     if (i->type != PirType::voyd()) {
         i->printRef(buf);
@@ -277,6 +283,12 @@ void Instruction::replaceUsesWithLimits(Value* replace, BB* start,
         apply(start->next0);
     if (start->next1)
         apply(start->next1);
+
+    // Propagate typefeedback
+    if (auto rep = Instruction::Cast(replace)) {
+        if (!rep->type.isA(typeFeedback) && rep->typeFeedback.isVoid())
+            rep->typeFeedback = typeFeedback;
+    }
 }
 
 void Instruction::replaceUsesWith(Value* replace) {
@@ -289,6 +301,12 @@ void Instruction::replaceUsesWith(Value* replace) {
             });
         }
     });
+
+    // Propagate typefeedback
+    if (auto rep = Instruction::Cast(replace)) {
+        if (!rep->type.isA(typeFeedback) && rep->typeFeedback.isVoid())
+            rep->typeFeedback = typeFeedback;
+    }
 }
 
 void Instruction::replaceUsesAndSwapWith(

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -6,7 +6,7 @@ extern "C" Rboolean(Rf_isObject)(SEXP s);
 namespace rir {
 namespace pir {
 
-void PirType::print(std::ostream& out) { out << *this << "\n"; }
+void PirType::print(std::ostream& out) const { out << *this << "\n"; }
 
 void PirType::merge(SEXPTYPE sexptype) {
     assert(isRType());
@@ -31,7 +31,9 @@ void PirType::merge(SEXPTYPE sexptype) {
         t_.r.set(RType::env);
         break;
     case PROMSXP:
-        t_.r.set(RType::prom);
+        flags_.set(TypeFlags::lazy);
+        flags_.set(TypeFlags::promiseWrapped);
+        t_.r = RTypeSet::Any();
         break;
     case EXPRSXP:
         t_.r.set(RType::ast);
@@ -89,8 +91,15 @@ PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
 }
 
 void PirType::merge(const ObservedValues& other) {
-    if (other.numTypes == 0 || other.numTypes == ObservedValues::MaxTypes)
+    if (!other.numTypes)
         return;
+
+    if (other.numTypes == ObservedValues::MaxTypes) {
+        merge(any());
+        flags_.set(TypeFlags::maybeObject);
+        flags_.set(TypeFlags::maybeNotScalar);
+        return;
+    }
 
     for (size_t i = 0; i < other.numTypes; ++i) {
         const auto& record = other.seen[i];

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -337,6 +337,13 @@ struct PirType {
         t_.r = RTypeSet(rtype);
     }
 
+    bool isVoid() const {
+        if (isRType())
+            return t_.r.empty();
+        else
+            return t_.n.empty();
+    }
+
     static const PirType voyd() { return PirType(NativeTypeSet()); }
     static const PirType bottom() { return optimistic(); }
 
@@ -368,7 +375,7 @@ struct PirType {
         return t_.r.includes(o.t_.r);
     }
 
-    void print(std::ostream& out = std::cout);
+    void print(std::ostream& out = std::cout) const;
 };
 
 inline std::ostream& operator<<(std::ostream& out, NativeType t) {

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -7,6 +7,7 @@
 #include "../translations/rir_2_pir/rir_2_pir.h"
 #include "../util/visitor.h"
 #include "api.h"
+#include "compiler/parameter.h"
 #include <string>
 #include <vector>
 
@@ -131,8 +132,8 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 }
 
 bool PirCheck::run(SEXP f) {
-    size_t oldconfig = Rir2PirCompiler::MAX_INPUT_SIZE;
-    Rir2PirCompiler::MAX_INPUT_SIZE = 3000;
+    size_t oldconfig = pir::Parameter::MAX_INPUT_SIZE;
+    pir::Parameter::MAX_INPUT_SIZE = 3000;
     Module m;
     ClosureVersion* pir = compilePir(f, &m);
     bool success = pir;
@@ -151,7 +152,7 @@ bool PirCheck::run(SEXP f) {
         }
     }
     }
-    Rir2PirCompiler::MAX_INPUT_SIZE = oldconfig;
+    pir::Parameter::MAX_INPUT_SIZE = oldconfig;
     if (!success)
         m.print(std::cout, false);
     return success;

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -10,6 +10,7 @@
 #include "R/RList.h"
 #include "R_ext/Parse.h"
 #include "api.h"
+#include "compiler/parameter.h"
 #include <string>
 #include <vector>
 
@@ -817,8 +818,8 @@ static Test tests[] = {
 namespace rir {
 
 void PirTests::run() {
-    size_t oldconfig = Rir2PirCompiler::MAX_INPUT_SIZE;
-    Rir2PirCompiler::MAX_INPUT_SIZE = 3000;
+    size_t oldconfig = pir::Parameter::MAX_INPUT_SIZE;
+    pir::Parameter::MAX_INPUT_SIZE = 3000;
     for (auto t : tests) {
         std::cout << "> " << t.first << "\n";
         if (!t.second()) {
@@ -826,6 +827,6 @@ void PirTests::run() {
             exit(1);
         }
     }
-    Rir2PirCompiler::MAX_INPUT_SIZE = oldconfig;
+    pir::Parameter::MAX_INPUT_SIZE = oldconfig;
 }
 } // namespace rir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -320,6 +320,21 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         // currently it does not pay off to put any deopts in there.
         if (callTargetFeedback.count(callee)) {
             auto& feedback = callTargetFeedback.at(callee);
+            // If this call was never executed. Might as well compile an
+            // unconditional deopt
+            if (!inPromise() && srcCode->funInvocationCount > 0 &&
+                feedback.taken == 0) {
+                // Hack to record the deoptimized call, to ensure we compile
+                // something better on re-optimization.
+                auto deoptPos = pos - 1 - sizeof(ObservedCallees);
+                if (*deoptPos != Opcode::record_call_)
+                    deoptPos = pos;
+                auto fs = insert.registerFrameState(srcCode, deoptPos, stack);
+                insert(new Deopt(fs));
+                stack.clear();
+                break;
+            }
+
             if (feedback.numTargets == 1)
                 monomorphic = feedback.getTarget(srcCode, 0);
         }
@@ -1043,6 +1058,19 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
                 log.failed("Abort r2p due to unsupported bc");
                 return nullptr;
             }
+
+            if (!inPromise() && !insert.getCurrentBB()->isEmpty()) {
+                auto last = insert.getCurrentBB()->last();
+
+                if (Deopt::Cast(last)) {
+                    finger = end;
+                    continue;
+                }
+
+                if (last->isDeoptBarrier())
+                    addCheckpoint(srcCode, nextPos, cur.stack, insert);
+            }
+
             if (cur.stack.size() != size - bc.popCount() + bc.pushCount()) {
                 srcCode->print(std::cerr);
                 std::cerr << "After interpreting '";
@@ -1052,12 +1080,6 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
                           << size << " to " << cur.stack.size() << "\n";
                 assert(false);
                 return nullptr;
-            }
-
-            if (!inPromise() && !insert.getCurrentBB()->isEmpty()) {
-                auto last = insert.getCurrentBB()->last();
-                if (last->isDeoptBarrier())
-                    addCheckpoint(srcCode, nextPos, cur.stack, insert);
             }
         }
     }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -3,6 +3,8 @@
 #include "R/RList.h"
 #include "rir_2_pir.h"
 
+#include "compiler/parameter.h"
+
 #include "../../analysis/query.h"
 #include "../../analysis/verifier.h"
 #include "../../opt/pass_definitions.h"
@@ -103,7 +105,7 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
         return fail();
     }
 
-    if (closure->rirFunction()->body()->codeSize > MAX_INPUT_SIZE) {
+    if (closure->rirFunction()->body()->codeSize > Parameter::MAX_INPUT_SIZE) {
         logger.warn("skipping huge function");
         return fail();
     }
@@ -230,7 +232,7 @@ void Rir2PirCompiler::optimizeModule() {
     logger.flush();
 }
 
-size_t Rir2PirCompiler::MAX_INPUT_SIZE =
+size_t Parameter::MAX_INPUT_SIZE =
     getenv("PIR_MAX_INPUT_SIZE") ? atoi(getenv("PIR_MAX_INPUT_SIZE")) : 3500;
 
 } // namespace pir

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -11,7 +11,6 @@ namespace pir {
 
 class Rir2PirCompiler : public RirCompiler {
   public:
-    static size_t MAX_INPUT_SIZE;
     static constexpr Assumptions::Flags minimalAssumptions =
         Assumptions::Flags(Assumption::CorrectOrderOfArguments) |
         Assumption::NotTooManyArguments;
@@ -44,6 +43,7 @@ class Rir2PirCompiler : public RirCompiler {
     void compileClosure(Closure* closure, const OptimizationContext& ctx,
                         MaybeCls success, Maybe fail);
 };
+
 } // namespace pir
 } // namespace rir
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -4,6 +4,7 @@
 #include "R/Funtab.h"
 #include "R/RList.h"
 #include "R/Symbols.h"
+#include "compiler/parameter.h"
 #include "compiler/translations/rir_2_pir/rir_2_pir_compiler.h"
 #include "ir/Deoptimization.h"
 #include "ir/RuntimeFeedback_inl.h"
@@ -684,7 +685,7 @@ static Function* dispatch(const CallContext& call, DispatchTable* vt) {
     return fun;
 };
 
-static unsigned PIR_WARMUP =
+unsigned pir::Parameter::RIR_WARMUP =
     getenv("PIR_WARMUP") ? atoi(getenv("PIR_WARMUP")) : 3;
 
 // Call a RIR function. Arguments are still untouched.
@@ -698,7 +699,8 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
     Function* fun = dispatch(call, table);
     fun->registerInvocation();
 
-    if (!fun->unoptimizable && fun->invocationCount() % PIR_WARMUP == 0) {
+    if (!fun->unoptimizable &&
+        fun->invocationCount() % pir::Parameter::RIR_WARMUP == 0) {
         Assumptions given =
             addDynamicAssumptionsForOneTarget(call, fun->signature());
         // addDynamicAssumptionForOneTarget compares arguments with the
@@ -2130,8 +2132,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                              given, ctx);
             auto fun = Function::unpack(version);
             addDynamicAssumptionsFromContext(call);
-            bool dispatchFail = !matches(call, fun->signature());
-            if (fun->invocationCount() % PIR_WARMUP == 0) {
+            bool dispatchFail = !fun->dead && !matches(call, fun->signature());
+            if (fun->invocationCount() % pir::Parameter::RIR_WARMUP == 0) {
                 Assumptions assumptions =
                     addDynamicAssumptionsForOneTarget(call, fun->signature());
                 if (assumptions != fun->signature().assumptions)
@@ -2564,7 +2566,16 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 rhs = PRVALUE(rhs);
             if (TYPEOF(lhs) == PROMSXP && PRVALUE(lhs) != R_UnboundValue)
                 lhs = PRVALUE(lhs);
-            ostack_push(ctx, rhs == lhs ? R_TrueValue : R_FalseValue);
+            // Special case for closures: (level 1) deep compare with body
+            // expression instead of body object, to ensure that a compiled
+            // closure is equal to the uncompiled one
+            if (lhs != rhs && TYPEOF(lhs) == CLOSXP && TYPEOF(rhs) == CLOSXP &&
+                CLOENV(lhs) == CLOENV(rhs) && FORMALS(lhs) == FORMALS(rhs) &&
+                BODY_EXPR(lhs) == BODY_EXPR(rhs))
+                ostack_push(ctx, R_TrueValue);
+            else
+                ostack_push(ctx, rhs == lhs ? R_TrueValue : R_FalseValue);
+
             NEXT();
         }
 
@@ -3327,8 +3338,16 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             }
 #endif
 
-            auto dt = DispatchTable::unpack(BODY(callCtxt->callee));
-            dt->remove(c);
+            if (!pir::Parameter::DEOPT_CHAOS) {
+                // TODO: this version is still reachable from static call inline
+                // caches. Thus we need to preserve it forever. We need some
+                // dependency management here.
+                Pool::insert(c->container());
+                // remove the deoptimized function. Unless on deopt chaos,
+                // always recompiling would just blow testing time...
+                auto dt = DispatchTable::unpack(BODY(callCtxt->callee));
+                dt->remove(c);
+            }
             assert(m->numFrames >= 1);
             size_t stackHeight = 0;
             for (size_t i = 0; i < m->numFrames; ++i)

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2144,7 +2144,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 fun = dispatch(call, dt);
                 // Patch inline cache
                 (*(Immediate*)pc) = Pool::insert(fun->container());
-                assert(fun != dt->baseline());
             }
             advanceImmediate();
 
@@ -3328,6 +3327,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             }
 #endif
 
+            auto dt = DispatchTable::unpack(BODY(callCtxt->callee));
+            dt->remove(c);
             assert(m->numFrames >= 1);
             size_t stackHeight = 0;
             for (size_t i = 0; i < m->numFrames; ++i)

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -52,6 +52,7 @@ struct DispatchTable
         }
         if (i == size())
             return;
+        get(i)->dead = true;
         for (; i < size() - 1; ++i) {
             setEntry(i, getEntry(i + 1));
         }

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -44,6 +44,21 @@ struct DispatchTable
         return false;
     }
 
+    void remove(Code* funCode) {
+        size_t i = 1;
+        for (; i < size(); ++i) {
+            if (get(i)->body() == funCode)
+                break;
+        }
+        if (i == size())
+            return;
+        for (; i < size() - 1; ++i) {
+            setEntry(i, getEntry(i + 1));
+        }
+        setEntry(i, nullptr);
+        size_--;
+    }
+
     // insert function ordered by increasing number of assumptions
     void insert(Function* fun) {
         // TODO: we might need to grow the DT here!

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -49,8 +49,8 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
               sizeof(Function) - NUM_PTRS * sizeof(FunctionSEXP),
               NUM_PTRS + defaultArgs.size()),
           size(functionSize), deopt(false), markOpt(false),
-          unoptimizable(false), uninlinable(false), numArgs(defaultArgs.size()),
-          signature_(signature) {
+          unoptimizable(false), uninlinable(false), dead(false),
+          numArgs(defaultArgs.size()), signature_(signature) {
         for (size_t i = 0; i < numArgs; ++i)
             setEntry(NUM_PTRS + i, defaultArgs[i]);
         body(body_);
@@ -77,6 +77,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     unsigned markOpt : 1;
     unsigned unoptimizable : 1;
     unsigned uninlinable : 1;
+    unsigned dead : 1;
 
     unsigned numArgs;
 

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -46,16 +46,16 @@ stopifnot(pir.check(function(depth) {
     1
   else
     0
-}, NoEnvSpec))
+}, NoEnvSpec, warmup=list(1)))
 
 xxx <- 12
 stopifnot(pir.check(function() {
   1 + xxx
 }, NoEnvForAdd, warmup=list()))
-
+yyy = 0
 stopifnot(pir.check(function() {
   1 + yyy
-}, NoEnvForAdd))
+}, NoEnvForAdd, warmup=list()))
 stopifnot(pir.check(function(x) {
   y <- 2
 }, NoStore))
@@ -139,7 +139,7 @@ stopifnot(pir.check(function() {
   b <- function() 1L
   f <- function(x, y) x() + y
   f(a, b())
-}, Returns42L))
+}, Returns42L, warmup=list()))
 stopifnot(pir.check(function() {
   x <- function() 32
   y <- function() 31
@@ -149,7 +149,7 @@ stopifnot(pir.check(function() {
       42L
   }
   f(x, y(), z)
-}, NoEnv))
+}, NoEnv, warmup=list()))
 
 mandelbrot <- function() {
     size = 30
@@ -210,7 +210,7 @@ stopifnot(pir.check(function() {
   while (x < 10)
     x <- x + 1
   x
-}, NoLoad, NoStore))
+}, NoLoad, NoStore, warmup=list()))
 stopifnot(pir.check(function(n) {
   x <- 1
   while (x < n)

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -52,7 +52,7 @@ rir.compile(function(){
 
 # inlined frameStates:
 
-if (Sys.getenv("PIR_DEOPT_CHAOS") != "1") {
+if (Sys.getenv("PIR_DEOPT_CHAOS") != "1" && Sys.getenv("PIR_WARMUP") != "2") {
     f <- pir.compile(rir.compile(function(x) g(x)))
     g <- rir.compile(function(x) h(x))
     h <- rir.compile(function(x) 1+i(x))

--- a/rir/tests/pir_scope_delay_env_regression.r
+++ b/rir/tests/pir_scope_delay_env_regression.r
@@ -1,0 +1,51 @@
+# In this regression the diagonal function was primed with
+# the first else branch being dead. Then we compile with
+# the assumption that n is not missing, which will kill
+# the then branch.
+# this leads to a function that directly deoptimizes (which
+# is intended to pick up typefeedback). But scope analysis
+# environment delay optimization would create an environment
+# with a fudged missing tag on the binding, since it did not
+# consider the difference between stvar and starg (the later
+# preserves missing flag.
+
+Diagonal = function (n, x = NULL) 
+{
+    n <- if (missing(n)) 
+        length(x)
+    else {
+        stopifnot(length(n) == 1, n == as.integer(n), n >= 0)
+        as.integer(n)
+    }
+    if (missing(x)) 
+        c(1,2,3)
+    else {
+        lx <- length(x)
+        lx.1 <- lx == 1L
+        stopifnot(lx.1 || lx == n)
+        if (is.logical(x)) 
+            cl <- "ldiMatrix"
+        else if (is.numeric(x)) {
+            cl <- "ddiMatrix"
+            x <- as.numeric(x)
+        }
+        else if (is.complex(x)) {
+            cl <- "zdiMatrix"
+        }
+        else stop("'x' has invalid data type")
+        if (lx.1 && !is.na(x) && x == 1) 
+            new(cl, Dim = c(n, n), diag = "U")
+        else new(cl, Dim = c(n, n), diag = "N", x = if (lx.1) 
+            rep.int(x, n)
+        else x)
+    }
+}
+
+t <- function() {
+  Diagonal()
+  Diagonal()
+  Diagonal(1)
+}
+
+pir.compile(rir.compile(t))
+t()


### PR DESCRIPTION
this prevents a dead call instruction (with no call target feedback)
from poisoning the analysis, since a generic call is emited.