### PR TITLE
Add BB id comments in debug graph output.

### DIFF
--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -56,7 +56,8 @@ void BB::printGraph(std::ostream& out, bool omitDeoptBranches) {
     }
     if (isJmp() || printDeoptOnlyDefault) {
         out << "BB" << uid() << " -> "
-            << "BB" << next0->uid() << ";\n";
+            << "BB" << next0->uid() << ";"
+            << "  // -> BB" << next0->id << "\n";
     }
     if (printDeoptOnlyDefault)
         out << "BB" << uid() << " -> d" << next1->id << " [color=red];\n";
@@ -73,7 +74,8 @@ void BB::printBBGraph(std::ostream& out, bool omitDeoptBranches) {
     }
     if (isJmp() || printDeoptOnlyDefault) {
         out << "BB" << uid() << " -> "
-            << "BB" << next0->uid() << ";\n";
+            << "BB" << next0->uid() << ";"
+            << "  // -> BB" << next0->id << "\n";
     }
     if (printDeoptOnlyDefault)
         out << "BB" << uid() << " -> d" << next1->id << " [color=red];\n";

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -410,9 +410,12 @@ void Branch::printGraphArgs(std::ostream& out, bool tty) const {
 }
 
 void Branch::printGraphBranches(std::ostream& out, size_t bbId) const {
-    out << "  BB" << bbId << " -> BB" << bb()->trueBranch()->uid()
-        << " [color=green];\n  BB" << bbId << " -> BB"
-        << bb()->falseBranch()->uid() << " [color=red];\n";
+    auto trueBB = bb()->trueBranch();
+    auto falseBB = bb()->falseBranch();
+    out << "  BB" << bbId << " -> BB" << trueBB->uid()
+        << " [color=green];  // -> BB" << trueBB->id << "\n"
+        << "  BB" << bbId << " -> BB" << falseBB->uid()
+        << " [color=red];  // -> BB" << falseBB->id << "\n";
 }
 
 void MkArg::printArgs(std::ostream& out, bool tty) const {
@@ -831,8 +834,12 @@ void Checkpoint::printGraphArgs(std::ostream& out, bool tty) const {
 }
 
 void Checkpoint::printGraphBranches(std::ostream& out, size_t bbId) const {
-    out << "  BB" << bbId << " -> BB" << bb()->trueBranch()->uid() << ";\n  BB"
-        << bbId << " -> BB" << bb()->falseBranch()->uid() << " [color=red];\n";
+    auto trueBB = bb()->trueBranch();
+    auto falseBB = bb()->falseBranch();
+    out << "  BB" << bbId << " -> BB" << trueBB->uid() << ";  // -> BB"
+        << trueBB->id << "\n"
+        << "  BB" << bbId << " -> BB" << falseBB->uid()
+        << " [color=red];  // -> BB" << falseBB->id << "\n";
 }
 
 BB* Checkpoint::deoptBranch() { return bb()->falseBranch(); }


### PR DESCRIPTION
Having branches written as:

    BB123456789 -> BB987654321

is basically unreadable, so now we add a comment:

    BB123456789 -> BB987654321 // -> BB2

We already have a user-readable label (xlabel) for the source BB, so we
don't need to print it twice.

---

Here's an example of what I mean:

```
BB93962499913904 [shape="box", fontname="monospace", xlabel="BB0", label="\
env'            e0.0  = MKEnv                  parent=<environment: R_GlobalEnv>, context 1\l\
real$'          %0.1  = LdConst                [1] 1 \l\
void                    Visible          v     \l\
void                    StVar            W     i, %0.1, e0.0\l\
cp              %0.4  = Checkpoint             \l\
"];
  BB93962499913904 -> BB93962488578752;  // -> BB1
  BB93962499913904 -> BB93962481214128 [color=red];  // -> BB2
```

Before, all I knew was that BB0 had a checkpoint, but now I know it jumps to BB1 and BB2.