### PR TITLE
updated type inference of `c(...)`

### DIFF
--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -104,9 +104,8 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                     }
 
                     if ("c" == name) {
-                        inferred = mergedArgumentType();
-                        if (c->nCallArgs() > 1)
-                            inferred.setNotScalar();
+                        inferred =
+                            mergedArgumentType().collectionType(c->nCallArgs());
                         break;
                     }
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -393,7 +393,7 @@ struct PirType {
                 t.setNotScalar();
             return t;
         } else if (t_.r.contains(RType::prom)) {
-            return PirType::val();
+            return val();
         } else {
             return forced().notObject().orNotScalar() | RType::vec;
         }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -346,12 +346,10 @@ struct PirType {
             return RType::nil;
         }
         if (isA(num() | RType::str | RType::cons | RType::code)) {
-            PirType t = *this;
             if (idx.isScalar())
-                t.setScalar();
+                return scalar();
             else
-                t = t.orNotScalar();
-            return t;
+                return orNotScalar();
         } else if (isA(RType::vec)) {
             return RType::vec;
         } else if (!maybeObj() && !PirType(RType::prom).isA(*this)) {
@@ -380,6 +378,36 @@ struct PirType {
         } else {
             // Possible object
             return valOrLazy();
+        }
+    }
+
+    // Type of c(<this>, ...numArgs)
+    PirType collectionType(int numArgs) const {
+        assert(isRType());
+        PirType t = *this;
+        if (t.isA(RType::nil)) {
+            return RType::nil;
+        }
+        t.t_.r.reset(RType::nil);
+        if (t.isA(num() | RType::str)) {
+            if (numArgs > 1)
+                t.setNotScalar();
+            RTypeSet r = t.t_.r;
+            if (r.contains(RType::str))
+                t.t_.r = RTypeSet(RType::str);
+            else if (r.contains(RType::cplx))
+                t.t_.r = RTypeSet(RType::cplx);
+            else if (r.contains(RType::real))
+                t.t_.r = RTypeSet(RType::real);
+            else if (r.contains(RType::integer))
+                t.t_.r = RTypeSet(RType::integer);
+            else if (r.contains(RType::logical))
+                t.t_.r = RTypeSet(RType::logical);
+            else
+                assert(false);
+            return t;
+        } else {
+            return RType::vec;
         }
     }
 

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -384,30 +384,18 @@ struct PirType {
     // Type of c(<this>, ...numArgs)
     PirType collectionType(int numArgs) const {
         assert(isRType());
-        PirType t = *this;
-        if (t.isA(RType::nil)) {
+        if (isA(RType::nil)) {
             return RType::nil;
-        }
-        t.t_.r.reset(RType::nil);
-        if (t.isA(num() | RType::str)) {
+        } else if (isA(num() | RType::str | RType::nil)) {
+            PirType t = *this;
+            t.t_.r.reset(RType::nil);
             if (numArgs > 1)
                 t.setNotScalar();
-            RTypeSet r = t.t_.r;
-            if (r.contains(RType::str))
-                t.t_.r = RTypeSet(RType::str);
-            else if (r.contains(RType::cplx))
-                t.t_.r = RTypeSet(RType::cplx);
-            else if (r.contains(RType::real))
-                t.t_.r = RTypeSet(RType::real);
-            else if (r.contains(RType::integer))
-                t.t_.r = RTypeSet(RType::integer);
-            else if (r.contains(RType::logical))
-                t.t_.r = RTypeSet(RType::logical);
-            else
-                assert(false);
             return t;
+        } else if (t_.r.contains(RType::prom)) {
+            return PirType::val();
         } else {
-            return RType::vec;
+            return forced().notObject().orNotScalar() | RType::vec;
         }
     }
 


### PR DESCRIPTION
The current inference is broken, e.g. `c(<promise>, ...)` will be inferred to return a promise.