### PR TITLE
Safelist master branch for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,3 +146,7 @@ cache:
     - external
     # cache homebrew formulas
     - /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
+
+branches:
+  only:
+  - master


### PR DESCRIPTION
I noticed that currently, Travis only builds for PRs. There is no build when we merge to master.

I think it's because of our current settings:

![image](https://user-images.githubusercontent.com/547059/57242105-9db97a00-7000-11e9-8b20-97640f215553.png)

I'd like to activate "build pushed branches," but to avoid building on every single feature branch (that's not ready for a PR), I'm adding this change to `.travis.yml` to allow only builds on master. (See [documentation](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches).)

Might also be good to activate [auto cancel PR builds](https://docs.travis-ci.com/user/customizing-the-build/#building-only-the-latest-commit): if there is a build that is queued (but not started) and you push a new commit, it cancels the queued build.

We'll probably want to disable auto cancel branch builds, so that every merge on master gets built.

(I cancelled the CI builds for this PR.)