### PR TITLE
added cleanup handler

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -366,3 +366,5 @@ bool startup() {
 }
 
 bool startup_ok = startup();
+
+void rirCleanup() {}

--- a/rir/src/api.h
+++ b/rir/src/api.h
@@ -25,4 +25,6 @@ extern SEXP rirOptDefaultOpts(SEXP closure, const rir::Assumptions&, SEXP name);
 extern SEXP rirOptDefaultOptsDryrun(SEXP closure, const rir::Assumptions&,
                                     SEXP name);
 
+REXPORT void rirCleanup();
+
 #endif // API_H_

--- a/rir/src/interpreter/runtime.cpp
+++ b/rir/src/interpreter/runtime.cpp
@@ -38,7 +38,7 @@ void initializeRuntime() {
     // initialize the global context
     globalContext_ = context_create();
     registerExternalCode(rirEval_f, rirApplyClosure, rir_compile, rirExpr,
-                         materialize, keepAliveSEXPs);
+                         materialize, keepAliveSEXPs, rirCleanup);
     configurations = new rir::Configurations();
 }
 


### PR DESCRIPTION
Adds a function `rirCleanup` which will be called when R exits.

Would be used by #474, also see https://github.com/reactorlabs/gnur/pull/3