### PR TITLE
Vector containing objects fix

### DIFF
--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,8 +995,6 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
-        if (!lhs()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1064,9 +1062,9 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         auto t = vec()->type;
         if (idx()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1079,9 +1077,10 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1059,10 +1059,7 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        PirType t = vec()->type.elem();
-        if (!idx()->type.isScalar())
-            t = t.orNotScalar();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.subsetType(idx()->type));
     }
 };
 
@@ -1075,7 +1072,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        maskEffectsAndTypeOnNonObjects(vec()->type.extractType(idx()->type));
     }
 };
 
@@ -1091,11 +1088,8 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        PirType t = vec()->type.elem();
-        // Technically throws error so it doesn't matter
-        if (!idx1()->type.isScalar() || !idx2()->type.isScalar())
-            t = t.orNotScalar();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(
+            vec()->type.subsetType(idx1()->type | idx2()->type));
     }
 };
 
@@ -1111,7 +1105,8 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        maskEffectsAndTypeOnNonObjects(
+            vec()->type.extractType(idx1()->type | idx2()->type));
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1059,10 +1059,7 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1075,10 +1072,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1094,10 +1088,7 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1113,10 +1104,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1059,7 +1059,10 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        PirType t = vec()->type.elem();
+        if (!idx()->type.isScalar())
+            t = t.orNotScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 
@@ -1088,7 +1091,11 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        PirType t = vec()->type.elem();
+        // Technically throws error so it doesn't matter
+        if (!idx1()->type.isScalar() || !idx2()->type.isScalar())
+            t = t.orNotScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1099,9 +1099,9 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
         auto t = vec()->type;
         if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1117,9 +1117,10 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1060,8 +1060,6 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1077,7 +1075,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1097,8 +1095,6 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx1()->type.isScalar() && idx2()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1117,7 +1113,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,6 +995,8 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
+        if (!lhs()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1056,11 +1058,15 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1070,8 +1076,12 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1083,11 +1093,16 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1099,8 +1114,13 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!Rf_isObject(e)) {
+    if (!isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!isObject(e)) {
+    if (!Rf_isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -334,6 +334,17 @@ struct PirType {
         return PirType(t_.r);
     }
 
+    // Type of an element, assuming this is a vector
+    PirType constexpr elem() const {
+        assert(isRType());
+        if (isA(PirType::num()))
+            return this;
+        else if (isA(RType::str))
+            return RType::chr;
+        else
+            return PirType::val();
+    }
+
     RIR_INLINE void setNotMissing() { *this = notMissing(); }
     RIR_INLINE void setNotObject() { *this = notObject(); }
     RIR_INLINE void setScalar() { *this = scalar(); }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -335,10 +335,10 @@ struct PirType {
     }
 
     // Type of an element, assuming this is a vector
-    PirType constexpr elem() const {
+    PirType elem() const {
         assert(isRType());
         if (isA(PirType::num()))
-            return this;
+            return *this;
         else if (isA(RType::str))
             return RType::chr;
         else

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -337,12 +337,12 @@ struct PirType {
     // Type of an element, assuming this is a vector
     PirType elem() const {
         assert(isRType());
-        if (isA(PirType::num()))
+        if (isA(num()))
             return *this;
         else if (isA(RType::str))
             return RType::chr;
         else
-            return PirType::val();
+            return val();
     }
 
     RIR_INLINE void setNotMissing() { *this = notMissing(); }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -302,6 +302,11 @@ struct PirType {
         return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeNotScalar));
     }
 
+    RIR_INLINE constexpr PirType orNotScalar() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ | TypeFlags::maybeNotScalar);
+    }
+
     RIR_INLINE constexpr PirType orPromiseWrapped() const {
         assert(isRType());
         return PirType(t_.r, flags_ | TypeFlags::promiseWrapped);
@@ -337,10 +342,8 @@ struct PirType {
     // Type of an element, assuming this is a vector
     PirType elem() const {
         assert(isRType());
-        if (isA(num()))
+        if (isA(num() | RType::str))
             return *this;
-        else if (isA(RType::str))
-            return RType::chr;
         else
             return val();
     }

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -526,6 +526,27 @@ bool testCfg() {
     return true;
 }
 
+bool testTypeRules() {
+    PirType r = RType::vec;
+    PirType r2 = RType::logical;
+    assert(r.subsetType(PirType::any()).isA(RType::vec));
+    assert(!r.subsetType(PirType::any()).maybeObj());
+    assert(!r.orObject().subsetType(PirType::bottom()).isA(RType::vec));
+    assert(!r.orObject().subsetType(PirType::bottom()).isA(PirType::val()));
+    assert(r.extractType(PirType::any()).isA(PirType::val()));
+    assert(!r.extractType(PirType::bottom()).isScalar());
+    assert(!r.extractType(PirType::bottom()).maybeMissing());
+    assert(!r.extractType(PirType::bottom()).isA(RType::vec));
+    assert(r.orObject().extractType(PirType::bottom()).maybeMissing());
+    assert(r2.subsetType(RType::real).isA(RType::logical));
+    assert(!r2.subsetType(RType::integer).isScalar());
+    assert(!r2.scalar().subsetType(RType::integer).isScalar());
+    assert(r2.subsetType(PirType(RType::integer).scalar()).isScalar());
+    assert(r2.extractType(RType::integer).isScalar());
+    assert(!r2.subsetType(PirType::any()).maybeObj());
+    return true;
+}
+
 static Test tests[] = {
     Test("test cfg", &testCfg),
     Test("test_42L", []() { return test42("42L"); }),
@@ -697,7 +718,7 @@ static Test tests[] = {
              return test42("{a<- 41L; b<- 1L; f <- function(x,y) x+y; f(a,b)}");
          }),
     Test("Test dead store analysis", &testDeadStore),
-};
+    Test("Test type rules", &testTypeRules)};
 
 } // namespace
 

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -107,7 +107,8 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         findBuiltin("~"),
         findBuiltin("crossprod"),
         findBuiltin("tcrossprod"),
-        findBuiltin("lengths"),
+        // Would be safe if not a vector of objects
+        // findBuiltin("lengths"),
         findBuiltin("round"),
         findBuiltin("signif"),
         findBuiltin("log"),


### PR DESCRIPTION
A vector containing objects isn't an object itself. However, it you extract an element that could be an object.

Currently we don't see any failures because PIR can't ever infer a vector containing objects isn't an object, e.g. `c(a, b, c)` will be marked as an object because PIR doesn't know the type signature of `c`, and there aren't any literals for object vectors.

Also, builtins (currently only `lengths`), do extract elements on their arguments, so we can't mark them as safe unless we know the arguments aren't object-containing vectors.