### PR TITLE
Uses fixed-len array instead of vector to store arg types

### DIFF
--- a/rir/src/runtime/FunctionSignature.h
+++ b/rir/src/runtime/FunctionSignature.h
@@ -102,6 +102,9 @@ struct FunctionSignature {
         return numArguments - assumptions.numMissing();
     }
 
+    // Tracks up to a fixed # of arg types, because tracking the types doesn't
+    // affect correctness (like assumptions), and otherwise the types would
+    // need to be exposed to the GC.
     static const unsigned MAX_TRACKED_ARGS = 4;
     const Environment envCreation;
     const OptimizationLevel optimization;


### PR DESCRIPTION
In `FunctionSignature`, we create vectors but don't explicitly `delete` them (since the signatures are destroyed by the R GC). This PR uses a fixed-length array of 4 arguments, and ignores the rest (currently signature arg types seem to only be used for printing)