### PR TITLE
fix pir's handling of missing args

### DIFF
--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -225,8 +225,8 @@ class TheInliner {
                                                           ->type.forced()
                                                           .orPromiseWrapped()
                                                     : ld->type;
-                                    auto cast =
-                                        new CastType(a, RType::prom, type);
+                                    auto cast = new CastType(a, RType::prom,
+                                                             type.notMissing());
                                     ip = bb->insert(ip + 1, cast);
                                     ip--;
                                     a = cast;

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -265,12 +265,23 @@ class TheScopeResolution {
                 analysis.lookupAt(after, i, [&](const AbstractLoad& aLoad) {
                     auto& res = aLoad.result;
 
+                    bool isActualLoad =
+                        LdVar::Cast(i) || LdFun::Cast(i) || LdVarSuper::Cast(i);
+
                     // In case the scope analysis is sure that this is
                     // actually the same as some other PIR value. So let's just
                     // replace it.
                     if (res.isSingleValue()) {
                         if (auto val = getSingleLocalValue(res)) {
                             if (val->type.isA(i->type)) {
+                                if (isActualLoad && val->type.maybeMissing()) {
+                                    // LdVar checks for missingness, so we need
+                                    // to preserve this.
+                                    auto chk = new ChkMissing(val);
+                                    ip = bb->insert(ip, chk);
+                                    ip++;
+                                    val = chk;
+                                }
                                 replacedValue[i] = val;
                                 i->replaceUsesWith(val);
                                 next = bb->remove(ip);
@@ -297,12 +308,19 @@ class TheScopeResolution {
                     // the same phi twice (e.g. if a force returns the result
                     // of a load, we will resolve the load and the force) which
                     // ends up being rather painful.
-                    bool isActualLoad =
-                        LdVar::Cast(i) || LdFun::Cast(i) || LdVarSuper::Cast(i);
                     if (!res.isUnknown() && isActualLoad) {
                         if (auto resPhi = tryInsertPhis(res, bb, ip)) {
-                            i->replaceUsesWith(resPhi);
-                            replacedValue[i] = resPhi;
+                            Value* val = resPhi;
+                            if (val->type.maybeMissing()) {
+                                // LdVar checks for missingness, so we need
+                                // to preserve this.
+                                auto chk = new ChkMissing(val);
+                                ip = bb->insert(ip, chk);
+                                ip++;
+                                val = chk;
+                            }
+                            i->replaceUsesWith(val);
+                            replacedValue[i] = val;
                             next = bb->remove(ip);
                             return;
                         }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -278,6 +278,8 @@ const Value* Instruction::cFollowCasts() const {
         return cast->arg<0>().val()->followCasts();
     if (auto chk = ChkClosure::Cast(this))
         return chk->arg<0>().val()->followCasts();
+    if (auto chk = ChkMissing::Cast(this))
+        return chk->arg<0>().val()->followCasts();
     return this;
 }
 
@@ -290,6 +292,8 @@ const Value* Instruction::cFollowCastsAndForce() const {
         if (mkarg->isEager())
             return mkarg->eagerArg()->followCastsAndForce();
     if (auto chk = ChkClosure::Cast(this))
+        return chk->arg<0>().val()->followCastsAndForce();
+    if (auto chk = ChkMissing::Cast(this))
         return chk->arg<0>().val()->followCastsAndForce();
     return this;
 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -701,7 +701,7 @@ class FLIE(Missing, 1, Effects() | Effect::ReadsEnv) {
 class FLI(ChkMissing, 1, Effect::Warn) {
   public:
     explicit ChkMissing(Value* in)
-        : FixedLenInstruction(in->type.notMissing(), {{PirType::val()}},
+        : FixedLenInstruction(in->type.notMissing(), {{PirType::any()}},
                               {{in}}) {}
 };
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -309,6 +309,10 @@ struct PirType {
         return PirType(t_.r, flags_ | TypeFlags::maybeObject);
     }
 
+    PirType constexpr notLazy() const {
+        return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::lazy));
+    }
+
     PirType constexpr forced() const {
         assert(isRType());
         FlagSet notPromised =

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -7,7 +7,7 @@ namespace pir {
 void readArgTypeFromAssumptions(const Assumptions& assumptions, PirType& type,
                                 int i) {
     if (assumptions.isEager(i))
-        type = PirType::promiseWrappedVal().notMissing();
+        type = type.notLazy().notMissing();
     if (assumptions.isNotObj(i))
         type.setNotObject();
     if (assumptions.isSimpleReal(i)) {
@@ -24,9 +24,10 @@ void readArgTypeFromAssumptions(const Assumptions& assumptions, PirType& type,
 void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
     auto mk = MkArg::Cast(arg);
     if (mk && mk->isEager()) {
-        assumptions.setEager(i);
         if (mk->eagerArg() == MissingArg::instance())
             assumptions.remove(Assumption::NoExplicitlyMissingArgs);
+        else
+            assumptions.setEager(i);
     }
     Value* value = arg->followCastsAndForce();
     if (!MkArg::Cast(value)) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -572,6 +572,7 @@ static void addDynamicAssumptionsFromContext(CallContext& call) {
                 }
             } else if (arg == R_MissingArg) {
                 given.remove(Assumption::NoExplicitlyMissingArgs);
+                isEager = false;
             }
             if (isObject(arg)) {
                 notObj = false;

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -59,6 +59,7 @@ if (Sys.getenv("PIR_DEOPT_CHAOS") != "1") {
     i <- rir.compile(function(x) 40-x)
     
     stopifnot(f(-1) == 42)
+    stopifnot(f(-1) == 42)
     
     hc1 = .Call("rir_invocation_count", h)
     ic1 = .Call("rir_invocation_count", i)

--- a/rir/tests/pir_regression_missing.R
+++ b/rir/tests/pir_regression_missing.R
@@ -69,9 +69,39 @@ stopifnot(h()==3)
 stopifnot(h()==3)
 stopifnot(h()==3)
 
+xx1 <- function() {
+   ok = 0
+
+   # returning a missing arg is supposed to error
+   f <- function(a,b)
+     a
+
+   tryCatch(f(), error=function(e) ok <<- 1)
+   stopifnot(ok == 1);
+}
+
+xx2 <- function() {
+   ok = 0
+   # forcing it too, the `(` function forces
+   q <- function(a) (a)
+   tryCatch(q(), error=function(e) ok <<- 1)
+   stopifnot(ok == 1);
+}
+
+xx3 <- function() {
+   # but passing on without forcing should not error
+   h <- function(a) 1
+   g <- function(a) h(a)
+   g()
+}
+
+for (i in 1:10)
+{xx1(); xx2(); xx3()}
+
+
+
 f <- pir.compile(rir.compile(function(a,b,c) a))
 g <- rir.compile(function() {
-  f()
   f(1)
   f(1,2)
   f(1,2,3)


### PR DESCRIPTION
accessing a missing arg throws an error. In pir, we replace ldvar with
ldvar_noforce and force. the former is responsible for checking
missingness. then in scope resolution we replace ldvar with the actual
value. this replacement "forgets" the missingness check. we fix this
with an explicit chkMissing instruction.