### PR TITLE
Small BB refactor and phi fix

### DIFF
--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -1,4 +1,5 @@
 #include "../pir/pir_impl.h"
+#include "../transform/bb.h"
 #include "../translations/pir_translator.h"
 #include "../util/cfg.h"
 #include "../util/visitor.h"
@@ -250,19 +251,8 @@ class TheCleanup {
             delete bb;
         }
 
-        auto renumberBBs = [&](Code* code) {
-            // Renumber in dominance order. This ensures that controlflow always
-            // goes from smaller id to bigger id, except for back-edges.
-            DominanceGraph dom(code);
-            code->nextBBId = 0;
-            DominatorTreeVisitor<VisitorHelpers::PointerMarker>(dom).run(
-                code->entry, [&](BB* bb) {
-                    bb->unsafeSetId(code->nextBBId++);
-                    bb->gc();
-                });
-        };
-        renumberBBs(function);
-        function->eachPromise(renumberBBs);
+        BBTransform::renumber(function);
+        function->eachPromise(BBTransform::renumber);
     }
 };
 } // namespace

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1698,7 +1698,7 @@ class VLI(Phi, Effects::None()) {
         SLOWASSERT(std::find(input.begin(), input.end(), in) == input.end() &&
                    "Duplicate PHI input block");
         input.push_back(in);
-        args_.push_back(InstrArg(arg, PirType::any()));
+        args_.push_back(InstrArg(arg, arg->type));
     }
     BB* inputAt(size_t i) const { return input.at(i); }
     void updateInputAt(size_t i, BB* bb) {

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -186,5 +186,15 @@ void BBTransform::insertAssume(Value* condition, Checkpoint* cp,
     insertAssume(condition, cp, contBB, contBegin, assumePositive);
 }
 
+void BBTransform::renumber(Code* fun) {
+    DominanceGraph dom(fun);
+    fun->nextBBId = 0;
+    DominatorTreeVisitor<VisitorHelpers::PointerMarker>(dom).run(
+        fun->entry, [&](BB* bb) {
+            bb->unsafeSetId(fun->nextBBId++);
+            bb->gc();
+        });
+}
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -16,6 +16,7 @@ class BBTransform {
     static BB* splitEdge(size_t next_id, BB* from, BB* to, Code* target);
     static BB* split(size_t next_id, BB* src, BB::Instrs::iterator,
                      Code* target);
+    static void splitCriticalEdges(Code* fun);
     static std::pair<Value*, BB*> forInline(BB* inlinee, BB* cont);
     static BB* lowerExpect(Code* closure, BB* src,
                            BB::Instrs::iterator position, Value* condition,

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -26,6 +26,9 @@ class BBTransform {
                              bool assumePositive);
     static void insertAssume(Value* condition, Checkpoint* cp,
                              bool assumePositive);
+    // Renumber in dominance order. This ensures that controlflow always goes
+    // from smaller id to bigger id, except for back-edges.
+    static void renumber(Code* fun);
 };
 
 } // namespace pir


### PR DESCRIPTION
These are some changes I originally made for the loop peeling work, but they're self-contained. Might as well get some feedback (code review and CI) instead of sitting on them any longer.

Commit 2fe9f42 is a small refactor because I thought I needed to renumber BBs. I no longer need this change, but kept the commit. I can remove it from the PR if we don't want to merge it.

Commit e892f39 is another small refactor, because I need to split critical edges during the loop peeling pass. I don't think any other pass actually produces critical edges, so this will be unreachable code until loop peeling is done. I guess that's an argument to not split this off and merge right away...

Commit 505d695 may be more controversial. It's a tiny change that allows phis to merge things like FrameStates, which I definitely need for loop peeling, but nothing actually depends on it right now. What I'm really interested in is how it interacts with everything else and whether it passes CI...

Thoughts?