### PR TITLE
elide env when forcing promises

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -186,6 +186,11 @@ class TheVerifier {
                           << p->owner->name() << "\n";
                 ok = false;
             }
+            if (mk->isEager() && mk->hasEnv()) {
+                mk->printRef(std::cerr);
+                std::cerr << " is evaluated, but still has env reference\n";
+                ok = false;
+            }
         }
 
         if (i->branchOrExit())

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -850,18 +850,30 @@ class FLIE(MkArg, 2, Effects::None()) {
                                          env),
           prom_(prom) {
         assert(eagerArg() == v);
-        noReflection = isEager();
+        if (isEager()) {
+            noReflection = true;
+            elideEnv();
+        }
     }
     MkArg(Value* v, Value* env)
         : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
                                          env),
           prom_(nullptr) {
         assert(eagerArg() == v);
-        noReflection = isEager();
+        if (isEager()) {
+            noReflection = true;
+            elideEnv();
+        }
     }
 
     Value* eagerArg() const { return arg(0).val(); }
-    void eagerArg(Value* eager) { arg(0).val() = eager; }
+    void eagerArg(Value* eager) {
+        arg(0).val() = eager;
+        assert(isEager());
+        noReflection = true;
+        // Environment is not needed once a promise is evaluated
+        elideEnv();
+    }
 
     void updatePromise(Promise* p) { prom_ = p; }
     Promise* prom() const { return prom_; }


### PR DESCRIPTION
The gnu R implementation of forcePromise sets the environment to nil
after it has been evaluated.

In case we statically evaluate a promise we should therefore be able to
elide the environment from the start.