### PR TITLE
Loop detection code

### DIFF
--- a/rir/src/compiler/analysis/loop_detection.cpp
+++ b/rir/src/compiler/analysis/loop_detection.cpp
@@ -1,0 +1,105 @@
+#include "loop_detection.h"
+#include "../util/visitor.h"
+
+namespace rir {
+namespace pir {
+
+bool LoopDetection::Loop::comesBefore(Instruction* a, Instruction* b) const {
+    if (a->bb() == b->bb()) {
+        return a->id().idx() < b->id().idx();
+    } else {
+        // ordering vector is reversed: larger means precedes
+        return ordering_.at(a->bb()) > ordering_.at(b->bb());
+    }
+}
+
+LoopDetection::LoopDetection(Code* code, bool determineNesting)
+    : code(code), cfg(code), dom(code) {
+    // map of header nodes to tail nodes
+    std::unordered_map<BB*, BBList> tailNodes;
+
+    // find back edges, i.e. edges n->h where h dominates n
+    Visitor::run(code->entry, [&](BB* maybeHeader) {
+        for (const auto& n : cfg.immediatePredecessors(maybeHeader)) {
+            if (dom.dominates(maybeHeader, n)) {
+                if (tailNodes.count(maybeHeader)) {
+                    tailNodes[maybeHeader].push_back(n);
+                } else {
+                    tailNodes.emplace(maybeHeader, BBList({n}));
+                }
+            }
+        }
+    });
+
+    // for each loop header, find the nodes in the loop
+    for (auto& l : tailNodes) {
+        const auto& header = l.first;
+        auto& todo = l.second;
+        std::unordered_map<BB*, size_t> ordering;
+        size_t counter = 0;
+        BBSet body = {header}; // header is part of loop body
+
+#ifdef DEBUG_LOOP_DETECTION
+        std::cerr << "\n========== Detected loop ==========";
+        std::cerr << "\n\tHeader: " << header->id;
+        std::cerr << "\n\tTails:";
+        for (const auto& t : todo) {
+            std::cerr << " " << t->id;
+        }
+        std::cerr << "\n\tBody (in order of discovery):";
+#endif
+
+        // depth-first search starting from the loop tail(s)
+        while (!todo.empty()) {
+            BB* cur = todo.back();
+#ifdef DEBUG_LOOP_DETECTION
+            std::cerr << " " << cur->id;
+#endif
+            todo.pop_back();
+            if (!body.count(cur)) {
+                body.insert(cur);
+                ordering[cur] = counter++;
+                for (const auto& p : cfg.immediatePredecessors(cur)) {
+                    todo.push_back(p);
+                }
+            }
+        }
+
+        // header node is topologically last
+        ordering[header] = counter++;
+        loops.emplace_back(Loop{header, body, ordering});
+    }
+
+    // reconstruct the loop hierarchy
+    if (determineNesting) {
+        // sort in ascending order of loop body size
+        std::sort(begin(), end(), [](const Loop& a, const Loop& b) {
+            return a.size() < b.size();
+        });
+
+#ifdef DEBUG_LOOP_DETECTION
+        std::cerr << "\n========== Determined loop hierarchy ==========\n";
+#endif
+
+        // compare each loop l to every other loop l'
+        // the smallest l' such that l is inside l' is the (nearest) outer loop
+        for (auto it = begin(); it != end(); ++it) {
+            for (auto it2 = it + 1; it2 != end(); ++it2) {
+                if (it2->contains(it->header())) {
+#ifdef DEBUG_LOOP_DETECTION
+                    std::cerr << "\tLoop " << it->header()->id
+                              << " is directly inside loop "
+                              << it2->header()->id << "\n";
+#endif
+                    it->setOuterLoop(&*it2);
+                    break;
+                }
+            }
+        }
+    }
+
+    // TODO: compute or add the loop preheader
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/analysis/loop_detection.cpp
+++ b/rir/src/compiler/analysis/loop_detection.cpp
@@ -13,8 +13,9 @@ bool LoopDetection::Loop::comesBefore(Instruction* a, Instruction* b) const {
     }
 }
 
-LoopDetection::LoopDetection(Code* code, bool determineNesting)
-    : code(code), cfg(code), dom(code) {
+LoopDetection::LoopDetection(Code* code, bool determineNesting) {
+    CFG cfg(code);
+    DominanceGraph dom(code);
     // map of header nodes to tail nodes
     std::unordered_map<BB*, BBList> tailNodes;
 

--- a/rir/src/compiler/analysis/loop_detection.h
+++ b/rir/src/compiler/analysis/loop_detection.h
@@ -2,7 +2,6 @@
 #define PIR_LOOP_DETECTION_H
 
 #include "../pir/pir.h"
-#include "../util/cfg.h"
 
 #include <unordered_map>
 #include <unordered_set>
@@ -44,32 +43,25 @@ class LoopDetection {
         Loop* outer_;
         // true if this loop does not contain another loop
         bool isInnermost_;
-        // topological ordering of nodes
-        std::unordered_map<BB*, size_t> ordering_;
 
       public:
-        Loop(BB* header, const BBSet& body,
-             const std::unordered_map<BB*, size_t>& ordering)
+        Loop(BB* header, const BBSet& body)
             : header_(header), body_(std::move(body)), outer_(nullptr),
-              isInnermost_(true), ordering_(std::move(ordering)) {}
+              isInnermost_(true) {}
 
         Loop(const Loop&) = delete;
         Loop& operator=(const Loop&) = delete;
         Loop(Loop&&) = default;
         Loop& operator=(Loop&&) = default;
 
-        RIR_INLINE BB* header() const { return header_; }
-        RIR_INLINE size_t size() const { return body_.size(); }
-        RIR_INLINE bool contains(BB* node) const { return body_.count(node); }
-        RIR_INLINE bool isInnermost() const { return isInnermost_; }
-        RIR_INLINE void setOuterLoop(Loop* o) {
+        BB* header() const { return header_; }
+        size_t size() const { return body_.size(); }
+        bool contains(BB* node) const { return body_.count(node); }
+        bool isInnermost() const { return isInnermost_; }
+        void setOuterLoop(Loop* o) {
             outer_ = o;
             o->isInnermost_ = false;
         }
-
-        // Returns true if a comes before b in the loop (without going through
-        // a back edge)
-        bool comesBefore(Instruction* a, Instruction* b) const;
 
         typedef BBSet::iterator iterator;
         typedef BBSet::const_iterator const_iterator;

--- a/rir/src/compiler/analysis/loop_detection.h
+++ b/rir/src/compiler/analysis/loop_detection.h
@@ -96,9 +96,6 @@ class LoopDetection {
     const_iterator end() const { return loops.end(); }
 
   private:
-    Code* code;
-    CFG cfg;
-    DominanceGraph dom;
     std::vector<Loop> loops;
 };
 


### PR DESCRIPTION
```
Does the standard textbook approach of identifying loops. A loop is
defined by a header h, and a back edge n->h where h dominates n. If
there are multiple back edges to the same header, the body is the union
of all the nodes computed for each back edge.

Once back edges are identified, we do a reverse depth-first search from
the "tail" until we reach the header.

There is an option to compute the loop-nesting forest, but it disabled
by default because it is slow.
```

I'm splitting this off from my loop peeling work, to make things more manageable and because #362 needs this.

However, as this PR stands, the loop detection code is never reached, and won't be until we have loop-invariant hoisting and/or loop peeling.