### PR TITLE
Liveness analysis: handle liveness at bb start

### DIFF
--- a/rir/src/compiler/analysis/liveness.h
+++ b/rir/src/compiler/analysis/liveness.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+// #define DEBUG_LIVENESS
+
 /*
  * The liveness analysis _does not_ use the static analysis framework. This is
  * intentional:
@@ -46,6 +48,7 @@ namespace pir {
 
 struct BBLiveness {
     uint8_t live = false;
+    uint8_t liveAtEntry = false;
     unsigned begin = -1;
     unsigned end = -1;
 };
@@ -55,8 +58,19 @@ class LivenessIntervals {
 
   public:
     LivenessIntervals(unsigned bbsSize, CFG const& cfg);
+
+    // Returns true if `what` is live *immediately after* `where`.
+    // This function cannot tell you if a value is live *before* the first
+    // instruction of a BB; instead, use `liveAtBBEntry`.
     bool live(Instruction* where, Value* what) const;
+
+    // Two values interfere iff there is a BB where they are both live and their
+    // intervals overlap.
     bool interfere(Value* v1, Value* v2) const;
+
+    // Returns true if `what` is live at the beginning of `bb`.
+    bool liveAtBBEntry(BB* bb, Value* what) const;
+
     size_t count(Value* v) const { return intervals.count(v); }
 };
 

--- a/rir/src/compiler/translations/pir_2_rir/allocators.h
+++ b/rir/src/compiler/translations/pir_2_rir/allocators.h
@@ -15,7 +15,7 @@ namespace pir {
  * 3. For now, just put everything on stack. (step 4 is thus skipped...)
  * 4. Assign the remaining Instructions to local RIR variable numbers
  *    (see computeAllocation):
- *    1. Coalesc all remaining phi with their inputs. This is save since we are
+ *    1. Coalesce all remaining phi with their inputs. This is save since we are
  *       already in CSSA. Directly allocate a register on the fly, such that.
  *    2. Traverse the dominance tree and eagerly allocate the remaining ones
  * 5. For debugging, verify the assignment with a static analysis that simulates
@@ -42,6 +42,12 @@ class SSAAllocator {
         : cfg(code), dom(code), code(code), bbsSize(code->nextBBId),
           livenessIntervals(bbsSize, cfg),
           sa(cls, code, log, livenessIntervals) {
+#ifdef DEBUG_LIVENESS
+        std::cerr << "^^^^^^^^^^ "
+                  << "SSAAllocator ran liveness analysis"
+                  << " ^^^^^^^^^^\n";
+        code->printGraphCode(std::cerr, false);
+#endif
 
         computeStackAllocation();
         computeAllocation();


### PR DESCRIPTION
Also add print debugging (behind a compile-time switch)

---

This is another thing I need for loop peeling, but I'm splitting it off because it can stand on its own (even if nothing uses it), and it'll make merging/reviewing the loop peeling branch easier when it's ready.

Per-instruction output looks like this:
```
========== Liveness info for instr:
real$'          %0.0  = LdConst                [1] 1
        Live in BB0: [0, 4)
        Live in BB1: ![0, 8)
        Live in BB2: ![0, 7)
        Live in BB6: ![0, 11)
```