### PR TITLE
add dockerfile and scripts to create a benchmark-baseline container with vanilla-r

### DIFF
--- a/container/benchmark-baseline/Dockerfile
+++ b/container/benchmark-baseline/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.gitlab.com/rirvm/rir_mirror/base
+RUN git clone --depth 1 https://github.com/charig/ReBench.git -b envVarsSupport /opt/ReBench && cd /opt/ReBench && pip install .
+RUN git clone --depth 1 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking
+RUN git clone --recursive https://github.com/reactorlabs/rir /opt/rir && cd /opt/rir && tools/sync.sh && git -C external/custom-r checkout R-3.5.1 && tools/build-gnur.sh custom-r && rm -rf custom-r/cache_recommended.tar custom-r/src .git

--- a/container/benchmark-baseline/update.sh
+++ b/container/benchmark-baseline/update.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker build -t registry.gitlab.com/rirvm/rir_mirror/benchmark-baseline .
+docker push registry.gitlab.com/rirvm/rir_mirror/benchmark-baseline


### PR DESCRIPTION
just a dockerfile to create a container for what used to be vanilla-r.
this container is identical to the benchmark kind of containers, except that rir is not built and the r is built without any rir modifications.