### PR TITLE
Typefeedback

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -46,8 +46,6 @@ void AbstractREnvironment::print(std::ostream& out, bool tty) const {
 }
 
 AbstractResult AbstractPirValue::merge(const AbstractPirValue& other) {
-    assert(other.type != PirType::bottom());
-
     if (unknown)
         return AbstractResult::None;
     if (type == PirType::bottom()) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -77,6 +77,20 @@ class TheCleanup {
                         used_p.insert(arg->prom()->id);
                         todo.push_back(arg->prom());
                     }
+                } else if (auto tt = IsType::Cast(i)) {
+                    auto arg = tt->arg<0>().val();
+                    if (arg->type.isA(tt->typeTest)) {
+                        tt->replaceUsesWith(True::instance());
+                        removed = true;
+                        next = bb->remove(ip);
+                    }
+                } else if (auto tt = CastType::Cast(i)) {
+                    auto arg = tt->arg<0>().val();
+                    if (arg->type == tt->type) {
+                        tt->replaceUsesWith(arg);
+                        removed = true;
+                        next = bb->remove(ip);
+                    }
                 } else if (auto asInt = AsInt::Cast(i)) {
                     auto arg = asInt->arg<0>().val();
                     if (arg->type.isA(

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -19,6 +19,8 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
     auto nonObjectArgs = [&](Instruction* i) {
         auto answer = true;
         i->eachArg([&](Value* arg) {
+            if (i->env() == arg)
+                return;
             if (arg->type.maybeObj() &&
                 (arg->typeFeedback.isVoid() || arg->typeFeedback.maybeObj()))
                 answer = false;

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -6,6 +6,7 @@
 #include "R/Funtab.h"
 #include "R/Symbols.h"
 #include "R/r.h"
+#include "compiler/parameter.h"
 #include "pass_definitions.h"
 #include "utils/Pool.h"
 
@@ -21,14 +22,10 @@ class TheInliner {
     ClosureVersion* version;
     explicit TheInliner(ClosureVersion* version) : version(version) {}
 
-    static const size_t MAX_SIZE;
-    static const size_t MAX_INLINEE_SIZE;
-    static const size_t INITIAL_FUEL;
-
     void operator()() {
-        size_t fuel = INITIAL_FUEL;
+        size_t fuel = Parameter::INLINER_INITIAL_FUEL;
 
-        if (version->size() > MAX_SIZE)
+        if (version->size() > Parameter::INLINER_MAX_SIZE)
             return;
 
         Visitor::run(version->entry, [&](BB* bb) {
@@ -119,7 +116,8 @@ class TheInliner {
                 // No recursive inlining
                 if (inlinee->owner() == version->owner()) {
                     continue;
-                } else if (inlinee->size() > MAX_INLINEE_SIZE) {
+                } else if (inlinee->size() >
+                           Parameter::INLINER_MAX_INLINEE_SIZE) {
                     inlineeCls->rirFunction()->uninlinable = true;
                     continue;
                 } else {
@@ -319,24 +317,24 @@ class TheInliner {
     }
 };
 
-// TODO: maybe implement something more resonable to pass in those constants.
-// For now it seems a simple env variable is just fine.
-const size_t TheInliner::MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
-                                        ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
-                                        : 4000;
-const size_t TheInliner::MAX_INLINEE_SIZE =
-    getenv("PIR_INLINER_MAX_INLINEE_SIZE")
-        ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-        : 100;
-const size_t TheInliner::INITIAL_FUEL =
-    getenv("PIR_INLINER_INITIAL_FUEL")
-        ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
-        : 5;
-
 } // namespace
 
 namespace rir {
 namespace pir {
+
+// TODO: maybe implement something more resonable to pass in those constants.
+// For now it seems a simple env variable is just fine.
+size_t Parameter::INLINER_MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
+                                         ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
+                                         : 4000;
+size_t Parameter::INLINER_MAX_INLINEE_SIZE =
+    getenv("PIR_INLINER_MAX_INLINEE_SIZE")
+        ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
+        : 100;
+size_t Parameter::INLINER_INITIAL_FUEL =
+    getenv("PIR_INLINER_INITIAL_FUEL")
+        ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
+        : 5;
 
 void Inline::apply(RirCompiler&, ClosureVersion* version, LogStream&) const {
     TheInliner s(version);

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -131,6 +131,8 @@ class PASS(LoadElision);
 
 class PASS(TypeInference);
 
+class PASS(TypeSpeculation);
+
 class PhaseMarker : public PirTranslator {
   public:
     explicit PhaseMarker(const std::string& name) : PirTranslator(name) {}

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -1,0 +1,99 @@
+#include "../analysis/available_checkpoints.h"
+#include "../pir/pir_impl.h"
+#include "../transform/bb.h"
+#include "../util/cfg.h"
+#include "../util/visitor.h"
+#include "R/r.h"
+#include "pass_definitions.h"
+
+#include <unordered_map>
+
+namespace rir {
+namespace pir {
+
+void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
+                            LogStream& log) const {
+
+    AvailableCheckpoints checkpoint(function, log);
+
+    std::unordered_map<Checkpoint*, std::unordered_map<Instruction*, PirType>>
+        speculate;
+
+    Visitor::run(function->entry, [&](BB* bb) {
+        auto ip = bb->begin();
+        while (ip != bb->end()) {
+            auto next = ip + 1;
+            auto i = *ip;
+            bool trigger = false;
+            if (Force::Cast(i)) {
+                auto arg = i->arg(0).val()->followCasts();
+                // Blacklist of where it is not worthwhile
+                if (!LdConst::Cast(arg) &&
+                    // leave this to the promise inliner
+                    !MkArg::Cast(arg) && !Force::Cast(arg) &&
+                    // leave this to scope analysis
+                    !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
+                    trigger = true;
+                }
+            }
+            if (trigger) {
+                PirType type = i->typeFeedback;
+                if (!type.isVoid() && !i->type.isA(type)) {
+                    if (auto cp = checkpoint.next(i)) {
+                        if (!type.maybeObj()) {
+                            if (type.isA(RType::integer) ||
+                                type.isA(RType::real)) {
+                                speculate[cp][i] = type;
+                            } else {
+                                speculate[cp][i] = i->type.notObject();
+                            }
+                        }
+                    }
+                }
+            }
+            ip = next;
+        }
+    });
+
+    Visitor::run(function->entry, [&](BB* bb) {
+        if (bb->isEmpty())
+            return;
+        auto cp = Checkpoint::Cast(bb->last());
+        if (!cp)
+            return;
+        if (!speculate.count(cp))
+            return;
+
+        bb = bb->trueBranch();
+        auto ip = bb->begin();
+
+        for (auto sp : speculate[cp]) {
+            auto i = sp.first;
+            PirType type = sp.second;
+
+            Instruction* condition = nullptr;
+            bool assumeTrue = true;
+
+            if (type == i->type.notObject()) {
+                condition = new IsObject(i);
+                assumeTrue = false;
+            } else {
+                condition = new IsType(type, i);
+            }
+
+            auto cast = new CastType(i, PirType::any(), type);
+            i->replaceUsesWithLimits(cast, bb, i);
+
+            ip = bb->insert(ip, condition);
+            ip++;
+            auto assume = new Assume(condition, cp);
+            assume->assumeTrue = assumeTrue;
+            ip = bb->insert(ip, assume);
+            ip++;
+            ip = bb->insert(ip, cast);
+            ip++;
+        }
+    });
+}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -26,14 +26,16 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
             auto i = *ip;
             bool trigger = false;
             if (Force::Cast(i)) {
-                auto arg = i->arg(0).val()->followCasts();
-                // Blacklist of where it is not worthwhile
-                if (!LdConst::Cast(arg) &&
-                    // leave this to the promise inliner
-                    !MkArg::Cast(arg) && !Force::Cast(arg) &&
-                    // leave this to scope analysis
-                    !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
-                    trigger = true;
+                if (!i->type.isA(i->typeFeedback)) {
+                    auto arg = i->arg(0).val()->followCasts();
+                    // Blacklist of where it is not worthwhile
+                    if (!LdConst::Cast(arg) &&
+                        // leave this to the promise inliner
+                        !MkArg::Cast(arg) && !Force::Cast(arg) &&
+                        // leave this to scope analysis
+                        !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
+                        trigger = true;
+                    }
                 }
             }
             if (trigger) {

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -12,6 +12,10 @@ struct Parameter {
     static bool DEOPT_CHAOS_SEED;
     static size_t MAX_INPUT_SIZE;
     static unsigned RIR_WARMUP;
+
+    static size_t INLINER_MAX_SIZE;
+    static size_t INLINER_MAX_INLINEE_SIZE;
+    static size_t INLINER_INITIAL_FUEL;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -365,12 +365,13 @@ const Value* Instruction::cFollowCastsAndForce() const {
 
 bool Instruction::envOnlyForObj() {
 #define V(Name)                                                                \
-    if (Name::Cast(this)) {                                                    \
+    if (Tag::Name == tag) {                                                    \
         return true;                                                           \
     }
     BINOP_INSTRUCTIONS(V)
-    VECTOR_RW_INSTRUCTIONS(V)
 #undef V
+    if (tag == Tag::Extract1_1D || tag == Tag::Extract2_1D)
+        return true;
     return false;
 }
 

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -481,6 +481,10 @@ void IsType::printArgs(std::ostream& out, bool tty) const {
 void Phi::updateType() {
     type = arg(0).val()->type;
     eachArg([&](BB*, Value* v) -> void { type = type | v->type; });
+    typeFeedback = arg(0).val()->type;
+    eachArg([&](BB*, Value* v) -> void {
+        typeFeedback = typeFeedback | v->typeFeedback;
+    });
 }
 
 void Phi::printArgs(std::ostream& out, bool tty) const {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -472,6 +472,12 @@ void Is::printArgs(std::ostream& out, bool tty) const {
     out << ", " << Rf_type2char(sexpTag);
 }
 
+void IsType::printArgs(std::ostream& out, bool tty) const {
+    arg<0>().val()->printRef(out);
+    out << " isA ";
+    typeTest.print(out);
+}
+
 void Phi::updateType() {
     type = arg(0).val()->type;
     eachArg([&](BB*, Value* v) -> void { type = type | v->type; });

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1120,6 +1120,16 @@ class FLI(Is, 1, Effects::None()) {
     void printArgs(std::ostream& out, bool tty) const override;
 };
 
+class FLI(IsType, 1, Effects::None()) {
+  public:
+    const PirType typeTest;
+    IsType(PirType type, Value* v)
+        : FixedLenInstruction(NativeType::test, {{PirType::any()}}, {{v}}),
+          typeTest(type) {}
+
+    void printArgs(std::ostream& out, bool tty) const override;
+};
+
 class FLI(LdFunctionEnv, 0, Effects::None()) {
   public:
     LdFunctionEnv() : FixedLenInstruction(RType::env) {}

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -73,6 +73,7 @@
     V(Inc)                                                                     \
     V(Dec)                                                                     \
     V(Is)                                                                      \
+    V(IsType)                                                                  \
     V(Plus)                                                                    \
     V(Minus)                                                                   \
     V(Identical)                                                               \

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -91,8 +91,14 @@ PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
 }
 
 void PirType::merge(const ObservedValues& other) {
-    if (!other.numTypes)
+    assert(other.numTypes);
+
+    if (other.numTypes == ObservedValues::MaxTypes) {
+        merge(any());
+        flags_.set(TypeFlags::maybeObject);
+        flags_.set(TypeFlags::maybeNotScalar);
         return;
+    }
 
     if (other.numTypes == ObservedValues::MaxTypes) {
         merge(any());

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -7,8 +7,8 @@
 #include <vector>
 
 #include "R/r_incl.h"
-#include "ir/RuntimeFeedback.h"
 #include "runtime/Assumptions.h"
+#include "runtime/TypeFeedback.h"
 #include "utils/EnumSet.h"
 
 namespace rir {

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -132,8 +132,10 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 }
 
 bool PirCheck::run(SEXP f) {
-    size_t oldconfig = pir::Parameter::MAX_INPUT_SIZE;
+    size_t oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
+    size_t oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
     pir::Parameter::MAX_INPUT_SIZE = 3000;
+    pir::Parameter::INLINER_MAX_SIZE = 3000;
     Module m;
     ClosureVersion* pir = compilePir(f, &m);
     bool success = pir;
@@ -152,7 +154,8 @@ bool PirCheck::run(SEXP f) {
         }
     }
     }
-    pir::Parameter::MAX_INPUT_SIZE = oldconfig;
+    pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
+    pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
     if (!success)
         m.print(std::cout, false);
     return success;

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1038,6 +1038,28 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                 break;
             }
 
+            case Tag::IsType: {
+                auto is = IsType::Cast(instr);
+                auto t = is->typeTest;
+                assert(!t.isVoid() && !t.maybeObj() && !t.maybeLazy() &&
+                       !t.maybePromiseWrapped());
+
+                if (t.isA(RType::integer)) {
+                    if (t.isScalar())
+                        cb.add(BC::is(TypeChecks::IntegerSimpleScalar));
+                    else
+                        cb.add(BC::is(TypeChecks::IntegerNonObject));
+                } else if (t.isA(RType::real)) {
+                    if (t.isScalar())
+                        cb.add(BC::is(TypeChecks::RealSimpleScalar));
+                    else
+                        cb.add(BC::is(TypeChecks::RealNonObject));
+                } else {
+                    assert(false);
+                }
+                break;
+            }
+
             case Tag::AsInt: {
                 auto asInt = AsInt::Cast(instr);
                 if (asInt->ceil)

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -290,9 +290,17 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
     }
 
+    case Opcode::record_type_: {
+        if (bc.immediate.typeFeedback.numTypes)
+            at(0)->typeFeedback.merge(bc.immediate.typeFeedback);
+        break;
+    }
+
     case Opcode::record_binop_: {
-        at(0)->typeFeedback.merge(bc.immediate.binopFeedback[0]);
-        at(1)->typeFeedback.merge(bc.immediate.binopFeedback[1]);
+        if (bc.immediate.binopFeedback[0].numTypes)
+            at(0)->typeFeedback.merge(bc.immediate.binopFeedback[0]);
+        if (bc.immediate.binopFeedback[1].numTypes)
+            at(1)->typeFeedback.merge(bc.immediate.binopFeedback[1]);
         break;
     }
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -296,14 +296,6 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
     }
 
-    case Opcode::record_binop_: {
-        if (bc.immediate.binopFeedback[0].numTypes)
-            at(0)->typeFeedback.merge(bc.immediate.binopFeedback[0]);
-        if (bc.immediate.binopFeedback[1].numTypes)
-            at(1)->typeFeedback.merge(bc.immediate.binopFeedback[1]);
-        break;
-    }
-
     case Opcode::record_call_: {
         Value* target = top();
         callTargetFeedback[target] = bc.immediate.callFeedback;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2007,16 +2007,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             NEXT();
         }
 
-        INSTRUCTION(record_binop_) {
-            ObservedValues* feedback = (ObservedValues*)pc;
-            SEXP l = ostack_at(ctx, 1);
-            SEXP r = ostack_top(ctx);
-            feedback[0].record(l);
-            feedback[1].record(r);
-            pc += 2 * sizeof(ObservedValues);
-            NEXT();
-        }
-
         INSTRUCTION(call_implicit_) {
 #ifdef ENABLE_SLOWASSERT
             auto lll = ostack_length(ctx);

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -29,6 +29,10 @@ BC_NOARGS(V, _)
         cs.insert(immediate.callFeedback);
         return;
 
+    case Opcode::record_type_:
+        cs.insert(immediate.typeFeedback);
+        break;
+
     case Opcode::record_binop_:
         cs.insert(immediate.binopFeedback[0]);
         cs.insert(immediate.binopFeedback[1]);
@@ -166,8 +170,23 @@ void BC::printOpcode(std::ostream& out) const { out << name(bc) << "  "; }
 
 void BC::print(std::ostream& out) const {
     out << "   ";
-    if (bc != Opcode::record_call_ && bc != Opcode::record_binop_)
+    if (bc != Opcode::record_call_ && bc != Opcode::record_binop_ &&
+        bc != Opcode::record_type_)
         printOpcode(out);
+
+    auto printTypeFeedback = [&](const ObservedValues& prof) {
+        if (prof.numTypes) {
+            for (size_t i = 0; i < prof.numTypes; ++i) {
+                auto t = prof.seen[i];
+                out << Rf_type2char(t.sexptype) << "(" << (t.object ? "o" : "")
+                    << (t.attribs ? "a" : "") << (t.scalar ? "s" : "") << ")";
+                if (i != (unsigned)prof.numTypes - 1)
+                    out << ", ";
+            }
+        } else {
+            out << "<?>";
+        }
+    };
 
     switch (bc) {
     case Opcode::invalid_:
@@ -290,22 +309,18 @@ void BC::print(std::ostream& out) const {
         break;
     }
 
+    case Opcode::record_type_: {
+        out << "[ ";
+        printTypeFeedback(immediate.typeFeedback);
+        out << " ]";
+        break;
+    }
+
     case Opcode::record_binop_: {
         auto prof = immediate.binopFeedback;
         out << "[ ";
         for (size_t j = 0; j < 2; ++j) {
-            if (prof[j].numTypes) {
-                for (size_t i = 0; i < prof[j].numTypes; ++i) {
-                    auto t = prof[j].seen[i];
-                    out << Rf_type2char(t.sexptype) << "("
-                        << (t.object ? "o" : "") << (t.attribs ? "a" : "")
-                        << (t.scalar ? "s" : "") << ")";
-                    if (i != (unsigned)prof[j].numTypes - 1)
-                        out << ", ";
-                }
-            } else {
-                out << "<?>";
-            }
+            printTypeFeedback(prof[j]);
             if (j == 0)
                 out << " x ";
         }

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -33,11 +33,6 @@ BC_NOARGS(V, _)
         cs.insert(immediate.typeFeedback);
         break;
 
-    case Opcode::record_binop_:
-        cs.insert(immediate.binopFeedback[0]);
-        cs.insert(immediate.binopFeedback[1]);
-        return;
-
     case Opcode::push_:
     case Opcode::deopt_:
     case Opcode::ldfun_:
@@ -170,8 +165,7 @@ void BC::printOpcode(std::ostream& out) const { out << name(bc) << "  "; }
 
 void BC::print(std::ostream& out) const {
     out << "   ";
-    if (bc != Opcode::record_call_ && bc != Opcode::record_binop_ &&
-        bc != Opcode::record_type_)
+    if (bc != Opcode::record_call_ && bc != Opcode::record_type_)
         printOpcode(out);
 
     auto printTypeFeedback = [&](const ObservedValues& prof) {
@@ -312,18 +306,6 @@ void BC::print(std::ostream& out) const {
     case Opcode::record_type_: {
         out << "[ ";
         printTypeFeedback(immediate.typeFeedback);
-        out << " ]";
-        break;
-    }
-
-    case Opcode::record_binop_: {
-        auto prof = immediate.binopFeedback;
-        out << "[ ";
-        for (size_t j = 0; j < 2; ++j) {
-            printTypeFeedback(prof[j]);
-            if (j == 0)
-                out << " x ";
-        }
         out << " ]";
         break;
     }

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -23,7 +23,6 @@ BC BC::name() { return BC(Opcode::name_##_); }
 BC_NOARGS(V, _)
 #undef V
 BC BC::recordCall() { return BC(Opcode::record_call_); }
-BC BC::recordBinop() { return BC(Opcode::record_binop_); }
 BC BC::recordType() { return BC(Opcode::record_type_); }
 BC BC::popn(unsigned n) {
     ImmediateArguments i;

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -24,6 +24,7 @@ BC_NOARGS(V, _)
 #undef V
 BC BC::recordCall() { return BC(Opcode::record_call_); }
 BC BC::recordBinop() { return BC(Opcode::record_binop_); }
+BC BC::recordType() { return BC(Opcode::record_type_); }
 BC BC::popn(unsigned n) {
     ImmediateArguments i;
     i.i = n;
@@ -216,6 +217,7 @@ BC BC::pick(uint32_t i) {
     im.i = i;
     return BC(Opcode::pick_, im);
 }
+BC BC::is(TypeChecks i) { return BC::is(static_cast<uint32_t>(i)); }
 BC BC::is(uint32_t i) {
     ImmediateArguments im;
     im.i = i;

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -138,7 +138,6 @@ class BC {
         NumLocals loc;
         LocalsCopy loc_cpy;
         ObservedCallees callFeedback;
-        ObservedValues binopFeedback[2];
         ObservedValues typeFeedback;
         ImmediateArguments() { memset(this, 0, sizeof(ImmediateArguments)); }
     };
@@ -668,9 +667,6 @@ BC_NOARGS(V, _)
             break;
         case Opcode::record_type_:
             memcpy(&immediate.typeFeedback, pc, sizeof(ObservedValues));
-            break;
-        case Opcode::record_binop_:
-            memcpy(&immediate.binopFeedback, pc, sizeof(ObservedValues) * 2);
             break;
 #define V(NESTED, name, name_) case Opcode::name_##_:
 BC_NOARGS(V, _)

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -13,8 +13,8 @@
 #include <array>
 #include <vector>
 
-#include "ir/RuntimeFeedback.h"
 #include "runtime/Assumptions.h"
+#include "runtime/TypeFeedback.h"
 
 #include "BC_noarg_list.h"
 
@@ -139,6 +139,7 @@ class BC {
         LocalsCopy loc_cpy;
         ObservedCallees callFeedback;
         ObservedValues binopFeedback[2];
+        ObservedValues typeFeedback;
         ImmediateArguments() { memset(this, 0, sizeof(ImmediateArguments)); }
     };
 
@@ -327,6 +328,7 @@ BC_NOARGS(V, _)
 #undef V
     inline static BC recordCall();
     inline static BC recordBinop();
+    inline static BC recordType();
     inline static BC popn(unsigned n);
     inline static BC push(SEXP constant);
     inline static BC push(double constant);
@@ -364,6 +366,7 @@ BC_NOARGS(V, _)
     inline static BC pick(uint32_t);
     inline static BC pull(uint32_t);
     inline static BC is(uint32_t);
+    inline static BC is(TypeChecks);
     inline static BC deopt(SEXP);
     inline static BC callImplicit(const std::vector<FunIdx>& args, SEXP ast,
                                   const Assumptions& given);
@@ -662,6 +665,9 @@ BC_NOARGS(V, _)
             break;
         case Opcode::record_call_:
             memcpy(&immediate.callFeedback, pc, sizeof(ObservedCallees));
+            break;
+        case Opcode::record_type_:
+            memcpy(&immediate.typeFeedback, pc, sizeof(ObservedValues));
             break;
         case Opcode::record_binop_:
             memcpy(&immediate.binopFeedback, pc, sizeof(ObservedValues) * 2);

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -171,7 +171,6 @@ static Sources hasSources(Opcode bc) {
     case Opcode::lgl_and_:
     case Opcode::lgl_or_:
     case Opcode::record_call_:
-    case Opcode::record_binop_:
     case Opcode::record_type_:
     case Opcode::deopt_:
     case Opcode::pop_context_:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -172,6 +172,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::lgl_or_:
     case Opcode::record_call_:
     case Opcode::record_binop_:
+    case Opcode::record_type_:
     case Opcode::deopt_:
     case Opcode::pop_context_:
     case Opcode::push_context_:

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -313,9 +313,6 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_, bo
         compileExpr(ctx, args[0]);
         compileExpr(ctx, args[1]);
 
-        if (Compiler::profile) {
-            cs << BC::recordBinop();
-        }
         if (fun == symbol::Add)
             cs << BC::add();
         else if (fun == symbol::Sub)
@@ -348,6 +345,9 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_, bo
 
         if (voidContext)
             cs << BC::pop();
+        else if (Compiler::profile)
+            cs << BC::recordType();
+
         return true;
     }
 
@@ -544,16 +544,15 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_, bo
         cs << (superAssign ? BC::ldvarSuper(target)
                            : BC::ldvarForUpdate(target));
 
+        if (Compiler::profile)
+            cs << BC::recordType();
+
         // And index
         compileExpr(ctx, *idx);
         if (is2d) {
             compileExpr(ctx, *idx2);
         }
 
-        // do the thing
-        if (Compiler::profile) {
-            cs << BC::recordBinop();
-        }
         if (is2d) {
             if (fun2 == symbol::DoubleBracket) {
                 cs << BC::subassign2_2();
@@ -700,27 +699,24 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_, bo
         compileExpr(ctx, *idx);
         if (is2d) {
             compileExpr(ctx, *(idx + 1));
-            if (Compiler::profile) {
-                cs << BC::recordBinop();
-            }
             if (fun == symbol::DoubleBracket)
                 cs << BC::extract2_2();
             else
                 cs << BC::extract1_2();
         } else {
-            if (Compiler::profile) {
-                cs << BC::recordBinop();
-            }
             if (fun == symbol::DoubleBracket)
                 cs << BC::extract2_1();
             else
                 cs << BC::extract1_1();
         }
         cs.addSrc(ast);
-        if (!voidContext)
+        if (!voidContext) {
+            if (Compiler::profile)
+                cs << BC::recordType();
             cs << BC::visible();
-        else
+        } else {
             cs << BC::pop();
+        }
         return true;
     }
 
@@ -1031,6 +1027,8 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args, bool voidC
     }
     if (voidContext)
         cs << BC::pop();
+    else if (Compiler::profile)
+        cs << BC::recordType();
 }
 
 // Lookup
@@ -1041,6 +1039,8 @@ void compileGetvar(CodeStream& cs, SEXP name, bool needsVisible = true) {
         cs << BC::push(R_MissingArg);
     } else {
         cs << BC::ldvar(name);
+        if (Compiler::profile)
+            cs << BC::recordType();
     }
     if (needsVisible)
         cs << BC::visible();

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -518,7 +518,6 @@ DEF_INSTR(deopt_, 1, -1, 0, 0)
  * heavy in size.
  */
 DEF_INSTR(record_call_, 4, 1, 1, 0)
-DEF_INSTR(record_binop_, 2, 2, 2, 0)
 DEF_INSTR(record_type_, 1, 1, 1, 0)
 
 DEF_INSTR(int3_, 0, 0, 0, 0)

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -519,6 +519,7 @@ DEF_INSTR(deopt_, 1, -1, 0, 0)
  */
 DEF_INSTR(record_call_, 4, 1, 1, 0)
 DEF_INSTR(record_binop_, 2, 2, 2, 0)
+DEF_INSTR(record_type_, 1, 1, 1, 0)
 
 DEF_INSTR(int3_, 0, 0, 0, 0)
 DEF_INSTR(printInvocation_, 0, 0, 0, 0)

--- a/rir/src/runtime/TypeFeedback.cpp
+++ b/rir/src/runtime/TypeFeedback.cpp
@@ -1,4 +1,4 @@
-#include "RuntimeFeedback.h"
+#include "TypeFeedback.h"
 #include "R/r.h"
 #include "runtime/Code.h"
 

--- a/rir/src/runtime/TypeFeedback.cpp
+++ b/rir/src/runtime/TypeFeedback.cpp
@@ -5,9 +5,6 @@
 #include <cassert>
 
 namespace rir {
-ObservedType::ObservedType(SEXP s)
-    : sexptype((uint8_t)TYPEOF(s)), scalar(IS_SCALAR(s, TYPEOF(s))),
-      object(OBJECT(s)), attribs(ATTRIB(s) != R_NilValue) {}
 
 SEXP ObservedCallees::getTarget(const Code* code, size_t pos) const {
     assert(pos < numTargets);

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -57,7 +57,7 @@ struct ObservedValues {
 
     ObservedValues() : numTypes(0) {}
 
-    void record(SEXP e) {
+    RIR_INLINE void record(SEXP e) {
         ObservedType type(e);
         if (numTypes < MaxTypes) {
             int i = 0;
@@ -73,6 +73,14 @@ static_assert(sizeof(ObservedValues) == sizeof(uint32_t),
               "Size needs to fit inside a record_ bc immediate args");
 
 #pragma pack(pop)
+
+enum class TypeChecks : uint32_t {
+    // Must be bigger than smallest sexptype
+    IntegerNonObject = 3330,
+    IntegerSimpleScalar = 3331,
+    RealNonObject = 3332,
+    RealSimpleScalar = 3334,
+};
 
 } // namespace rir
 #endif

--- a/rir/src/runtime/TypeFeedback_inl.h
+++ b/rir/src/runtime/TypeFeedback_inl.h
@@ -6,6 +6,10 @@
 
 namespace rir {
 
+ObservedType::ObservedType(SEXP s)
+    : sexptype((uint8_t)TYPEOF(s)), scalar(IS_SCALAR(s, TYPEOF(s))),
+      object(OBJECT(s)), attribs(ATTRIB(s) != R_NilValue) {}
+
 void ObservedCallees::record(Code* caller, SEXP callee) {
     if (taken < CounterOverflow)
         taken++;

--- a/rir/src/runtime/TypeFeedback_inl.h
+++ b/rir/src/runtime/TypeFeedback_inl.h
@@ -1,8 +1,8 @@
 #ifndef RIR_RUNTIME_FEEDBACK_INL_H
 #define RIR_RUNTIME_FEEDBACK_INL_H
 
-#include "RuntimeFeedback.h"
-#include "runtime/Code.h"
+#include "Code.h"
+#include "TypeFeedback.h"
 
 namespace rir {
 

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -75,10 +75,10 @@ void Configurations::defaultOptimizations() {
     //
     // This pass is scheduled second, since we want to first try to do this
     // statically in Phase 1
-    optimizations.push_back(new pir::ElideEnvSpec());
+    optimizations.push_back(new pir::TypeSpeculation());
     optimizations.push_back(new pir::ElideEnvSpec());
     addDefaultOpt();
-    optimizations.push_back(new pir::ElideEnvSpec());
+    optimizations.push_back(new pir::TypeSpeculation());
     optimizations.push_back(new pir::ElideEnvSpec());
 
     phasemarker("Phase 2: Env speculation");


### PR DESCRIPTION
instead of recording inputs, record results. Remove record binop
instructions, instead a singular record instruction that we place
*after* ldvars and binops.