### PR TITLE
Add a BBTransform helper to remove dead instructions.

### DIFF
--- a/rir/src/compiler/opt/gvn.cpp
+++ b/rir/src/compiler/opt/gvn.cpp
@@ -1,5 +1,6 @@
 #include "../pir/pir.h"
 #include "../pir/pir_impl.h"
+#include "../transform/bb.h"
 #include "../util/visitor.h"
 #include "R/r.h"
 #include "pass_definitions.h"
@@ -196,6 +197,10 @@ void GVN::apply(RirCompiler&, ClosureVersion* cls, LogStream& log) const {
             }
         }
     }
+
+    // Remove dead instructions here, instead of deferring to the cleanup pass.
+    // Sometimes a dead instruction will trip the verifier.
+    BBTransform::removeDeadInstrs(cls);
 }
 
 } // namespace pir

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -217,5 +217,20 @@ void BBTransform::renumber(Code* fun) {
         });
 }
 
+void BBTransform::removeDeadInstrs(Code* fun) {
+    Visitor::run(fun->entry, [&](BB* bb) {
+        auto ip = bb->begin();
+        while (ip != bb->end()) {
+            Instruction* i = *ip;
+            auto next = ip + 1;
+            if (i->unused() && !i->branchOrExit() &&
+                !i->hasObservableEffects()) {
+                next = bb->remove(ip);
+            }
+            ip = next;
+        }
+    });
+}
+
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -27,9 +27,13 @@ class BBTransform {
                              bool assumePositive);
     static void insertAssume(Value* condition, Checkpoint* cp,
                              bool assumePositive);
+
     // Renumber in dominance order. This ensures that controlflow always goes
     // from smaller id to bigger id, except for back-edges.
     static void renumber(Code* fun);
+
+    // Remove dead instructions (instead of waiting until the cleanup pass)
+    static void removeDeadInstrs(Code* fun);
 };
 
 } // namespace pir

--- a/rir/tests/pir_regression_gvn.R
+++ b/rir/tests/pir_regression_gvn.R
@@ -1,0 +1,11 @@
+# TODO(mhyee): this will be subsumed by the loop peeling tests
+
+f <- pir.compile(rir.compile(function() {
+    sum <- 0
+    for (i in 1:10) {
+        if (i == 5) next
+        sum <- sum + i
+    }
+    sum
+}))
+stopifnot(f() ==  50)


### PR DESCRIPTION
The GVN pass can sometimes generate dead phis that are also invalid;
normally, these phis would be removed by the cleanup pass. However, this
could trip the verifier.