### PR TITLE
Fix gte/lte mixup.

### DIFF
--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -764,8 +764,8 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                 SIMPLE_WITH_SRCIDX(Pow, pow);
                 SIMPLE_WITH_SRCIDX(Lt, lt);
                 SIMPLE_WITH_SRCIDX(Gt, gt);
-                SIMPLE_WITH_SRCIDX(Lte, ge);
-                SIMPLE_WITH_SRCIDX(Gte, le);
+                SIMPLE_WITH_SRCIDX(Lte, le);
+                SIMPLE_WITH_SRCIDX(Gte, ge);
                 SIMPLE_WITH_SRCIDX(Eq, eq);
                 SIMPLE_WITH_SRCIDX(Neq, ne);
                 SIMPLE_WITH_SRCIDX(Colon, colon);

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -688,8 +688,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 
         BINOP(Lt, lt_);
         BINOP(Gt, gt_);
-        BINOP(Gte, le_);
-        BINOP(Lte, ge_);
+        BINOP(Gte, ge_);
+        BINOP(Lte, le_);
         BINOP(Mod, mod_);
         BINOP(Div, div_);
         BINOP(IDiv, idiv_);


### PR DESCRIPTION
Somehow we made the same mistake in rir_2_pir and pir_2_rir, so the bug
cancelled itself out.

However, Constantfold did not have the bug, so some branches got
incorrectly optimized out.

(This was originally fixed by @o- but not merged yet, but I need this
fix.)

---

I'm merging this once CI passes.