### PR TITLE
Deopt must change the return type

### DIFF
--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -136,6 +136,7 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
     } else if (Deopt::Cast(i)) {
         // who knows what the deopt target will return...
         state.returnValue.taint();
+        effect.update();
     } else if (auto mk = MkEnv::Cast(i)) {
         Value* lexicalEnv = mk->lexicalEnv();
         // If we know the caller, we can fill in the parent env

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -136,7 +136,8 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
     } else if (Deopt::Cast(i)) {
         // who knows what the deopt target will return...
         state.returnValue.taint();
-        effect.update();
+        state.mayUseReflection = true;
+        effect.taint();
     } else if (auto mk = MkEnv::Cast(i)) {
         Value* lexicalEnv = mk->lexicalEnv();
         // If we know the caller, we can fill in the parent env

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -45,6 +45,10 @@ class ScopeAnalysisState {
             mayUseReflection = true;
             res.lostPrecision();
         }
+        if (!returnValue.isUnknown() && other.returnValue.isUnknown()) {
+            returnValue.taint();
+            res.lostPrecision();
+        }
 
         return res.max(envs.merge(other.envs));
     }


### PR DESCRIPTION
Scope analysis infers call return types (same as #492, it was already implemented). When it encounters a `Deopt` it taints the local state, the problem is this doesn't always affect the final state.