### PR TITLE
add an assumption for non reflective arguments

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -69,12 +69,17 @@ pir.check <- function(f, ..., warmup=NULL) {
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))
     if (length(checks) == 0)
         stop("pir.check: needs at least 1 check")
+
+    .Call("pir_check_warmup_begin")
     rir.compile(f)
-    if (is.list(warmup)) {
+    if (!is.null(warmup)) {
+        rir.compile(warmup)
+        pir.compile(warmup)
         for (i in 1:as.numeric(Sys.getenv("PIR_WARMUP", unset="3")))
-            do.call(f, warmup)
+            warmup(f)
     }
     .Call("pir_check", f, checks)
+    #.Call("pir_check_warmup_end")
 }
 
 # creates a bitset with pir debug options

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -6,6 +6,7 @@
 
 #include "api.h"
 
+#include "compiler/parameter.h"
 #include "compiler/test/PirCheck.h"
 #include "compiler/test/PirTests.h"
 #include "compiler/translations/pir_2_rir/pir_2_rir.h"
@@ -288,6 +289,24 @@ REXPORT SEXP pir_compile(SEXP what, SEXP name, SEXP debugFlags,
 
 REXPORT SEXP pir_tests() {
     PirTests::run();
+    return R_NilValue;
+}
+
+static size_t oldMaxInput = 0;
+static size_t oldInlinerMax = 0;
+
+REXPORT SEXP pir_check_warmup_begin(SEXP f, SEXP checksSxp, SEXP env) {
+    if (oldMaxInput == 0) {
+        oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
+        oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
+    }
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
+    pir::Parameter::INLINER_MAX_SIZE = 4000;
+    return R_NilValue;
+}
+REXPORT SEXP pir_check_warmup_end(SEXP f, SEXP checksSxp, SEXP env) {
+    pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
+    pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
     return R_NilValue;
 }
 

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -101,7 +101,7 @@ struct AbstractPirValue {
     typedef std::function<void(const ValOrig&)> ValOrigMaybe;
     typedef std::function<bool(const ValOrig&)> ValOrigMaybePredicate;
 
-    void ifSingleValue(ValMaybe known) {
+    void ifSingleValue(ValMaybe known) const {
         if (!unknown && vals.size() == 1)
             known((*vals.begin()).val);
     }
@@ -334,6 +334,17 @@ class AbstractREnvironmentHierarchy {
     AbstractLoad superGet(Value* env, SEXP e) const;
 
     std::unordered_set<Value*> potentialParents(Value* env) const;
+
+    AbstractResult taintLeaked() {
+        AbstractResult res;
+        for (auto e : envs) {
+            if (e.second.leaked) {
+                e.second.taint();
+                res.taint();
+            }
+        }
+        return res;
+    }
 };
 
 template <typename Kind>

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -152,6 +152,33 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                     continue;
                 }
 
+                auto availableAssumptions = call->inferAvailableAssumptions();
+
+                // We picked up more assumptions, let's compile a better
+                // version. Maybe we should limit this at some point, to avoid
+                // version explosion.
+                if (availableAssumptions.includes(
+                        Assumption::NoReflectiveArgument) &&
+                    !version->assumptions().includes(
+                        Assumption::NoReflectiveArgument)) {
+                    auto newVersion = cls->cloneWithAssumptions(
+                        version, availableAssumptions,
+                        [&](ClosureVersion* newCls) {
+                            Visitor::run(newCls->entry, [&](Instruction* i) {
+                                if (auto f = Force::Cast(i)) {
+                                    if (LdArg::Cast(f)) {
+                                        f->elideEnv();
+                                        f->effects.reset();
+                                    }
+                                }
+                            });
+                        });
+                    call->hint = newVersion;
+                    assert(call->tryDispatch() == newVersion);
+                    ip = next;
+                    continue;
+                }
+
                 bool allEager = version->properties.includes(
                     ClosureVersion::Property::IsEager);
                 if (!allEager &&
@@ -199,7 +226,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                 // below.
                 todo.insert(args.begin(), args.end());
 
-                Assumptions newAssumptions = call->inferAvailableAssumptions();
+                Assumptions newAssumptions = availableAssumptions;
                 for (size_t i = 0; i < call->nCallArgs(); ++i) {
                     if (!newAssumptions.isEager(i) && isEager(i))
                         newAssumptions.setEager(i);

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -53,8 +53,8 @@ ClosureVersion* Closure::cloneWithAssumptions(ClosureVersion* version,
 
 ClosureVersion*
 Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
-    // Reverse since they are ordered by number of assumptions
-    for (auto c = versions.rbegin(); c != versions.rend(); c++) {
+    // ordered by number of assumptions
+    for (auto c = versions.begin(); c != versions.end(); c++) {
         auto candidate = *c;
         auto candidateCtx = candidate.first;
         if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -54,7 +54,7 @@ ClosureVersion* Closure::cloneWithAssumptions(ClosureVersion* version,
 ClosureVersion*
 Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
     // ordered by number of assumptions
-    for (auto c = versions.begin(); c != versions.end(); c++) {
+    for (auto c = versions.rbegin(); c != versions.rend(); c++) {
         auto candidate = *c;
         auto candidateCtx = candidate.first;
         if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -413,7 +413,10 @@ void Branch::printGraphBranches(std::ostream& out, size_t bbId) const {
 
 void MkArg::printArgs(std::ostream& out, bool tty) const {
     eagerArg()->printRef(out);
-    out << ", " << *prom() << ", ";
+    out << ", " << *prom();
+    if (noReflection)
+        out << " (!refl)";
+    out << ", ";
 }
 
 void Missing::printArgs(std::ostream& out, bool tty) const {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -761,6 +761,7 @@ Assumptions CallInstruction::inferAvailableAssumptions() const {
 
     // Make some optimistic assumptions, they might be reset below...
     given.add(Assumption::NoExplicitlyMissingArgs);
+    given.add(Assumption::NoReflectiveArgument);
 
     size_t i = 0;
     eachCallArg([&](Value* arg) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -837,6 +837,8 @@ class FLIE(MkArg, 2, Effects::None()) {
     Promise* prom_;
 
   public:
+    bool noReflection = false;
+
     MkArg(Promise* prom, Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -844,12 +844,14 @@ class FLIE(MkArg, 2, Effects::None()) {
                                          env),
           prom_(prom) {
         assert(eagerArg() == v);
+        noReflection = isEager();
     }
     MkArg(Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
           prom_(nullptr) {
         assert(eagerArg() == v);
+        noReflection = isEager();
     }
 
     Value* eagerArg() const { return arg(0).val(); }

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -148,8 +148,8 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 bool PirCheck::run(SEXP f) {
     size_t oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
     size_t oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3000;
-    pir::Parameter::INLINER_MAX_SIZE = 3000;
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
+    pir::Parameter::INLINER_MAX_SIZE = 4000;
     Module m;
     ClosureVersion* pir = compilePir(f, &m);
     bool success = pir;

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -15,7 +15,7 @@ namespace rir {
 
 using namespace pir;
 
-static ClosureVersion* compilePir(SEXP f, Module* m) {
+static ClosureVersion* recompilePir(SEXP f, Module* m) {
     if (TYPEOF(f) != CLOSXP) {
         Rf_warning("pir check failed: not a closure");
         return nullptr;
@@ -146,12 +146,8 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 }
 
 bool PirCheck::run(SEXP f) {
-    size_t oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
-    size_t oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3500;
-    pir::Parameter::INLINER_MAX_SIZE = 4000;
     Module m;
-    ClosureVersion* pir = compilePir(f, &m);
+    ClosureVersion* pir = recompilePir(f, &m);
     bool success = pir;
     if (success) {
         for (PirCheck::Type type : types) {
@@ -168,8 +164,6 @@ bool PirCheck::run(SEXP f) {
         }
     }
     }
-    pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
-    pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
     if (!success)
         m.print(std::cout, false);
     return success;

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -705,7 +705,7 @@ namespace rir {
 
 void PirTests::run() {
     size_t oldconfig = pir::Parameter::MAX_INPUT_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3000;
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
     for (auto t : tests) {
         std::cout << "> " << t.first << "\n";
         if (!t.second()) {

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -42,6 +42,8 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
                 assumptions.setSimpleInt(i);
         }
     }
+    if (!MkArg::Cast(value) || !MkArg::Cast(value)->noReflection)
+        assumptions.remove(Assumption::NoReflectiveArgument);
 }
 
 } // namespace pir

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -22,15 +22,17 @@ void readArgTypeFromAssumptions(const Assumptions& assumptions, PirType& type,
 }
 
 void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
-    auto mk = MkArg::Cast(arg);
-    if (mk && mk->isEager()) {
-        if (mk->eagerArg() == MissingArg::instance())
-            assumptions.remove(Assumption::NoExplicitlyMissingArgs);
-        else
-            assumptions.setEager(i);
-    }
-    Value* value = arg->followCastsAndForce();
-    if (!MkArg::Cast(value)) {
+    if (auto mk = MkArg::Cast(arg)) {
+        if (mk->isEager()) {
+            if (mk->eagerArg() == MissingArg::instance())
+                assumptions.remove(Assumption::NoExplicitlyMissingArgs);
+            else
+                assumptions.setEager(i);
+        }
+        // if (!mk->noReflection)
+        //    assumptions.remove(Assumption::NoReflectiveArgument);
+    } else {
+        Value* value = arg->followCastsAndForce();
         if (!value->type.maybeObj())
             assumptions.setNotObj(i);
         if (assumptions.isEager(i) && assumptions.isNotObj(i) &&
@@ -42,8 +44,6 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
                 assumptions.setSimpleInt(i);
         }
     }
-    if (!MkArg::Cast(value) || !MkArg::Cast(value)->noReflection)
-        assumptions.remove(Assumption::NoReflectiveArgument);
 }
 
 } // namespace pir

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1974,8 +1974,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto arguments = (Immediate*)pc;
             advanceImmediateN(n);
             auto names = (Immediate*)pc;
@@ -2019,8 +2019,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto arguments = (Immediate*)pc;
             advanceImmediateN(n);
             CallContext call(c, ostack_top(ctx), n, ast, arguments, env, given,
@@ -2045,8 +2045,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             CallContext call(c, ostack_at(ctx, n), n, ast,
                              ostack_cell_at(ctx, n - 1), env, given, ctx);
             res = doCall(call, ctx);
@@ -2069,8 +2069,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto names = (Immediate*)pc;
             advanceImmediateN(n);
             CallContext call(c, ostack_at(ctx, n), n, ast,
@@ -2121,8 +2121,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             Immediate ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             SEXP callee = cp_pool_at(ctx, readImmediate());
             advanceImmediate();
             SEXP version = cp_pool_at(ctx, readImmediate());

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -281,7 +281,7 @@ class BC {
         switch (bc) {
         // First handle the varlength BCs. In all three cases the number of
         // call arguments is the 2nd immediate argument and the
-        // instructions have 2 fixed length immediates. After that there are
+        // instructions have 4 fixed length immediates. After that there are
         // narg varlen immediates for the first two and 2*narg varlen
         // immediates in the last case.
         case Opcode::call_implicit_:
@@ -289,13 +289,13 @@ class BC {
             pc++;
             Immediate nargs;
             memcpy(&nargs, pc, sizeof(Immediate));
-            return 1 + (3 + nargs) * sizeof(Immediate);
+            return 1 + (4 + nargs) * sizeof(Immediate);
         }
         case Opcode::named_call_implicit_: {
             pc++;
             Immediate nargs;
             memcpy(&nargs, pc, sizeof(Immediate));
-            return 1 + (3 + 2 * nargs) * sizeof(Immediate);
+            return 1 + (4 + 2 * nargs) * sizeof(Immediate);
         }
         case Opcode::mk_stub_env_:
         case Opcode::mk_env_: {

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -127,21 +127,21 @@ DEF_INSTR(movloc_, 2, 0, 0, 1)
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + nargs
  */
-DEF_INSTR(call_implicit_, 3, 1, 1, 0)
+DEF_INSTR(call_implicit_, 4, 1, 1, 0)
 /*
  * Same as above, but with names for the arguments as immediates
  *
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + 2 * nargs
  */
-DEF_INSTR(named_call_implicit_, 3, 1, 1, 0)
+DEF_INSTR(named_call_implicit_, 4, 1, 1, 0)
 
 /**
  * call_:: Like call_implicit_, but expects arguments on stack
  *         on top of the callee; these arguments can be both
  *         values and promises (even preseeded w/ a value)
  */
-DEF_INSTR(call_, 3, -1, 1, 0)
+DEF_INSTR(call_, 4, -1, 1, 0)
 
 /*
  * Same as above, but with names for the arguments as immediates
@@ -149,13 +149,13 @@ DEF_INSTR(call_, 3, -1, 1, 0)
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + nargs
  */
-DEF_INSTR(named_call_, 3, -1, 1, 0)
+DEF_INSTR(named_call_, 4, -1, 1, 0)
 
 /**
  * static_call_:: Like call_, but the callee is statically known
  *                and is accessed via the immediate callsite
  */
-DEF_INSTR(static_call_, 5, -1, 1, 0)
+DEF_INSTR(static_call_, 6, -1, 1, 0)
 
 /**
  * call_builtin_:: Like static call, but calls a builtin

--- a/rir/src/runtime/Assumptions.cpp
+++ b/rir/src/runtime/Assumptions.cpp
@@ -4,6 +4,9 @@ namespace rir {
 
 std::ostream& operator<<(std::ostream& out, Assumption a) {
     switch (a) {
+    case Assumption::NoReflectiveArgument:
+        out << "!RefA";
+        break;
     case Assumption::NoExplicitlyMissingArgs:
         out << "!ExpMi";
         break;

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -111,6 +111,14 @@ struct Assumptions {
 
     RIR_INLINE bool operator<(const Assumptions& other) const {
         // Order by number of assumptions! Important for dispatching.
+        if (*this != other) {
+            if (subtype(other))
+                return false;
+            if (other.subtype(*this))
+                return true;
+        }
+
+        // for std::map we need a complete order, subtype is only partial
         if (missing != other.missing)
             return missing > other.missing;
         if (flags.count() != other.flags.count())

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -36,15 +36,16 @@ enum class Assumption {
                              //  supplied >= (nargs - missing)
                              //  Note: can still have explicitly missing args
     NotTooManyArguments,     // The number of args supplied is <= nargs
+    NoReflectiveArgument,    // Argument promises are not reflective
 
     FIRST = Arg0IsEager_,
-    LAST = NotTooManyArguments
+    LAST = NoReflectiveArgument
 };
 
 #pragma pack(push)
 #pragma pack(1)
 struct Assumptions {
-    typedef EnumSet<Assumption, uint16_t> Flags;
+    typedef EnumSet<Assumption, uint32_t> Flags;
 
     constexpr static size_t MAX_MISSING = 255;
     // # of args with type assumptions
@@ -56,10 +57,11 @@ struct Assumptions {
     explicit constexpr Assumptions(const Flags& flags) : flags(flags) {}
     constexpr Assumptions(const Flags& flags, uint8_t missing)
         : flags(flags), missing(missing) {}
-    explicit Assumptions(uint32_t i) {
+    explicit Assumptions(void* pos) {
         // Silences unused warning:
         (void)unused;
-        memcpy(this, &i, sizeof(i));
+        (void)unused2;
+        memcpy(this, pos, sizeof(*this));
     }
 
     RIR_INLINE void add(Assumption a) { flags.set(a); }
@@ -136,12 +138,14 @@ struct Assumptions {
   private:
     Flags flags;
     uint8_t missing = 0;
+
     uint8_t unused = 0;
+    uint16_t unused2 = 0;
 };
 #pragma pack(pop)
 
 typedef uint32_t Immediate;
-static_assert(sizeof(Assumptions) == sizeof(Immediate),
+static_assert(sizeof(Assumptions) == 2 * sizeof(Immediate),
               "Assumptions needs to be one immediate arg size");
 
 std::ostream& operator<<(std::ostream& out, Assumption a);

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -113,16 +113,14 @@ struct Assumptions {
         // Order by number of assumptions! Important for dispatching.
         if (*this != other) {
             if (subtype(other))
-                return false;
-            if (other.subtype(*this))
                 return true;
+            if (other.subtype(*this))
+                return false;
         }
 
-        // for std::map we need a complete order, subtype is only partial
+        // we need a complete order, subtype is only partial
         if (missing != other.missing)
-            return missing > other.missing;
-        if (flags.count() != other.flags.count())
-            return flags.count() > other.flags.count();
+            return missing < other.missing;
         return flags < other.flags;
     }
 

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -67,18 +67,31 @@ struct DispatchTable
         assert(fun->signature().optimization !=
                FunctionSignature::OptimizationLevel::Baseline);
         auto assumptions = fun->signature().assumptions;
-        assert(size() < capacity());
         size_t i = 1;
         for (; i < size(); ++i) {
             if (get(i)->signature().assumptions == assumptions) {
                 setEntry(i, fun->container());
                 return;
             }
-            if (!(assumptions < get(i)->signature().assumptions)) {
+            if (!(get(i)->signature().assumptions < assumptions)) {
                 break;
             }
         }
-        SLOWASSERT(!contains(fun->signature().assumptions));
+        assert(!contains(fun->signature().assumptions));
+        if (size() == capacity()) {
+            std::cout << "Tried to insert into a full Dispatch table. Have: \n";
+            for (size_t i = 0; i < size(); ++i) {
+                auto e = getEntry(i);
+                std::cout << "* "
+                          << Function::unpack(e)->signature().assumptions
+                          << "\n";
+            }
+            std::cout << "\n";
+            std::cout << "Tried to insert: " << assumptions << "\n";
+            Rf_error("failed");
+            return;
+        }
+
         size_++;
         for (size_t j = size() - 1; j > i; --j) {
             setEntry(j, getEntry(j - 1));
@@ -94,10 +107,19 @@ struct DispatchTable
         }
         std::cout << "\n";
 #endif
-        SLOWASSERT(contains(fun->signature().assumptions));
+
+#ifdef DEBUG_DISPATCH
+        for (size_t i = 0; i < size() - 1; ++i) {
+            assert(get(i)->signature().assumptions <
+                   get(i + 1)->signature().assumptions);
+            assert(!(get(i + 1)->signature().assumptions <
+                     get(i)->signature().assumptions));
+        }
+        assert(contains(fun->signature().assumptions));
+#endif
     }
 
-    static DispatchTable* create(size_t capacity = 15) {
+    static DispatchTable* create(size_t capacity = 20) {
         size_t size =
             sizeof(DispatchTable) + (capacity * sizeof(DispatchTableEntry));
         SEXP s = Rf_allocVector(EXTERNALSXP, size);

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -151,8 +151,8 @@ stopifnot(pir.check(function() {
   f(x, y(), z)
 }, NoEnv, warmup=list()))
 
-mandelbrot <- function() {
-    size = 30
+mandelbrot <- function(size) {
+    size = size
     sum = 0
     byteAcc = 0
     bitNum  = 0
@@ -198,9 +198,14 @@ mandelbrot <- function() {
     }
     return (sum)
 }
+# ensure that this trampoline function is small. otherwise we fail on
+# small MAX_PIR_INPUT, because the caller of mandelbrot won't be compiled
+mandelbrot_tramp <- function(x)
+  mandelbrot(x)
+
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(
-  pir.check(mandelbrot, NoExternalCalls, NoPromise, NoStore, warmup=list())
+  pir.check(mandelbrot_tramp, NoExternalCalls, NoPromise, NoStore, warmup=list(16))
 )
 
 # New tests

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -46,16 +46,16 @@ stopifnot(pir.check(function(depth) {
     1
   else
     0
-}, NoEnvSpec, warmup=list(1)))
+}, NoEnvSpec, warmup=function(f){cat(".\n"); f(0)}))
 
 xxx <- 12
 stopifnot(pir.check(function() {
   1 + xxx
-}, NoEnvForAdd, warmup=list()))
+}, NoEnvForAdd, warmup=function(f) f()))
 yyy = 0
 stopifnot(pir.check(function() {
   1 + yyy
-}, NoEnvForAdd, warmup=list()))
+}, NoEnvForAdd, warmup=function(f) f()))
 stopifnot(pir.check(function(x) {
   y <- 2
 }, NoStore))
@@ -139,7 +139,7 @@ stopifnot(pir.check(function() {
   b <- function() 1L
   f <- function(x, y) x() + y
   f(a, b())
-}, Returns42L, warmup=list()))
+}, Returns42L, warmup=function(f)f()))
 stopifnot(pir.check(function() {
   x <- function() 32
   y <- function() 31
@@ -149,7 +149,7 @@ stopifnot(pir.check(function() {
       42L
   }
   f(x, y(), z)
-}, NoEnv, warmup=list()))
+}, NoEnv, warmup=function(f)f()))
 
 mandelbrot <- function(size) {
     size = size
@@ -198,14 +198,9 @@ mandelbrot <- function(size) {
     }
     return (sum)
 }
-# ensure that this trampoline function is small. otherwise we fail on
-# small MAX_PIR_INPUT, because the caller of mandelbrot won't be compiled
-mandelbrot_tramp <- function(x)
-  mandelbrot(x)
-
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(
-  pir.check(mandelbrot_tramp, NoExternalCalls, NoPromise, NoStore, warmup=list(16))
+  pir.check(mandelbrot, NoExternalCalls, NoPromise, NoStore, warmup=function(f)f(16))
 )
 
 # New tests
@@ -215,13 +210,13 @@ stopifnot(pir.check(function() {
   while (x < 10)
     x <- x + 1
   x
-}, NoLoad, NoStore, warmup=list()))
+}, NoLoad, NoStore, warmup=function(f)f()))
 stopifnot(pir.check(function(n) {
   x <- 1
   while (x < n)
     x <- x + 1
   x
-}, NoLoad, NoStore, warmup=list(10)))
+}, NoLoad, NoStore, warmup=function(f)f(10)))
 
 # Negative Test
 
@@ -279,19 +274,19 @@ stopifnot(pir.check(function(x) {
     5
   else
     4
-}, OneEq, warmup=list(3)))
+}, OneEq, warmup=function(f)f(3)))
 stopifnot(pir.check(function(x) {
   if ((x == 1) == FALSE)
     5
   else
     4
-}, OneEq, warmup=list(4L)))
+}, OneEq, warmup=function(f)f(4L)))
 stopifnot(pir.check(function(x, y) {
   a <- y == 1 # This is the one eq
   (x == 1) == NA
-}, OneEq, warmup=list(5.7, "")))
+}, OneEq, warmup=function(f)f(5.7, "")))
 # Relies on better visibility
-# stopifnot(pir.check(function(x) !!!!!x, OneNot, warmup=list(1)))
+# stopifnot(pir.check(function(x) !!!!!x, OneNot, warmup=function(f)f(1)))
 # Testing NoAsInt itself
 stopifnot(!pir.check(function(n) {
   x <- 0
@@ -315,9 +310,9 @@ stopifnot(!pir.check(function(x) {
 stopifnot(pir.check(function(x) {
   x == 4
   x
-}, NoEq, warmup=list(5)))
+}, NoEq, warmup=function(f)f(5)))
 stopifnot(pir.check(function(x, y) {
   x == 3+7i
   y == NA
   x + y
-}, NoEq, warmup=list(5L, 2L)))
+}, NoEq, warmup=function(f)f(5L, 2L)))


### PR DESCRIPTION
1. tag all promises as no reflective, if we can rule out that they are reflective
2. set a context assumption if all arguments are non-reflective
3. remove dependency on local environment when forcing arguments under the nonReflectiveArguments assumption