### PR TITLE
Revert "Safelist master branch for Travis CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,3 @@ cache:
     - external
     # cache homebrew formulas
     - /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
-
-branches:
-  only:
-  - master


### PR DESCRIPTION
Reverts reactorlabs/rir#481

---

On Travis, "build pushed branches" means a build runs whenever you push to `reactorlabs/rir`, which includes commits/merges to `master`, pushing new feature branches, pushing commits to existing feature branches, etc. (This is the current behaviour of our GitLab CI.) Forks and PRs from forks are completely ignored.

"Build pushed pull requests" means whenever you open a new PR (or commit to a PR), Travis will merge it into master and then build that. The PR can be from a `reactorlabs/rir` branch, or a fork's branch.

Because our workflow had us opening branches from `reactorlabs/rir`, this means we would get duplicate Travis builds, one for the push (whatever the branch is) and one for the PR (the merge of the branch and master).

I had hoped that prevent this by specifying only `master` should be built, but that didn't work. So I am reverting that commit.

But I'm also going to enable "build pushed branches" and disable "build pushed pull requests."