### PR TITLE
Revert "Infer static call return types"

### DIFF
--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -48,15 +48,5 @@ std::unordered_set<Value*> Query::returned(Code* c) {
     return returned;
 }
 
-PirType Query::returnType(Closure* c) {
-    PirType t = PirType::bottom();
-    c->eachVersion([&](ClosureVersion* cv) {
-        for (Value* val : Query::returned(cv)) {
-            t = t | val->type;
-        }
-    });
-    return t;
-}
-
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/analysis/query.h
+++ b/rir/src/compiler/analysis/query.h
@@ -19,7 +19,6 @@ class Query {
     static bool noEnvSpec(Code* c);
     static bool noDeopt(Code* c);
     static std::unordered_set<Value*> returned(Code* c);
-    static PirType returnType(Closure* c);
 };
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -5,7 +5,6 @@
 #include "R/Funtab.h"
 
 #include "../analysis/abstract_value.h"
-#include "../analysis/query.h"
 
 #include "pass_definitions.h"
 
@@ -114,10 +113,6 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                     inferred = i->type;
                     break;
                 }
-
-                case Tag::StaticCall:
-                    inferred = Query::returnType(StaticCall::Cast(i)->cls());
-                    break;
 
                 default:
                     inferred = i->type;


### PR DESCRIPTION
Reverts reactorlabs/rir#492

I am sorry I was too trigger happy with this. This is actually not correct, because it fails to consider the deoptimization case. A function can deoptimize and then the deoptimized version can return something else altogether.