### PR TITLE
fix wrong order of env stub content

### DIFF
--- a/rir/src/interpreter/LazyEnvironment.h
+++ b/rir/src/interpreter/LazyEnvironment.h
@@ -29,8 +29,8 @@ struct LazyEnvironment
         : RirRuntimeObject(sizeof(LazyEnvironment), nargs + 1),
           frameEnd(frameEnd), nargs(nargs), names(names) {
         setEntry(0, parent);
-        for (size_t i = 0; i < nargs; i++) {
-            setEntry(i + 1, ostack_pop(ctx));
+        for (long i = nargs - 1; i >= 0; --i) {
+            setArg(i, ostack_pop(ctx));
         }
     }
 


### PR DESCRIPTION
create stub/create env used reverse ordering and stvar/ldvar used normal
ordering.

let's use the order that is consistent with the order of the names