### PR TITLE
Type assertions

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -63,7 +63,7 @@ pir.tests <- function() {
 
 # returns TRUE f, when PIR compiled, satisfies the the given checks (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
-# warmup=list(...) will call the function with ... to get better assumptions.
+# warmup=<FUN> will call <FUN> repeatedly to get better assumptions.
 pir.check <- function(f, ..., warmup=NULL) {
     checks <- 
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -294,19 +294,23 @@ REXPORT SEXP pir_tests() {
 
 static size_t oldMaxInput = 0;
 static size_t oldInlinerMax = 0;
+static bool oldRirStrongSafeForce = false;
 
 REXPORT SEXP pir_check_warmup_begin(SEXP f, SEXP checksSxp, SEXP env) {
     if (oldMaxInput == 0) {
         oldMaxInput = pir::Parameter::MAX_INPUT_SIZE;
         oldInlinerMax = pir::Parameter::INLINER_MAX_SIZE;
+        oldRirStrongSafeForce = pir::Parameter::RIR_STRONG_SAFE_FORCE;
     }
     pir::Parameter::MAX_INPUT_SIZE = 3500;
     pir::Parameter::INLINER_MAX_SIZE = 4000;
+    pir::Parameter::RIR_STRONG_SAFE_FORCE = true;
     return R_NilValue;
 }
 REXPORT SEXP pir_check_warmup_end(SEXP f, SEXP checksSxp, SEXP env) {
     pir::Parameter::MAX_INPUT_SIZE = oldMaxInput;
     pir::Parameter::INLINER_MAX_SIZE = oldInlinerMax;
+    pir::Parameter::RIR_STRONG_SAFE_FORCE = oldRirStrongSafeForce;
     return R_NilValue;
 }
 

--- a/rir/src/common.h
+++ b/rir/src/common.h
@@ -12,9 +12,11 @@ extern void printBacktrace();
 
 #ifdef ENABLE_SLOWASSERT
 #define SLOWASSERT(what) assert(what)
+__attribute__((unused)) static bool IS_SLOWASSERT = true;
 #else
 #define SLOWASSERT(what)                                                       \
     {}
+__attribute__((unused)) static bool IS_SLOWASSERT = false;
 #endif
 
 // from boost

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -420,8 +420,9 @@ void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
                                 f->replaceUsesWith(promRes);
                                 split->remove(split->begin());
 
-                                MkArg* fixedMkArg = new MkArg(
-                                    mkarg->prom(), promRes, mkarg->promEnv());
+                                MkArg* fixedMkArg =
+                                    new MkArg(mkarg->prom(), R_UnboundValue,
+                                              promRes, mkarg->promEnv());
                                 next =
                                     split->insert(split->begin(), fixedMkArg);
                                 forcedMkArg[mkarg] = fixedMkArg;

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -19,6 +19,7 @@ struct Parameter {
     static size_t INLINER_INITIAL_FUEL;
 
     static bool RIR_STRONG_SAFE_FORCE;
+    static bool RIR_CHECK_PIR_TYPES;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -1,6 +1,7 @@
 #ifndef PIR_PARAMETER_H
 #define PIR_PARAMETER_H
 
+#include "../common.h"
 #include <stddef.h>
 
 namespace rir {
@@ -16,6 +17,8 @@ struct Parameter {
     static size_t INLINER_MAX_SIZE;
     static size_t INLINER_MAX_INLINEE_SIZE;
     static size_t INLINER_INITIAL_FUEL;
+
+    static bool RIR_STRONG_SAFE_FORCE;
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -414,8 +414,15 @@ void Branch::printGraphBranches(std::ostream& out, size_t bbId) const {
 void MkArg::printArgs(std::ostream& out, bool tty) const {
     eagerArg()->printRef(out);
     out << ", " << *prom();
+    std::string past;
+    {
+        CaptureOut rec;
+        Rf_PrintValue(promAst());
+        past = rec.oneline(5);
+    }
+    out << " " << past;
     if (noReflection)
-        out << " (!refl)";
+        out << "(!refl)";
     out << ", ";
 }
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -835,32 +835,36 @@ class Return
 class Promise;
 class FLIE(MkArg, 2, Effects::None()) {
     Promise* prom_;
+    SEXP promAst_;
 
   public:
     bool noReflection = false;
 
-    MkArg(Promise* prom, Value* v, Value* env)
+    MkArg(Promise* prom, SEXP promAst, Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
-          prom_(prom) {
+          prom_(prom), promAst_(promAst) {
         assert(eagerArg() == v);
         noReflection = isEager();
     }
     MkArg(Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
-          prom_(nullptr) {
+          prom_(nullptr), promAst_(R_UnboundValue) {
         assert(eagerArg() == v);
         noReflection = isEager();
     }
 
     Value* eagerArg() const { return arg(0).val(); }
     void eagerArg(Value* eager) { arg(0).val() = eager; }
-
-    void updatePromise(Promise* p) { prom_ = p; }
-    Promise* prom() const { return prom_; }
-
     bool isEager() const { return eagerArg() != UnboundValue::instance(); }
+
+    void updatePromise(Promise* p) {
+        prom_ = p;
+        promAst_ = R_UnboundValue;
+    }
+    Promise* prom() const { return prom_; }
+    SEXP promAst() const { return promAst_; }
 
     void printArgs(std::ostream& out, bool tty) const override;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,8 +995,6 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
-        if (!lhs()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1064,9 +1062,9 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         auto t = vec()->type;
         if (idx()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1079,9 +1077,10 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1067,10 +1067,7 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1083,10 +1080,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1102,10 +1096,7 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 
@@ -1121,10 +1112,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type;
-        if (PirType(RType::vec).isA(t))
-            t = t.orObject();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1099,9 +1099,9 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
         auto t = vec()->type;
         if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
-        if (!t.isA(PirType::num() | RType::str))
-            type = type.orObject();
     }
 };
 
@@ -1117,9 +1117,10 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
-        if (!vec()->type.isA(PirType::num() | RType::str))
-            type = type.orObject();
+        auto t = vec()->type.scalar();
+        if (PirType(RType::vec).isA(t))
+            t = t.orObject();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1060,8 +1060,6 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1077,7 +1075,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1097,8 +1095,6 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
         auto t = vec()->type;
-        if (idx1()->type.isScalar() && idx2()->type.isScalar())
-            t.setScalar();
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);
@@ -1117,7 +1113,7 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = vec()->type.scalar();
+        auto t = vec()->type;
         if (PirType(RType::vec).isA(t))
             t = t.orObject();
         maskEffectsAndTypeOnNonObjects(t);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1067,7 +1067,10 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        PirType t = vec()->type.elem();
+        if (!idx()->type.isScalar())
+            t = t.orNotScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 
@@ -1096,7 +1099,11 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        PirType t = vec()->type.elem();
+        // Technically throws error so it doesn't matter
+        if (!idx1()->type.isScalar() || !idx2()->type.isScalar())
+            t = t.orNotScalar();
+        maskEffectsAndTypeOnNonObjects(t);
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -995,6 +995,8 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() { return arg(2).val(); }
     void updateType() override final {
         maskEffectsAndTypeOnNonObjects(lhs()->type | rhs()->type);
+        if (!lhs()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1056,11 +1058,15 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1070,8 +1076,12 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(PirType::valOrLazy(),
                                          {{PirType::val(), PirType::val()}},
                                          {{vec, idx}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1083,11 +1093,16 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        auto t = arg<0>().val()->type;
-        if (arg<1>().val()->type.isScalar())
+        auto t = vec()->type;
+        if (idx1()->type.isScalar() && idx2()->type.isScalar())
             t.setScalar();
         maskEffectsAndTypeOnNonObjects(t);
+        if (!t.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 
@@ -1099,8 +1114,13 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
               PirType::valOrLazy(),
               {{PirType::val(), PirType::val(), PirType::val()}},
               {{vec, idx1, idx2}}, env, srcIdx) {}
+    Value* vec() { return arg(0).val(); }
+    Value* idx1() { return arg(1).val(); }
+    Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(arg<0>().val()->type.scalar());
+        maskEffectsAndTypeOnNonObjects(vec()->type.scalar());
+        if (!vec()->type.isA(PirType::num() | RType::str))
+            type = type.orObject();
     }
 };
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1067,10 +1067,7 @@ class FLIE(Extract1_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        PirType t = vec()->type.elem();
-        if (!idx()->type.isScalar())
-            t = t.orNotScalar();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(vec()->type.subsetType(idx()->type));
     }
 };
 
@@ -1083,7 +1080,7 @@ class FLIE(Extract2_1D, 3, Effects::Any()) {
     Value* vec() { return arg(0).val(); }
     Value* idx() { return arg(1).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        maskEffectsAndTypeOnNonObjects(vec()->type.extractType(idx()->type));
     }
 };
 
@@ -1099,11 +1096,8 @@ class FLIE(Extract1_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        PirType t = vec()->type.elem();
-        // Technically throws error so it doesn't matter
-        if (!idx1()->type.isScalar() || !idx2()->type.isScalar())
-            t = t.orNotScalar();
-        maskEffectsAndTypeOnNonObjects(t);
+        maskEffectsAndTypeOnNonObjects(
+            vec()->type.subsetType(idx1()->type | idx2()->type));
     }
 };
 
@@ -1119,7 +1113,8 @@ class FLIE(Extract2_2D, 4, Effects::Any()) {
     Value* idx1() { return arg(1).val(); }
     Value* idx2() { return arg(2).val(); }
     void updateType() override final {
-        maskEffectsAndTypeOnNonObjects(vec()->type.elem());
+        maskEffectsAndTypeOnNonObjects(
+            vec()->type.extractType(idx1()->type | idx2()->type));
     }
 };
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!Rf_isObject(e)) {
+    if (!isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -80,7 +80,7 @@ void PirType::merge(SEXPTYPE sexptype) {
 PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     merge(TYPEOF(e));
 
-    if (!isObject(e)) {
+    if (!Rf_isObject(e)) {
         flags_.reset(TypeFlags::maybeObject);
     }
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -334,6 +334,17 @@ struct PirType {
         return PirType(t_.r);
     }
 
+    // Type of an element, assuming this is a vector
+    PirType constexpr elem() const {
+        assert(isRType());
+        if (isA(PirType::num()))
+            return this;
+        else if (isA(RType::str))
+            return RType::chr;
+        else
+            return PirType::val();
+    }
+
     RIR_INLINE void setNotMissing() { *this = notMissing(); }
     RIR_INLINE void setNotObject() { *this = notObject(); }
     RIR_INLINE void setScalar() { *this = scalar(); }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -335,10 +335,10 @@ struct PirType {
     }
 
     // Type of an element, assuming this is a vector
-    PirType constexpr elem() const {
+    PirType elem() const {
         assert(isRType());
         if (isA(PirType::num()))
-            return this;
+            return *this;
         else if (isA(RType::str))
             return RType::chr;
         else

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -337,12 +337,12 @@ struct PirType {
     // Type of an element, assuming this is a vector
     PirType elem() const {
         assert(isRType());
-        if (isA(PirType::num()))
+        if (isA(num()))
             return *this;
         else if (isA(RType::str))
             return RType::chr;
         else
-            return PirType::val();
+            return val();
     }
 
     RIR_INLINE void setNotMissing() { *this = notMissing(); }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -302,6 +302,11 @@ struct PirType {
         return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeNotScalar));
     }
 
+    RIR_INLINE constexpr PirType orNotScalar() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ | TypeFlags::maybeNotScalar);
+    }
+
     RIR_INLINE constexpr PirType orPromiseWrapped() const {
         assert(isRType());
         return PirType(t_.r, flags_ | TypeFlags::promiseWrapped);
@@ -337,10 +342,8 @@ struct PirType {
     // Type of an element, assuming this is a vector
     PirType elem() const {
         assert(isRType());
-        if (isA(num()))
+        if (isA(num() | RType::str))
             return *this;
-        else if (isA(RType::str))
-            return RType::chr;
         else
             return val();
     }

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -526,6 +526,27 @@ bool testCfg() {
     return true;
 }
 
+bool testTypeRules() {
+    PirType r = RType::vec;
+    PirType r2 = RType::logical;
+    assert(r.subsetType(PirType::any()).isA(RType::vec));
+    assert(!r.subsetType(PirType::any()).maybeObj());
+    assert(!r.orObject().subsetType(PirType::bottom()).isA(RType::vec));
+    assert(!r.orObject().subsetType(PirType::bottom()).isA(PirType::val()));
+    assert(r.extractType(PirType::any()).isA(PirType::val()));
+    assert(!r.extractType(PirType::bottom()).isScalar());
+    assert(!r.extractType(PirType::bottom()).maybeMissing());
+    assert(!r.extractType(PirType::bottom()).isA(RType::vec));
+    assert(r.orObject().extractType(PirType::bottom()).maybeMissing());
+    assert(r2.subsetType(RType::real).isA(RType::logical));
+    assert(!r2.subsetType(RType::integer).isScalar());
+    assert(!r2.scalar().subsetType(RType::integer).isScalar());
+    assert(r2.subsetType(PirType(RType::integer).scalar()).isScalar());
+    assert(r2.extractType(RType::integer).isScalar());
+    assert(!r2.subsetType(PirType::any()).maybeObj());
+    return true;
+}
+
 static Test tests[] = {
     Test("test cfg", &testCfg),
     Test("test_42L", []() { return test42("42L"); }),
@@ -697,7 +718,7 @@ static Test tests[] = {
              return test42("{a<- 41L; b<- 1L; f <- function(x,y) x+y; f(a,b)}");
          }),
     Test("Test dead store analysis", &testDeadStore),
-};
+    Test("Test type rules", &testTypeRules)};
 
 } // namespace
 

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1323,7 +1323,7 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             // Check the return type
             if (pir::Parameter::RIR_CHECK_PIR_TYPES &&
                 instr->type != PirType::voyd() &&
-                instr->type != NativeType::context) {
+                instr->type != NativeType::context && !CastType::Cast(instr)) {
                 cb.add(BC::assertType(instr->type));
             }
 

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1320,6 +1320,13 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                       needsEnsureNamed.count(instr)))
                 cb.add(BC::ensureNamed());
 
+            // Check the return type
+            if (pir::Parameter::RIR_CHECK_PIR_TYPES &&
+                instr->type != PirType::voyd() &&
+                instr->type != NativeType::context) {
+                cb.add(BC::assertType(instr->type));
+            }
+
             // Store the result
             if (alloc.sa.dead(instr)) {
                 cb.add(BC::pop());

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -1010,8 +1010,9 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
             }
 
             case Tag::MkArg: {
-                auto p = MkArg::Cast(instr)->prom();
-                unsigned id = ctx.cs().addPromise(getPromise(ctx, p));
+                auto mkarg = MkArg::Cast(instr);
+                unsigned id = ctx.cs().addPromise(
+                    getPromise(ctx, mkarg->prom()), mkarg->promAst());
                 cb.add(BC::promise(id));
                 break;
             }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -820,6 +820,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     case Opcode::static_call_:
     case Opcode::pop_context_:
     case Opcode::push_context_:
+    case Opcode::assert_type_:
         log.unsupportedBC("Unsupported BC (are you recompiling?)", bc);
         assert(false && "Recompiling PIR not supported for now.");
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -22,8 +22,8 @@ class Rir2Pir {
         return tryCompile(srcFunction->body(), insert);
     }
 
-    Value* tryCreateArg(rir::Code* prom, Builder& insert, bool eager) const
-        __attribute__((warn_unused_result));
+    Value* tryCreateArg(rir::Code* promise, SEXP promiseAst, Builder& insert,
+                        bool eager) const __attribute__((warn_unused_result));
 
   private:
     Value* tryTranslatePromise(rir::Code* srcCode, Builder& insert) const

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -127,17 +127,19 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
             auto arg = closure->formals().defaultArgs()[i];
             if (arg != R_MissingArg) {
                 Value* res = nullptr;
+                SEXP argAst = R_UnboundValue;
                 if (TYPEOF(arg) != EXTERNALSXP) {
                     // A bit of a hack to compile default args, which somehow
                     // are not compiled.
                     // TODO: why are they sometimes not compiled??
                     auto funexp = rir::Compiler::compileExpression(arg);
                     protect(funexp);
+                    argAst = arg;
                     arg = Function::unpack(funexp)->body()->container();
                 }
                 if (rir::Code::check(arg)) {
                     auto code = rir::Code::unpack(arg);
-                    res = rir2pir.tryCreateArg(code, builder, false);
+                    res = rir2pir.tryCreateArg(code, argAst, builder, false);
                     if (!res) {
                         logger.warn("Failed to compile default arg");
                         return fail();

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -107,7 +107,8 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         findBuiltin("~"),
         findBuiltin("crossprod"),
         findBuiltin("tcrossprod"),
-        findBuiltin("lengths"),
+        // Would be safe if not a vector of objects
+        // findBuiltin("lengths"),
         findBuiltin("round"),
         findBuiltin("signif"),
         findBuiltin("log"),

--- a/rir/src/interpreter/call_context.h
+++ b/rir/src/interpreter/call_context.h
@@ -117,12 +117,12 @@ struct CallContext {
         return cp_pool_at(ctx, names[i]);
     }
 
-    void safeForceArgs() const {
+    void safeForceArgs(bool strong) const {
         assert(hasStackArgs());
         for (unsigned i = 0; i < passedArgs; i++) {
             SEXP arg = stackArg(i);
             if (TYPEOF(arg) == PROMSXP) {
-                safeForcePromise(arg, false);
+                safeForcePromise(arg, strong);
             }
         }
     }

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -76,6 +76,10 @@ SEXP safeForcePromise(SEXP e, bool strong) {
         }
         return val;
     } else {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "promise known: ";
+        Rf_PrintValue(PRVALUE(e));
+#endif
         return PRVALUE(e);
     }
 }

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -1,4 +1,5 @@
 #include "safe_force.h"
+#include "../compiler/parameter.h"
 #include "R/RList.h"
 #include "R/Sexp.h"
 #include "R/Symbols.h"
@@ -8,20 +9,66 @@
 
 namespace rir {
 
-SEXP safeEval(SEXP e, SEXP rho) {
-    SEXPTYPE t = TYPEOF(e);
-    if (t == LANGSXP || t == SYMSXP || t == PROMSXP || t == BCODESXP ||
-        t == EXTERNALSXP) {
+// #define DEBUG_SAFE_EVAL
+
+SEXP safeEval(SEXP e, SEXP rho, bool strong) {
+    assert((!strong || pir::Parameter::RIR_STRONG_SAFE_FORCE) &&
+           "currently never strong safe forces unless explicitly enabled");
+    if (e == R_UnboundValue) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval failed on unbound\n";
+#endif
         return R_UnboundValue;
+    } else if (e == R_MissingArg) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval missing\n";
+#endif
+        return e;
+    }
+    SEXPTYPE t = TYPEOF(e);
+    if (t == LANGSXP || t == BCODESXP || t == EXTERNALSXP) {
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval failed: ";
+        Rf_PrintValue(e);
+#endif
+        return R_UnboundValue;
+    } else if (t == PROMSXP) {
+        if (!strong)
+            return R_UnboundValue;
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval promise -> ";
+#endif
+        return safeForcePromise(e, strong);
+    } else if (t == SYMSXP) {
+        if (!strong || rho == nullptr)
+            return R_UnboundValue;
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval lookup " << CHAR(PRINTNAME(e));
+#endif
+        SEXP f = Rf_findVar(e, rho);
+        if (f == R_UnboundValue) {
+#ifdef DEBUG_SAFE_EVAL
+            std::cout << " failed\n";
+#endif
+            return R_UnboundValue;
+        }
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << " -> ";
+#endif
+        return safeEval(f, rho, strong);
     } else {
         // Constant
+#ifdef DEBUG_SAFE_EVAL
+        std::cout << "safe eval constant: ";
+        Rf_PrintValue(e);
+#endif
         return e;
     }
 }
 
-SEXP safeForcePromise(SEXP e) {
+SEXP safeForcePromise(SEXP e, bool strong) {
     if (PRVALUE(e) == R_UnboundValue) {
-        SEXP val = safeEval(PRCODE(e), PRENV(e));
+        SEXP val = safeEval(PRCODE(e), PRENV(e), strong);
         if (val != R_UnboundValue) {
             SET_PRVALUE(e, val);
             ENSURE_NAMEDMAX(val);

--- a/rir/src/interpreter/safe_force.h
+++ b/rir/src/interpreter/safe_force.h
@@ -1,15 +1,16 @@
 #ifndef RIR_SAFE_FORCE_H
 #define RIR_SAFE_FORCE_H
 
+#include "../common.h"
 #include <R/r.h>
 
 namespace rir {
 
 // Will try to evaluate the SEXP if it definitely doesn't cause side effects,
 // rho can be nullptr if the environment is unknown
-SEXP safeEval(SEXP e, SEXP rho);
+SEXP safeEval(SEXP e, SEXP rho, bool strong);
 // Will try to evaluate the promise if it definitely doesn't cause side effects
-SEXP safeForcePromise(SEXP e);
+SEXP safeForcePromise(SEXP e, bool strong);
 
 } // namespace rir
 

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -128,6 +128,10 @@ BC_NOARGS(V, _)
         cs.insert(immediate.loc_cpy);
         return;
 
+    case Opcode::assert_type_:
+        cs.insert(immediate.pirType());
+        return;
+
     case Opcode::invalid_:
     case Opcode::num_of:
         assert(false);
@@ -325,6 +329,9 @@ BC_NOARGS(V, _)
     case Opcode::brfalse_:
     case Opcode::br_:
         out << immediate.offset;
+        break;
+    case Opcode::assert_type_:
+        out << immediate.pirType();
         break;
     }
     out << "\n";

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 
+#include "../compiler/pir/type.h"
 #include "BC_inc.h"
 #include "R/Protect.h"
 #include "R/r.h"
@@ -316,6 +317,12 @@ BC BC::deopt(SEXP deoptMetadata) {
     ImmediateArguments i;
     i.pool = Pool::insert(deoptMetadata);
     return BC(Opcode::deopt_, i);
+}
+
+BC BC::assertType(pir::PirType typ) {
+    ImmediateArguments i;
+    i.setPirType(typ);
+    return BC(Opcode::assert_type_, i);
 }
 
 } // namespace rir

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <memory>
 
+#include "../compiler/pir/type.h"
 #include "R/r.h"
 #include "common.h"
 
@@ -140,6 +141,10 @@ class BC {
         ObservedCallees callFeedback;
         ObservedValues typeFeedback;
         ImmediateArguments() { memset(this, 0, sizeof(ImmediateArguments)); }
+        pir::PirType pirType() const { return pir::PirType(this); }
+        void setPirType(pir::PirType typ) {
+            memcpy(this, &typ, sizeof(pir::PirType));
+        }
     };
 
     static Immediate readImmediate(Opcode** pc) {
@@ -378,9 +383,9 @@ BC_NOARGS(V, _)
     inline static BC staticCall(size_t nargs, SEXP ast, SEXP targetClosure,
                                 SEXP targetVersion, const Assumptions& given);
     inline static BC callBuiltin(size_t nargs, SEXP ast, SEXP target);
-
     inline static BC mkEnv(const std::vector<SEXP>& names,
                            SignedImmediate contextPos, bool stub);
+    inline static BC assertType(pir::PirType typ);
 
     inline static BC decode(Opcode* pc, const Code* code) {
         BC cur;
@@ -671,6 +676,9 @@ BC_NOARGS(V, _)
 #define V(NESTED, name, name_) case Opcode::name_##_:
 BC_NOARGS(V, _)
 #undef V
+            break;
+        case Opcode::assert_type_:
+            immediate.setPirType(pir::PirType(pc));
             break;
         case Opcode::invalid_:
         case Opcode::num_of:

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -177,6 +177,7 @@ static Sources hasSources(Opcode bc) {
     case Opcode::push_context_:
     case Opcode::ceil_:
     case Opcode::floor_:
+    case Opcode::assert_type_:
         return Sources::NotNeeded;
 
     case Opcode::ldloc_:

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -18,7 +18,7 @@ DEF_INSTR(push_context_, 1, 2, 0, 0)
 DEF_INSTR(pop_context_, 0, 1, 0, 0)
 
 /**
- * make_env_:: create a new environment with the parent and all locals taken
+ * mk_env_:: create a new environment with the parent and all locals taken
  * from stack and the argument names as immediates.
  */
 DEF_INSTR(mk_env_, 2, -1, 1, 0)
@@ -522,5 +522,10 @@ DEF_INSTR(record_type_, 1, 1, 1, 0)
 
 DEF_INSTR(int3_, 0, 0, 0, 0)
 DEF_INSTR(printInvocation_, 0, 0, 0, 0)
+
+/*
+ * assert_type_ :: asserts that tos has the immediate PIR type
+ */
+DEF_INSTR(assert_type_, 2, 1, 1, 1)
 
 #undef DEF_INSTR

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -116,7 +116,11 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     }
 
     Code* getPromise(size_t idx) const {
-        return unpack(getExtraPoolEntry(idx));
+        return unpack(getExtraPoolEntry(idx * 2));
+    }
+
+    SEXP getPromiseAst(size_t idx) const {
+        return getExtraPoolEntry((idx * 2) + 1);
     }
 
     size_t size() const {

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -316,3 +316,20 @@ stopifnot(pir.check(function(x, y) {
   y == NA
   x + y
 }, NoEq, warmup=function(f)f(5L, 2L)))
+
+# Strong safe force
+x <- 10
+stopifnot(pir.check(function(n) {
+  x <- 1
+  while (x < n)
+    x <- x + 1
+  x
+}, NoEnv, warmup=function(f)f(x)))
+class(x) <- "something"
+stopifnot(!pir.check(function(n) {
+  x <- 1
+  while (x < n)
+    x <- x + 1
+  x
+}, NoEnv, warmup=function(f)f(x)))
+


### PR DESCRIPTION
When `RIR_CHECK_PIR_TYPES=1`, after every PIR instruction with a non-void type is converted into RIR bytecode, an `assert_type_` opcode will be emitted with the instruction's type. This will assert that the top of stack SEXP actually has the instruction's type.

This makes an ugly dependency on PIR, since the RIR interpreter accesses PIR types. It isn't too bad and doesn't create cycles, because `pir/type` doesn't have much dependencies. I think the best solution would be to move `PirType` outside of PIR, maybe into the `ir` folder. Although I'm not sure what everyone else thinks, so I didn't do this yet.