### PR TITLE
Safe force for stronger tests

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -63,7 +63,7 @@ pir.tests <- function() {
 
 # returns TRUE f, when PIR compiled, satisfies the the given checks (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
-# warmup=list(...) will call the function with ... to get better assumptions.
+# warmup=<FUN> will call <FUN> repeatedly to get better assumptions.
 pir.check <- function(f, ..., warmup=NULL) {
     checks <- 
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -69,12 +69,17 @@ pir.check <- function(f, ..., warmup=NULL) {
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))
     if (length(checks) == 0)
         stop("pir.check: needs at least 1 check")
+
+    .Call("pir_check_warmup_begin")
     rir.compile(f)
-    if (is.list(warmup)) {
+    if (!is.null(warmup)) {
+        rir.compile(warmup)
+        pir.compile(warmup)
         for (i in 1:as.numeric(Sys.getenv("PIR_WARMUP", unset="3")))
-            do.call(f, warmup)
+            warmup(f)
     }
     .Call("pir_check", f, checks)
+    #.Call("pir_check_warmup_end")
 }
 
 # creates a bitset with pir debug options

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -78,8 +78,9 @@ pir.check <- function(f, ..., warmup=NULL) {
         for (i in 1:as.numeric(Sys.getenv("PIR_WARMUP", unset="3")))
             warmup(f)
     }
-    .Call("pir_check", f, checks)
-    #.Call("pir_check_warmup_end")
+    res = .Call("pir_check", f, checks)
+    .Call("pir_check_warmup_end")
+    res
 }
 
 # creates a bitset with pir debug options

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -6,6 +6,7 @@
 
 #include "api.h"
 
+#include "compiler/parameter.h"
 #include "compiler/test/PirCheck.h"
 #include "compiler/test/PirTests.h"
 #include "compiler/translations/pir_2_rir/pir_2_rir.h"
@@ -288,6 +289,24 @@ REXPORT SEXP pir_compile(SEXP what, SEXP name, SEXP debugFlags,
 
 REXPORT SEXP pir_tests() {
     PirTests::run();
+    return R_NilValue;
+}
+
+static size_t oldMaxInput = 0;
+static size_t oldInlinerMax = 0;
+
+REXPORT SEXP pir_check_warmup_begin(SEXP f, SEXP checksSxp, SEXP env) {
+    if (oldMaxInput == 0) {
+        oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
+        oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
+    }
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
+    pir::Parameter::INLINER_MAX_SIZE = 4000;
+    return R_NilValue;
+}
+REXPORT SEXP pir_check_warmup_end(SEXP f, SEXP checksSxp, SEXP env) {
+    pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
+    pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
     return R_NilValue;
 }
 

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -294,19 +294,23 @@ REXPORT SEXP pir_tests() {
 
 static size_t oldMaxInput = 0;
 static size_t oldInlinerMax = 0;
+static bool oldRirStrongSafeForce = false;
 
 REXPORT SEXP pir_check_warmup_begin(SEXP f, SEXP checksSxp, SEXP env) {
     if (oldMaxInput == 0) {
         oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
         oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
+        oldRirStrongSafeForce = pir::Parameter::RIR_STRONG_SAFE_FORCE;
     }
     pir::Parameter::MAX_INPUT_SIZE = 3500;
     pir::Parameter::INLINER_MAX_SIZE = 4000;
+    pir::Parameter::RIR_STRONG_SAFE_FORCE = true;
     return R_NilValue;
 }
 REXPORT SEXP pir_check_warmup_end(SEXP f, SEXP checksSxp, SEXP env) {
     pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
     pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
+    pir::Parameter::RIR_STRONG_SAFE_FORCE = oldRirStrongSafeForce;
     return R_NilValue;
 }
 

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -101,7 +101,7 @@ struct AbstractPirValue {
     typedef std::function<void(const ValOrig&)> ValOrigMaybe;
     typedef std::function<bool(const ValOrig&)> ValOrigMaybePredicate;
 
-    void ifSingleValue(ValMaybe known) {
+    void ifSingleValue(ValMaybe known) const {
         if (!unknown && vals.size() == 1)
             known((*vals.begin()).val);
     }
@@ -334,6 +334,17 @@ class AbstractREnvironmentHierarchy {
     AbstractLoad superGet(Value* env, SEXP e) const;
 
     std::unordered_set<Value*> potentialParents(Value* env) const;
+
+    AbstractResult taintLeaked() {
+        AbstractResult res;
+        for (auto e : envs) {
+            if (e.second.leaked) {
+                e.second.taint();
+                res.taint();
+            }
+        }
+        return res;
+    }
 };
 
 template <typename Kind>

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -1,4 +1,5 @@
 #include "../pir/pir_impl.h"
+#include "../transform/bb.h"
 #include "../translations/pir_translator.h"
 #include "../util/cfg.h"
 #include "../util/visitor.h"
@@ -250,19 +251,8 @@ class TheCleanup {
             delete bb;
         }
 
-        auto renumberBBs = [&](Code* code) {
-            // Renumber in dominance order. This ensures that controlflow always
-            // goes from smaller id to bigger id, except for back-edges.
-            DominanceGraph dom(code);
-            code->nextBBId = 0;
-            DominatorTreeVisitor<VisitorHelpers::PointerMarker>(dom).run(
-                code->entry, [&](BB* bb) {
-                    bb->unsafeSetId(code->nextBBId++);
-                    bb->gc();
-                });
-        };
-        renumberBBs(function);
-        function->eachPromise(renumberBBs);
+        BBTransform::renumber(function);
+        function->eachPromise(BBTransform::renumber);
     }
 };
 } // namespace

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -168,7 +168,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                                 if (auto f = Force::Cast(i)) {
                                     if (LdArg::Cast(f)) {
                                         f->elideEnv();
-                                        f->effects.reset();
+                                        f->effects.reset(Effect::Reflection);
                                     }
                                 }
                             });

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -152,6 +152,33 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                     continue;
                 }
 
+                auto availableAssumptions = call->inferAvailableAssumptions();
+
+                // We picked up more assumptions, let's compile a better
+                // version. Maybe we should limit this at some point, to avoid
+                // version explosion.
+                if (availableAssumptions.includes(
+                        Assumption::NoReflectiveArgument) &&
+                    !version->assumptions().includes(
+                        Assumption::NoReflectiveArgument)) {
+                    auto newVersion = cls->cloneWithAssumptions(
+                        version, availableAssumptions,
+                        [&](ClosureVersion* newCls) {
+                            Visitor::run(newCls->entry, [&](Instruction* i) {
+                                if (auto f = Force::Cast(i)) {
+                                    if (LdArg::Cast(f)) {
+                                        f->elideEnv();
+                                        f->effects.reset();
+                                    }
+                                }
+                            });
+                        });
+                    call->hint = newVersion;
+                    assert(call->tryDispatch() == newVersion);
+                    ip = next;
+                    continue;
+                }
+
                 bool allEager = version->properties.includes(
                     ClosureVersion::Property::IsEager);
                 if (!allEager &&
@@ -199,7 +226,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                 // below.
                 todo.insert(args.begin(), args.end());
 
-                Assumptions newAssumptions = call->inferAvailableAssumptions();
+                Assumptions newAssumptions = availableAssumptions;
                 for (size_t i = 0; i < call->nCallArgs(); ++i) {
                     if (!newAssumptions.isEager(i) && isEager(i))
                         newAssumptions.setEager(i);

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -420,8 +420,9 @@ void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
                                 f->replaceUsesWith(promRes);
                                 split->remove(split->begin());
 
-                                MkArg* fixedMkArg = new MkArg(
-                                    mkarg->prom(), promRes, mkarg->promEnv());
+                                MkArg* fixedMkArg =
+                                    new MkArg(mkarg->prom(), R_UnboundValue,
+                                              promRes, mkarg->promEnv());
                                 next =
                                     split->insert(split->begin(), fixedMkArg);
                                 forcedMkArg[mkarg] = fixedMkArg;

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -1,6 +1,7 @@
 #ifndef PIR_PARAMETER_H
 #define PIR_PARAMETER_H
 
+#include "../common.h"
 #include <stddef.h>
 
 namespace rir {
@@ -16,6 +17,8 @@ struct Parameter {
     static size_t INLINER_MAX_SIZE;
     static size_t INLINER_MAX_INLINEE_SIZE;
     static size_t INLINER_INITIAL_FUEL;
+
+    static bool RIR_STRONG_SAFE_FORCE;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -53,8 +53,8 @@ ClosureVersion* Closure::cloneWithAssumptions(ClosureVersion* version,
 
 ClosureVersion*
 Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
-    // Reverse since they are ordered by number of assumptions
-    for (auto c = versions.rbegin(); c != versions.rend(); c++) {
+    // ordered by number of assumptions
+    for (auto c = versions.begin(); c != versions.end(); c++) {
         auto candidate = *c;
         auto candidateCtx = candidate.first;
         if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -54,7 +54,7 @@ ClosureVersion* Closure::cloneWithAssumptions(ClosureVersion* version,
 ClosureVersion*
 Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
     // ordered by number of assumptions
-    for (auto c = versions.begin(); c != versions.end(); c++) {
+    for (auto c = versions.rbegin(); c != versions.rend(); c++) {
         auto candidate = *c;
         auto candidateCtx = candidate.first;
         if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -55,8 +55,8 @@ ClosureVersion*
 Closure::findCompatibleVersion(const OptimizationContext& ctx) const {
     // ordered by number of assumptions
     for (auto c = versions.rbegin(); c != versions.rend(); c++) {
-        auto candidate = *c;
-        auto candidateCtx = candidate.first;
+        const auto& candidate = *c;
+        const auto& candidateCtx = candidate.first;
         if (candidateCtx.subtype(OptimizationContext(ctx.assumptions)))
             return candidate.second;
     }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -413,7 +413,10 @@ void Branch::printGraphBranches(std::ostream& out, size_t bbId) const {
 
 void MkArg::printArgs(std::ostream& out, bool tty) const {
     eagerArg()->printRef(out);
-    out << ", " << *prom() << ", ";
+    out << ", " << *prom();
+    if (noReflection)
+        out << " (!refl)";
+    out << ", ";
 }
 
 void Missing::printArgs(std::ostream& out, bool tty) const {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -761,6 +761,7 @@ Assumptions CallInstruction::inferAvailableAssumptions() const {
 
     // Make some optimistic assumptions, they might be reset below...
     given.add(Assumption::NoExplicitlyMissingArgs);
+    given.add(Assumption::NoReflectiveArgument);
 
     size_t i = 0;
     eachCallArg([&](Value* arg) {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -414,8 +414,15 @@ void Branch::printGraphBranches(std::ostream& out, size_t bbId) const {
 void MkArg::printArgs(std::ostream& out, bool tty) const {
     eagerArg()->printRef(out);
     out << ", " << *prom();
+    std::string past;
+    {
+        CaptureOut rec;
+        Rf_PrintValue(promAst());
+        past = rec.oneline(5);
+    }
+    out << " " << past;
     if (noReflection)
-        out << " (!refl)";
+        out << "(!refl)";
     out << ", ";
 }
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -835,32 +835,36 @@ class Return
 class Promise;
 class FLIE(MkArg, 2, Effects::None()) {
     Promise* prom_;
+    SEXP promAst_;
 
   public:
     bool noReflection = false;
 
-    MkArg(Promise* prom, Value* v, Value* env)
+    MkArg(Promise* prom, SEXP promAst, Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
-          prom_(prom) {
+          prom_(prom), promAst_(promAst) {
         assert(eagerArg() == v);
         noReflection = isEager();
     }
     MkArg(Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
-          prom_(nullptr) {
+          prom_(nullptr), promAst_(R_UnboundValue) {
         assert(eagerArg() == v);
         noReflection = isEager();
     }
 
     Value* eagerArg() const { return arg(0).val(); }
     void eagerArg(Value* eager) { arg(0).val() = eager; }
-
-    void updatePromise(Promise* p) { prom_ = p; }
-    Promise* prom() const { return prom_; }
-
     bool isEager() const { return eagerArg() != UnboundValue::instance(); }
+
+    void updatePromise(Promise* p) {
+        prom_ = p;
+        promAst_ = R_UnboundValue;
+    }
+    Promise* prom() const { return prom_; }
+    SEXP promAst() const { return promAst_; }
 
     void printArgs(std::ostream& out, bool tty) const override;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,8 +995,6 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
-        if (!lhs()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1064,9 +1062,9 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         auto t = vec()->type;
         if (idx()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1079,9 +1077,10 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -837,6 +837,8 @@ class FLIE(MkArg, 2, Effects::None()) {
     Promise* prom_;
 
   public:
+    bool noReflection = false;
+
     MkArg(Promise* prom, Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -844,12 +844,14 @@ class FLIE(MkArg, 2, Effects::None()) {
                                          env),
           prom_(prom) {
         assert(eagerArg() == v);
+        noReflection = isEager();
     }
     MkArg(Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
           prom_(nullptr) {
         assert(eagerArg() == v);
+        noReflection = isEager();
     }
 
     Value* eagerArg() const { return arg(0).val(); }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1059,10 +1059,7 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1075,10 +1072,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1094,10 +1088,7 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1113,10 +1104,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1099,9 +1099,9 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
         auto t = vec()->type;
         if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1117,9 +1117,10 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1060,8 +1060,6 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1077,7 +1075,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1097,8 +1095,6 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx1()->type.isScalar() && idx2()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1117,7 +1113,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,6 +995,8 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
+        if (!lhs()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1056,11 +1058,15 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1070,8 +1076,12 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1083,11 +1093,16 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1099,8 +1114,13 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1702,7 +1702,7 @@ class VLI(Phi, Effects::None()) {
         SLOWASSERT(std::find(input.begin(), input.end(), in) == input.end() &&
                    "Duplicate PHI input block");
         input.push_back(in);
-        args_.push_back(InstrArg(arg, PirType::any()));
+        args_.push_back(InstrArg(arg, arg->type));
     }
     BB* inputAt(size_t i) const { return input.at(i); }
     void updateInputAt(size_t i, BB* bb) {

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!Rf_isObject(e)) {
+    if (!isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!isObject(e)) {
+    if (!Rf_isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -334,6 +334,17 @@ struct PirType {
         return PirType(t_.r);
     }
 
+    // Type of an element, assuming this is a vector
+    PirType constexpr elem() const {
+        assert(isRType());
+        if (isA(PirType::num()))
+            return this;
+        else if (isA(RType::str))
+            return RType::chr;
+        else
+            return PirType::val();
+    }
+
     RIR_INLINE void setNotMissing() { *this = notMissing(); }
     RIR_INLINE void setNotObject() { *this = notObject(); }
     RIR_INLINE void setScalar() { *this = scalar(); }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -335,10 +335,10 @@ struct PirType {
     }
 
     // Type of an element, assuming this is a vector
-    PirType constexpr elem() const {
+    PirType elem() const {
         assert(isRType());
         if (isA(PirType::num()))
-            return this;
+            return *this;
         else if (isA(RType::str))
             return RType::chr;
         else

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -148,8 +148,8 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 bool PirCheck::run(SEXP f) {
     size_t oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
     size_t oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3000;
-    pir::Parameter::INLINER_MAX_SIZE = 3000;
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
+    pir::Parameter::INLINER_MAX_SIZE = 4000;
     Module m;
     ClosureVersion* pir = compilePir(f, &m);
     bool success = pir;

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -15,7 +15,7 @@ namespace rir {
 
 using namespace pir;
 
-static ClosureVersion* compilePir(SEXP f, Module* m) {
+static ClosureVersion* recompilePir(SEXP f, Module* m) {
     if (TYPEOF(f) != CLOSXP) {
         Rf_warning("pir check failed: not a closure");
         return nullptr;
@@ -146,12 +146,8 @@ PirCheck::Type PirCheck::parseType(const char* str) {
 }
 
 bool PirCheck::run(SEXP f) {
-    size_t oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
-    size_t oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3500;
-    pir::Parameter::INLINER_MAX_SIZE = 4000;
     Module m;
-    ClosureVersion* pir = compilePir(f, &m);
+    ClosureVersion* pir = recompilePir(f, &m);
     bool success = pir;
     if (success) {
         for (PirCheck::Type type : types) {
@@ -168,8 +164,6 @@ bool PirCheck::run(SEXP f) {
         }
     }
     }
-    pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
-    pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
     if (!success)
         m.print(std::cout, false);
     return success;

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -705,7 +705,7 @@ namespace rir {
 
 void PirTests::run() {
     size_t oldconfig = pir::Parameter::MAX_INPUT_SIZE;
-    pir::Parameter::MAX_INPUT_SIZE = 3000;
+    pir::Parameter::MAX_INPUT_SIZE = 3500;
     for (auto t : tests) {
         std::cout << "> " << t.first << "\n";
         if (!t.second()) {

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -186,5 +186,15 @@ void BBTransform::insertAssume(Value* condition, Checkpoint* cp,
     insertAssume(condition, cp, contBB, contBegin, assumePositive);
 }
 
+void BBTransform::renumber(Code* fun) {
+    DominanceGraph dom(fun);
+    fun->nextBBId = 0;
+    DominatorTreeVisitor<VisitorHelpers::PointerMarker>(dom).run(
+        fun->entry, [&](BB* bb) {
+            bb->unsafeSetId(fun->nextBBId++);
+            bb->gc();
+        });
+}
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -16,6 +16,7 @@ class BBTransform {
     static BB* splitEdge(size_t next_id, BB* from, BB* to, Code* target);
     static BB* split(size_t next_id, BB* src, BB::Instrs::iterator,
                      Code* target);
+    static void splitCriticalEdges(Code* fun);
     static std::pair<Value*, BB*> forInline(BB* inlinee, BB* cont);
     static BB* lowerExpect(Code* closure, BB* src,
                            BB::Instrs::iterator position, Value* condition,

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -26,6 +26,9 @@ class BBTransform {
                              bool assumePositive);
     static void insertAssume(Value* condition, Checkpoint* cp,
                              bool assumePositive);
+    // Renumber in dominance order. This ensures that controlflow always goes
+    // from smaller id to bigger id, except for back-edges.
+    static void renumber(Code* fun);
 };
 
 } // namespace pir

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1010,8 +1010,9 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
 
             case Tag::MkArg: {
-                auto p = MkArg::Cast(instr)->prom();
-                unsigned id = ctx.cs().addPromise(getPromise(ctx, p));
+                auto mkarg = MkArg::Cast(instr);
+                unsigned id = ctx.cs().addPromise(
+                    getPromise(ctx, mkarg->prom()), mkarg->promAst());
                 cb.add(BC::promise(id));
                 break;
             }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -22,8 +22,8 @@ class Rir2Pir {
         return tryCompile(srcFunction->body(), insert);
     }
 
-    Value* tryCreateArg(rir::Code* prom, Builder& insert, bool eager) const
-        __attribute__((warn_unused_result));
+    Value* tryCreateArg(rir::Code* promise, SEXP promiseAst, Builder& insert,
+                        bool eager) const __attribute__((warn_unused_result));
 
   private:
     Value* tryTranslatePromise(rir::Code* srcCode, Builder& insert) const

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -127,17 +127,19 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
             auto arg = closure->formals().defaultArgs()[i];
             if (arg != R_MissingArg) {
                 Value* res = nullptr;
+                SEXP argAst = R_UnboundValue;
                 if (TYPEOF(arg) != EXTERNALSXP) {
                     // A bit of a hack to compile default args, which somehow
                     // are not compiled.
                     // TODO: why are they sometimes not compiled??
                     auto funexp = rir::Compiler::compileExpression(arg);
                     protect(funexp);
+                    argAst = arg;
                     arg = Function::unpack(funexp)->body()->container();
                 }
                 if (rir::Code::check(arg)) {
                     auto code = rir::Code::unpack(arg);
-                    res = rir2pir.tryCreateArg(code, builder, false);
+                    res = rir2pir.tryCreateArg(code, argAst, builder, false);
                     if (!res) {
                         logger.warn("Failed to compile default arg");
                         return fail();

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -42,6 +42,8 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
                 assumptions.setSimpleInt(i);
         }
     }
+    if (!MkArg::Cast(value) || !MkArg::Cast(value)->noReflection)
+        assumptions.remove(Assumption::NoReflectiveArgument);
 }
 
 } // namespace pir

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -22,15 +22,17 @@ void readArgTypeFromAssumptions(const Assumptions& assumptions, PirType& type,
 }
 
 void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
-    auto mk = MkArg::Cast(arg);
-    if (mk && mk->isEager()) {
-        if (mk->eagerArg() == MissingArg::instance())
-            assumptions.remove(Assumption::NoExplicitlyMissingArgs);
-        else
-            assumptions.setEager(i);
-    }
-    Value* value = arg->followCastsAndForce();
-    if (!MkArg::Cast(value)) {
+    if (auto mk = MkArg::Cast(arg)) {
+        if (mk->isEager()) {
+            if (mk->eagerArg() == MissingArg::instance())
+                assumptions.remove(Assumption::NoExplicitlyMissingArgs);
+            else
+                assumptions.setEager(i);
+        }
+        // if (!mk->noReflection)
+        //    assumptions.remove(Assumption::NoReflectiveArgument);
+    } else {
+        Value* value = arg->followCastsAndForce();
         if (!value->type.maybeObj())
             assumptions.setNotObj(i);
         if (assumptions.isEager(i) && assumptions.isNotObj(i) &&
@@ -42,8 +44,6 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
                 assumptions.setSimpleInt(i);
         }
     }
-    if (!MkArg::Cast(value) || !MkArg::Cast(value)->noReflection)
-        assumptions.remove(Assumption::NoReflectiveArgument);
 }
 
 } // namespace pir

--- a/rir/src/compiler/util/ConvertAssumptions.cpp
+++ b/rir/src/compiler/util/ConvertAssumptions.cpp
@@ -29,8 +29,8 @@ void writeArgTypeToAssumptions(Assumptions& assumptions, Value* arg, int i) {
             else
                 assumptions.setEager(i);
         }
-        // if (!mk->noReflection)
-        //    assumptions.remove(Assumption::NoReflectiveArgument);
+        if (!mk->noReflection)
+            assumptions.remove(Assumption::NoReflectiveArgument);
     } else {
         Value* value = arg->followCastsAndForce();
         if (!value->type.maybeObj())

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -107,7 +107,8 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         findBuiltin("~"),
         findBuiltin("crossprod"),
         findBuiltin("tcrossprod"),
-        findBuiltin("lengths"),
+        // Would be safe if not a vector of objects
+        // findBuiltin("lengths"),
         findBuiltin("round"),
         findBuiltin("signif"),
         findBuiltin("log"),

--- a/rir/src/interpreter/call_context.h
+++ b/rir/src/interpreter/call_context.h
@@ -117,12 +117,12 @@ struct CallContext {
         return cp_pool_at(ctx, names[i]);
     }
 
-    void safeForceArgs() const {
+    void safeForceArgs(bool strong) const {
         assert(hasStackArgs());
         for (unsigned i = 0; i < passedArgs; i++) {
             SEXP arg = stackArg(i);
             if (TYPEOF(arg) == PROMSXP) {
-                safeForcePromise(arg, false);
+                safeForcePromise(arg, strong);
             }
         }
     }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1974,8 +1974,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto arguments = (Immediate*)pc;
             advanceImmediateN(n);
             auto names = (Immediate*)pc;
@@ -2019,8 +2019,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto arguments = (Immediate*)pc;
             advanceImmediateN(n);
             CallContext call(c, ostack_top(ctx), n, ast, arguments, env, given,
@@ -2045,8 +2045,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             CallContext call(c, ostack_at(ctx, n), n, ast,
                              ostack_cell_at(ctx, n - 1), env, given, ctx);
             res = doCall(call, ctx);
@@ -2069,8 +2069,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             size_t ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             auto names = (Immediate*)pc;
             advanceImmediateN(n);
             CallContext call(c, ostack_at(ctx, n), n, ast,
@@ -2121,8 +2121,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             Immediate ast = readImmediate();
             advanceImmediate();
-            Assumptions given(readImmediate());
-            advanceImmediate();
+            Assumptions given(pc);
+            pc += sizeof(Assumptions);
             SEXP callee = cp_pool_at(ctx, readImmediate());
             advanceImmediate();
             SEXP version = cp_pool_at(ctx, readImmediate());

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -76,6 +76,10 @@ SEXP safeForcePromise(SEXP e, bool strong) {
         }
         return val;
     } else {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "promise known: ";
+        Rf_PrintValue(PRVALUE(e));
+#endif
         return PRVALUE(e);
     }
 }

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -1,4 +1,5 @@
 #include "safe_force.h"
+#include "../compiler/parameter.h"
 #include "R/RList.h"
 #include "R/Sexp.h"
 #include "R/Symbols.h"
@@ -8,20 +9,66 @@
 
 namespace rir {
 
-SEXP safeEval(SEXP e, SEXP rho) {
-    SEXPTYPE t = TYPEOF(e);
-    if (t == LANGSXP || t == SYMSXP || t == PROMSXP || t == BCODESXP ||
-        t == EXTERNALSXP) {
+// #define DEBUG_SAFE_EVAL
+
+SEXP safeEval(SEXP e, SEXP rho, bool strong) {
+    assert((!strong || pir::Parameter::RIR_STRONG_SAFE_FORCE) &&
+           "currently never strong safe forces unless explicitly enabled");
+    if (e == R_UnboundValue) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval failed on unbound\n";
+#endif
         return R_UnboundValue;
+    } else if (e == R_MissingArg) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval missing\n";
+#endif
+        return e;
+    }
+    SEXPTYPE t = TYPEOF(e);
+    if (t == LANGSXP || t == BCODESXP || t == EXTERNALSXP) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval failed: ";
+        Rf_PrintValue(e);
+#endif
+        return R_UnboundValue;
+    } else if (t == PROMSXP) {
+        if (!strong)
+            return R_UnboundValue;
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval promise -> ";
+#endif
+        return safeForcePromise(e, strong);
+    } else if (t == SYMSXP) {
+        if (!strong || rho == nullptr)
+            return R_UnboundValue;
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval lookup " << CHAR(PRINTNAME(e));
+#endif
+        SEXP f = Rf_findVar(e, rho);
+        if (f == R_UnboundValue) {
+#ifdef DEBUG_SAFE_EVAL
+            std::cout << " failed\n";
+#endif
+            return R_UnboundValue;
+        }
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << " -> ";
+#endif
+        return safeEval(f, rho, strong);
     } else {
         // Constant
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval constant: ";
+        Rf_PrintValue(e);
+#endif
         return e;
     }
 }
 
-SEXP safeForcePromise(SEXP e) {
+SEXP safeForcePromise(SEXP e, bool strong) {
     if (PRVALUE(e) == R_UnboundValue) {
-        SEXP val = safeEval(PRCODE(e), PRENV(e));
+        SEXP val = safeEval(PRCODE(e), PRENV(e), strong);
         if (val != R_UnboundValue) {
             SET_PRVALUE(e, val);
             ENSURE_NAMEDMAX(val);

--- a/rir/src/interpreter/safe_force.h
+++ b/rir/src/interpreter/safe_force.h
@@ -1,15 +1,16 @@
 #ifndef RIR_SAFE_FORCE_H
 #define RIR_SAFE_FORCE_H
 
+#include "../common.h"
 #include <R/r.h>
 
 namespace rir {
 
 // Will try to evaluate the SEXP if it definitely doesn't cause side effects,
 // rho can be nullptr if the environment is unknown
-SEXP safeEval(SEXP e, SEXP rho);
+SEXP safeEval(SEXP e, SEXP rho, bool strong);
 // Will try to evaluate the promise if it definitely doesn't cause side effects
-SEXP safeForcePromise(SEXP e);
+SEXP safeForcePromise(SEXP e, bool strong);
 
 } // namespace rir
 

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -281,7 +281,7 @@ class BC {
         switch (bc) {
         // First handle the varlength BCs. In all three cases the number of
         // call arguments is the 2nd immediate argument and the
-        // instructions have 2 fixed length immediates. After that there are
+        // instructions have 4 fixed length immediates. After that there are
         // narg varlen immediates for the first two and 2*narg varlen
         // immediates in the last case.
         case Opcode::call_implicit_:
@@ -289,13 +289,13 @@ class BC {
             pc++;
             Immediate nargs;
             memcpy(&nargs, pc, sizeof(Immediate));
-            return 1 + (3 + nargs) * sizeof(Immediate);
+            return 1 + (4 + nargs) * sizeof(Immediate);
         }
         case Opcode::named_call_implicit_: {
             pc++;
             Immediate nargs;
             memcpy(&nargs, pc, sizeof(Immediate));
-            return 1 + (3 + 2 * nargs) * sizeof(Immediate);
+            return 1 + (4 + 2 * nargs) * sizeof(Immediate);
         }
         case Opcode::mk_stub_env_:
         case Opcode::mk_env_: {

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -127,21 +127,21 @@ DEF_INSTR(movloc_, 2, 0, 0, 1)
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + nargs
  */
-DEF_INSTR(call_implicit_, 3, 1, 1, 0)
+DEF_INSTR(call_implicit_, 4, 1, 1, 0)
 /*
  * Same as above, but with names for the arguments as immediates
  *
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + 2 * nargs
  */
-DEF_INSTR(named_call_implicit_, 3, 1, 1, 0)
+DEF_INSTR(named_call_implicit_, 4, 1, 1, 0)
 
 /**
  * call_:: Like call_implicit_, but expects arguments on stack
  *         on top of the callee; these arguments can be both
  *         values and promises (even preseeded w/ a value)
  */
-DEF_INSTR(call_, 3, -1, 1, 0)
+DEF_INSTR(call_, 4, -1, 1, 0)
 
 /*
  * Same as above, but with names for the arguments as immediates
@@ -149,13 +149,13 @@ DEF_INSTR(call_, 3, -1, 1, 0)
  *                  THIS IS A VARIABLE LENGTH INSTRUCTION
  *                  the actual number of immediates is 3 + nargs
  */
-DEF_INSTR(named_call_, 3, -1, 1, 0)
+DEF_INSTR(named_call_, 4, -1, 1, 0)
 
 /**
  * static_call_:: Like call_, but the callee is statically known
  *                and is accessed via the immediate callsite
  */
-DEF_INSTR(static_call_, 5, -1, 1, 0)
+DEF_INSTR(static_call_, 6, -1, 1, 0)
 
 /**
  * call_builtin_:: Like static call, but calls a builtin

--- a/rir/src/runtime/Assumptions.cpp
+++ b/rir/src/runtime/Assumptions.cpp
@@ -4,6 +4,9 @@ namespace rir {
 
 std::ostream& operator<<(std::ostream& out, Assumption a) {
     switch (a) {
+    case Assumption::NoReflectiveArgument:
+        out << "!RefA";
+        break;
     case Assumption::NoExplicitlyMissingArgs:
         out << "!ExpMi";
         break;

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -111,6 +111,14 @@ struct Assumptions {
 
     RIR_INLINE bool operator<(const Assumptions& other) const {
         // Order by number of assumptions! Important for dispatching.
+        if (*this != other) {
+            if (subtype(other))
+                return false;
+            if (other.subtype(*this))
+                return true;
+        }
+
+        // for std::map we need a complete order, subtype is only partial
         if (missing != other.missing)
             return missing > other.missing;
         if (flags.count() != other.flags.count())

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -121,6 +121,8 @@ struct Assumptions {
         // we need a complete order, subtype is only partial
         if (missing != other.missing)
             return missing < other.missing;
+        if (flags.count() != other.flags.count())
+            return flags.count() < other.flags.count();
         return flags < other.flags;
     }
 
@@ -152,7 +154,7 @@ struct Assumptions {
 
 typedef uint32_t Immediate;
 static_assert(sizeof(Assumptions) == 2 * sizeof(Immediate),
-              "Assumptions needs to be one immediate arg size");
+              "Assumptions needs to be 2 immediate args long");
 
 std::ostream& operator<<(std::ostream& out, Assumption a);
 

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -36,15 +36,16 @@ enum class Assumption {
                              //  supplied >= (nargs - missing)
                              //  Note: can still have explicitly missing args
     NotTooManyArguments,     // The number of args supplied is <= nargs
+    NoReflectiveArgument,    // Argument promises are not reflective
 
     FIRST = Arg0IsEager_,
-    LAST = NotTooManyArguments
+    LAST = NoReflectiveArgument
 };
 
 #pragma pack(push)
 #pragma pack(1)
 struct Assumptions {
-    typedef EnumSet<Assumption, uint16_t> Flags;
+    typedef EnumSet<Assumption, uint32_t> Flags;
 
     constexpr static size_t MAX_MISSING = 255;
     // # of args with type assumptions
@@ -56,10 +57,11 @@ struct Assumptions {
     explicit constexpr Assumptions(const Flags& flags) : flags(flags) {}
     constexpr Assumptions(const Flags& flags, uint8_t missing)
         : flags(flags), missing(missing) {}
-    explicit Assumptions(uint32_t i) {
+    explicit Assumptions(void* pos) {
         // Silences unused warning:
         (void)unused;
-        memcpy(this, &i, sizeof(i));
+        (void)unused2;
+        memcpy(this, pos, sizeof(*this));
     }
 
     RIR_INLINE void add(Assumption a) { flags.set(a); }
@@ -136,12 +138,14 @@ struct Assumptions {
   private:
     Flags flags;
     uint8_t missing = 0;
+
     uint8_t unused = 0;
+    uint16_t unused2 = 0;
 };
 #pragma pack(pop)
 
 typedef uint32_t Immediate;
-static_assert(sizeof(Assumptions) == sizeof(Immediate),
+static_assert(sizeof(Assumptions) == 2 * sizeof(Immediate),
               "Assumptions needs to be one immediate arg size");
 
 std::ostream& operator<<(std::ostream& out, Assumption a);

--- a/rir/src/runtime/Assumptions.h
+++ b/rir/src/runtime/Assumptions.h
@@ -113,16 +113,14 @@ struct Assumptions {
         // Order by number of assumptions! Important for dispatching.
         if (*this != other) {
             if (subtype(other))
-                return false;
-            if (other.subtype(*this))
                 return true;
+            if (other.subtype(*this))
+                return false;
         }
 
-        // for std::map we need a complete order, subtype is only partial
+        // we need a complete order, subtype is only partial
         if (missing != other.missing)
-            return missing > other.missing;
-        if (flags.count() != other.flags.count())
-            return flags.count() > other.flags.count();
+            return missing < other.missing;
         return flags < other.flags;
     }
 

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -116,7 +116,11 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     }
 
     Code* getPromise(size_t idx) const {
-        return unpack(getExtraPoolEntry(idx));
+        return unpack(getExtraPoolEntry(idx * 2));
+    }
+
+    SEXP getPromiseAst(size_t idx) const {
+        return getExtraPoolEntry((idx * 2) + 1);
     }
 
     size_t size() const {

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -106,9 +106,7 @@ struct DispatchTable
                       << "\n";
         }
         std::cout << "\n";
-#endif
 
-#ifdef DEBUG_DISPATCH
         for (size_t i = 0; i < size() - 1; ++i) {
             assert(get(i)->signature().assumptions <
                    get(i + 1)->signature().assumptions);

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -67,18 +67,31 @@ struct DispatchTable
         assert(fun->signature().optimization !=
                FunctionSignature::OptimizationLevel::Baseline);
         auto assumptions = fun->signature().assumptions;
-        assert(size() < capacity());
         size_t i = 1;
         for (; i < size(); ++i) {
             if (get(i)->signature().assumptions == assumptions) {
                 setEntry(i, fun->container());
                 return;
             }
-            if (!(assumptions < get(i)->signature().assumptions)) {
+            if (!(get(i)->signature().assumptions < assumptions)) {
                 break;
             }
         }
-        SLOWASSERT(!contains(fun->signature().assumptions));
+        assert(!contains(fun->signature().assumptions));
+        if (size() == capacity()) {
+            std::cout << "Tried to insert into a full Dispatch table. Have: \n";
+            for (size_t i = 0; i < size(); ++i) {
+                auto e = getEntry(i);
+                std::cout << "* "
+                          << Function::unpack(e)->signature().assumptions
+                          << "\n";
+            }
+            std::cout << "\n";
+            std::cout << "Tried to insert: " << assumptions << "\n";
+            Rf_error("failed");
+            return;
+        }
+
         size_++;
         for (size_t j = size() - 1; j > i; --j) {
             setEntry(j, getEntry(j - 1));
@@ -94,10 +107,19 @@ struct DispatchTable
         }
         std::cout << "\n";
 #endif
-        SLOWASSERT(contains(fun->signature().assumptions));
+
+#ifdef DEBUG_DISPATCH
+        for (size_t i = 0; i < size() - 1; ++i) {
+            assert(get(i)->signature().assumptions <
+                   get(i + 1)->signature().assumptions);
+            assert(!(get(i + 1)->signature().assumptions <
+                     get(i)->signature().assumptions));
+        }
+        assert(contains(fun->signature().assumptions));
+#endif
     }
 
-    static DispatchTable* create(size_t capacity = 15) {
+    static DispatchTable* create(size_t capacity = 20) {
         size_t size =
             sizeof(DispatchTable) + (capacity * sizeof(DispatchTableEntry));
         SEXP s = Rf_allocVector(EXTERNALSXP, size);

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -316,3 +316,20 @@ stopifnot(pir.check(function(x, y) {
   y == NA
   x + y
 }, NoEq, warmup=function(f)f(5L, 2L)))
+
+# Strong safe force
+x <- 10
+stopifnot(pir.check(function(n) {
+  x <- 1
+  while (x < n)
+    x <- x + 1
+  x
+}, NoEnv, warmup=function(f)f(x)))
+class(x) <- "something"
+stopifnot(!pir.check(function(n) {
+  x <- 1
+  while (x < n)
+    x <- x + 1
+  x
+}, NoEnv, warmup=function(f)f(x)))
+

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -151,8 +151,8 @@ stopifnot(pir.check(function() {
   f(x, y(), z)
 }, NoEnv, warmup=list()))
 
-mandelbrot <- function() {
-    size = 30
+mandelbrot <- function(size) {
+    size = size
     sum = 0
     byteAcc = 0
     bitNum  = 0
@@ -198,9 +198,14 @@ mandelbrot <- function() {
     }
     return (sum)
 }
+# ensure that this trampoline function is small. otherwise we fail on
+# small MAX_PIR_INPUT, because the caller of mandelbrot won't be compiled
+mandelbrot_tramp <- function(x)
+  mandelbrot(x)
+
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(
-  pir.check(mandelbrot, NoExternalCalls, NoPromise, NoStore, warmup=list())
+  pir.check(mandelbrot_tramp, NoExternalCalls, NoPromise, NoStore, warmup=list(16))
 )
 
 # New tests

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -46,16 +46,16 @@ stopifnot(pir.check(function(depth) {
     1
   else
     0
-}, NoEnvSpec, warmup=list(1)))
+}, NoEnvSpec, warmup=function(f){cat(".\n"); f(0)}))
 
 xxx <- 12
 stopifnot(pir.check(function() {
   1 + xxx
-}, NoEnvForAdd, warmup=list()))
+}, NoEnvForAdd, warmup=function(f) f()))
 yyy = 0
 stopifnot(pir.check(function() {
   1 + yyy
-}, NoEnvForAdd, warmup=list()))
+}, NoEnvForAdd, warmup=function(f) f()))
 stopifnot(pir.check(function(x) {
   y <- 2
 }, NoStore))
@@ -139,7 +139,7 @@ stopifnot(pir.check(function() {
   b <- function() 1L
   f <- function(x, y) x() + y
   f(a, b())
-}, Returns42L, warmup=list()))
+}, Returns42L, warmup=function(f)f()))
 stopifnot(pir.check(function() {
   x <- function() 32
   y <- function() 31
@@ -149,7 +149,7 @@ stopifnot(pir.check(function() {
       42L
   }
   f(x, y(), z)
-}, NoEnv, warmup=list()))
+}, NoEnv, warmup=function(f)f()))
 
 mandelbrot <- function(size) {
     size = size
@@ -198,14 +198,9 @@ mandelbrot <- function(size) {
     }
     return (sum)
 }
-# ensure that this trampoline function is small. otherwise we fail on
-# small MAX_PIR_INPUT, because the caller of mandelbrot won't be compiled
-mandelbrot_tramp <- function(x)
-  mandelbrot(x)
-
 # This can't be run if PIR_MAX_INPUT_SIZE is too low
 stopifnot(
-  pir.check(mandelbrot_tramp, NoExternalCalls, NoPromise, NoStore, warmup=list(16))
+  pir.check(mandelbrot, NoExternalCalls, NoPromise, NoStore, warmup=function(f)f(16))
 )
 
 # New tests
@@ -215,13 +210,13 @@ stopifnot(pir.check(function() {
   while (x < 10)
     x <- x + 1
   x
-}, NoLoad, NoStore, warmup=list()))
+}, NoLoad, NoStore, warmup=function(f)f()))
 stopifnot(pir.check(function(n) {
   x <- 1
   while (x < n)
     x <- x + 1
   x
-}, NoLoad, NoStore, warmup=list(10)))
+}, NoLoad, NoStore, warmup=function(f)f(10)))
 
 # Negative Test
 
@@ -279,19 +274,19 @@ stopifnot(pir.check(function(x) {
     5
   else
     4
-}, OneEq, warmup=list(3)))
+}, OneEq, warmup=function(f)f(3)))
 stopifnot(pir.check(function(x) {
   if ((x == 1) == FALSE)
     5
   else
     4
-}, OneEq, warmup=list(4L)))
+}, OneEq, warmup=function(f)f(4L)))
 stopifnot(pir.check(function(x, y) {
   a <- y == 1 # This is the one eq
   (x == 1) == NA
-}, OneEq, warmup=list(5.7, "")))
+}, OneEq, warmup=function(f)f(5.7, "")))
 # Relies on better visibility
-# stopifnot(pir.check(function(x) !!!!!x, OneNot, warmup=list(1)))
+# stopifnot(pir.check(function(x) !!!!!x, OneNot, warmup=function(f)f(1)))
 # Testing NoAsInt itself
 stopifnot(!pir.check(function(n) {
   x <- 0
@@ -315,9 +310,9 @@ stopifnot(!pir.check(function(x) {
 stopifnot(pir.check(function(x) {
   x == 4
   x
-}, NoEq, warmup=list(5)))
+}, NoEq, warmup=function(f)f(5)))
 stopifnot(pir.check(function(x, y) {
   x == 3+7i
   y == NA
   x + y
-}, NoEq, warmup=list(5L, 2L)))
+}, NoEq, warmup=function(f)f(5L, 2L)))

--- a/tools/pre-push.d/90-tests.hook
+++ b/tools/pre-push.d/90-tests.hook
@@ -4,8 +4,9 @@ ROOT=$1
 
 git diff --exit-code > /dev/null && git diff --cached --exit-code > /dev/null
 if test "$?" -ne 0; then
-  echo "please commit or stash your changes before pushing."
-  exit 1
+  echo "warning: repository is dirty"
+  git status -s
+  sleep 2
 fi
 
 . "${ROOT}/tools/script_include.sh"


### PR DESCRIPTION
`pir.check` safe forces arguments, so we can get more assumptions. Also, you can manually enable always safe force with `RIR_STRONG_SAFE_FORCE=1`.