### PR TITLE
support calling closure from R with extra method dispatch arguments

### DIFF
--- a/rir/src/interpreter/interp_incl.h
+++ b/rir/src/interpreter/interp_incl.h
@@ -40,7 +40,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 SEXP rirExpr(SEXP f);
 
 SEXP rirEval_f(SEXP f, SEXP env);
-SEXP rirApplyClosure(SEXP, SEXP, SEXP, SEXP);
+SEXP rirApplyClosure(SEXP, SEXP, SEXP, SEXP, SEXP);
 
 SEXP argsLazyCreation(void* rirDataWrapper);
 


### PR DESCRIPTION
this should fix the issue where innerBenchmarkLoop in harnes.r is never compiled, since it is called trough UseMethod