### PR TITLE
Elide env with partially undefined vars

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -11,6 +11,7 @@ AbstractPirValue::AbstractPirValue() : type(PirType::bottom()) {}
 AbstractPirValue::AbstractPirValue(Value* v, Instruction* o,
                                    unsigned recursionLevel)
     : type(v->type) {
+    assert(o || v == UnboundValue::instance());
     vals.insert(ValOrig(v, o, recursionLevel));
 }
 
@@ -124,7 +125,12 @@ AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
         auto aenv = envs.at(env);
         if (!aenv.absent(e)) {
             const AbstractPirValue& res = aenv.get(e);
-            return AbstractLoad(env, res);
+            // UnboundValue has fall-through semantics which cause lookup to
+            // fall through.
+            if (res.maybeUnboundValue())
+                return AbstractLoad(env, AbstractPirValue::tainted());
+            if (!res.isUnboundValue())
+                return AbstractLoad(env, res);
         }
         auto parent = envs.at(env).parentEnv();
         assert(parent);
@@ -158,6 +164,9 @@ AbstractLoad AbstractREnvironmentHierarchy::getFun(Value* env, SEXP e) const {
             // If it might be a closure, we can neither be sure, nor exclude
             // this binding...
             if (res.type.maybe(RType::closure))
+                return AbstractLoad(env, AbstractPirValue::tainted());
+
+            if (res.maybeUnboundValue())
                 return AbstractLoad(env, AbstractPirValue::tainted());
         }
         auto parent = envs.at(env).parentEnv();

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -416,11 +416,13 @@ void ScopeAnalysis::tryMaterializeEnv(const ScopeAnalysisState& state,
         //       StVar (StArg) x, ...
         // in this case starg must be preserved, since it does not override the
         // missing flag on the environment binding
-        auto maybeMissing = e.second.checkEachSource([&](const ValOrig& src) {
+        auto maybeStarg = e.second.checkEachSource([&](const ValOrig& src) {
+            if (!src.origin)
+                return false;
             auto st = StVar::Cast(src.origin);
             return st && st->isStArg;
         });
-        if (maybeMissing)
+        if (maybeStarg)
             return;
         theEnv[e.first] = e.second;
     }

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -851,8 +851,6 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
 
                 auto loadArg = [&](Value* what, size_t argNumber) {
                     if (what == UnboundValue::instance()) {
-                        assert(MkArg::Cast(instr) &&
-                               "only mkarg supports R_UnboundValue");
                         cb.add(BC::push(R_UnboundValue));
                     } else if (what == MissingArg::instance()) {
                         cb.add(BC::push(R_MissingArg));

--- a/rir/src/compiler/util/cfg.cpp
+++ b/rir/src/compiler/util/cfg.cpp
@@ -137,7 +137,7 @@ const DominanceGraph::BBList& DominanceGraph::dominators(BB* bb) const {
 
 void DominanceGraph::dominatorTreeNext(
     BB* bb, const std::function<void(BB*)>& apply) const {
-    Visitor::run(bb, [&](BB* b) {
+    BreadthFirstVisitor::run(bb, [&](BB* b) {
         if (immediatelyDominates(bb, b))
             apply(b);
     });

--- a/rir/src/compiler/util/phi_placement.cpp
+++ b/rir/src/compiler/util/phi_placement.cpp
@@ -57,9 +57,10 @@ PhiPlacement::PhiPlacement(ClosureVersion* cls, BB* target,
                     return;
                 if (!input.otherPhi && !input.aValue)
                     return;
-                if (phis.includes(next))
+
+                if (phis.includes(next)) {
                     placement[next].insert(input);
-                else
+                } else
                     pendingInput[next] = input;
             };
 
@@ -97,14 +98,15 @@ PhiPlacement::PhiPlacement(ClosureVersion* cls, BB* target,
                        targetPhiPosition != ci->first) {
                 // Remove single input phis
                 auto input1 = *ci->second.begin();
-                assert(input1.otherPhi != ci->first);
-                // update all other phis which have us as input
-                for (auto& c : placement) {
-                    for (auto in : c.second) {
-                        if (in.otherPhi == ci->first) {
-                            in.otherPhi = input1.otherPhi;
-                            in.aValue = input1.aValue;
-                            changed = true;
+                if (input1.otherPhi != ci->first) {
+                    // update all other phis which have us as input
+                    for (auto& c : placement) {
+                        for (auto& in : c.second) {
+                            if (in.otherPhi == ci->first) {
+                                in.otherPhi = input1.otherPhi;
+                                in.aValue = input1.aValue;
+                                changed = true;
+                            }
                         }
                     }
                 }

--- a/rir/src/utils/configurations.cpp
+++ b/rir/src/utils/configurations.cpp
@@ -107,12 +107,10 @@ void Configurations::defaultOptimizations() {
     phasemarker("Phase 3: Cleanup Checkpoints");
 
     // ==== Phase 4) Final round of default opts
-    for (size_t i = 0; i < 2; ++i)
+    for (size_t i = 0; i < 3; ++i) {
         addDefaultOpt();
-
-    // Our backend really does not like unused checkpoints, so be sure to remove
-    // all of them here already.
-    optimizations.push_back(new pir::CleanupCheckpoints());
+        optimizations.push_back(new pir::CleanupCheckpoints());
+    }
 
     phasemarker("Phase 4: finished");
 }


### PR DESCRIPTION
If we have the case:

     e = env()
    loop:
     checkpoint ...
     stvar "x", 42, e
     goto loop

and want to move "e" into the deopt case, we need to create an env,
which is `env(x=phi(unboundValue,42))`, since on the first iteration
of the loop the value is not declared, but on the second iteration it
is.

This PR adds support for exactly that case.