### PR TITLE
script to poll for benchmark container update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ rir container:
     - docker info
   script:
     - echo "$CI_BUILD_TOKEN" | docker login -u "$CI_BUILD_USER" --password-stdin registry.gitlab.com
-    - docker build -t registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA .
+    - docker build --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA -t registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA .
     - docker push registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
 
 benchmark container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG CI_COMMIT_SHA
 FROM registry.gitlab.com/rirvm/rir_mirror/base
 ADD . /opt/rir
+RUN echo $CI_COMMIT_SHA > /opt/rir_version
 RUN cd /opt/rir && tools/sync.sh && tools/build-gnur.sh custom-r && rm -rf external/custom-r/cache_recommended.tar .git && find external -type f -name '*.o' -exec rm -f {} \;
 RUN mkdir -p /opt/rir/build/release      && cd /opt/rir/build/release      && cmake -DCMAKE_BUILD_TYPE=release      -GNinja ../.. && ninja && rm -rf build/*/CMakeFiles
 RUN mkdir -p /opt/rir/build/fullverifier && cd /opt/rir/build/fullverifier && cmake -DCMAKE_BUILD_TYPE=fullverifier -GNinja ../.. && ninja && rm -rf build/*/CMakeFiles


### PR DESCRIPTION
container/notifyImageUpdate.sh blocks until the image tagged master in
the benchmark registry is updated.

also add the current commit id to /opt/rir_version

@charig this should solve your todo 1. basically you don't need to update the repo on the benchmark machine at all. just run the notifyImageUpdate script and it will block until there is a new benchmark container available. then just run the rirvm/rir_mirror/benchmark:master image and use the commit sha in /opt/rir_version

the usage is:

```
./notifyImageUpdate.sh some command
```
e.g.
```
./notifyImageUpdate.sh docker run registry.gitlab.com/rirvm/rir_mirror/benchmark:master ......
```

this will run the command whenever the master image changes



UPDATE: we'll put this script in the benchmark repo. just merging the rir_version part