### PR TITLE
cleanup and unify type inference

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -272,22 +272,6 @@ class TheVerifier {
             }
         }
 
-        if (auto cast = CastType::Cast(i)) {
-            auto arg = cast->arg<0>().val();
-            // assertion is:
-            // "input is a promise => output is a promise"
-            // to remove a promise wrapper -- even for eager args -- a force
-            // instruction is needed!
-            if (arg->type.maybePromiseWrapped() &&
-                !cast->type.maybePromiseWrapped()) {
-                std::cerr << "Error at instruction '";
-                i->print(std::cerr);
-                std::cerr
-                    << "': Cannot cast away promise wrapper. need to use Force";
-                ok = false;
-            }
-        }
-
         i->eachArg([&](const InstrArg& a) -> void {
             auto v = a.val();
             auto t = a.type();

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -272,6 +272,22 @@ class TheVerifier {
             }
         }
 
+        if (auto cast = CastType::Cast(i)) {
+            auto arg = cast->arg<0>().val();
+            // assertion is:
+            // "input is a promise => output is a promise"
+            // to remove a promise wrapper -- even for eager args -- a force
+            // instruction is needed!
+            if (arg->type.maybePromiseWrapped() &&
+                !cast->type.maybePromiseWrapped()) {
+                std::cerr << "Error at instruction '";
+                i->print(std::cerr);
+                std::cerr
+                    << "': Cannot cast away promise wrapper. need to use Force";
+                ok = false;
+            }
+        }
+
         i->eachArg([&](const InstrArg& a) -> void {
             auto v = a.val();
             auto t = a.type();

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -55,6 +55,7 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
     CFG cfg(function);
     AvailableCheckpoints checkpoint(function, log);
     AvailableAssumptions assumptions(function, log);
+    std::unordered_map<Checkpoint*, Checkpoint*> replaced;
 
     Visitor::runPostChange(function->entry, [&](BB* bb) {
         auto ip = bb->begin();
@@ -67,12 +68,16 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
             // this one.
             if (auto cp = Checkpoint::Cast(instr)) {
                 if (auto cp0 = checkpoint.at(instr)) {
+                    while (replaced.count(cp0))
+                        cp0 = replaced.at(cp0);
+                    replaced[cp] = cp0;
+
                     assert(bb->last() == instr);
                     cp->replaceUsesWith(cp0);
                     bb->remove(ip);
                     delete bb->next1;
                     bb->next1 = nullptr;
-                    next = bb->end();
+                    return;
                 }
             }
 
@@ -89,6 +94,8 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
                     // if we move both at the same time, we could even jump over
                     // effectful instructions.
                     if (auto cp0 = checkpoint.at(instr)) {
+                        while (replaced.count(cp0))
+                            cp0 = replaced.at(cp0);
                         if (assume->checkpoint() != cp0)
                             assume->checkpoint(cp0);
                     }

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -131,7 +131,7 @@ class TheCleanup {
                 }
 
                 if (!removed) {
-                    i->updateType();
+                    i->updateTypeAndEffects();
                 }
                 ip = next;
             }

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -104,7 +104,7 @@ void DelayEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                                               BB* fastPathBranch) {
                 auto newEnvInstr = envInstr->clone();
                 deoptBranch->insert(deoptBranch->begin(), newEnvInstr);
-                envInstr->replaceUsesWithLimits(newEnvInstr, deoptBranch);
+                envInstr->replaceUsesIn(newEnvInstr, deoptBranch);
                 it = bb->moveToBegin(it, fastPathBranch);
             };
 

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -168,6 +168,8 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                                 if (auto f = Force::Cast(i)) {
                                     if (LdArg::Cast(f)) {
                                         f->elideEnv();
+                                        f->effects.reset(
+                                            Effect::DependsOnAssume);
                                         f->effects.reset(Effect::Reflection);
                                     }
                                 }

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -25,9 +25,7 @@ void ElideEnv::apply(RirCompiler&, ClosureVersion* function, LogStream&) const {
                     });
                     if (!envIsNeeded) {
                         i->elideEnv();
-                        i->type.setNotObject();
-                        i->effects.reset(Effect::Reflection);
-                        i->type = i->type.forced();
+                        i->updateTypeAndEffects();
                     }
                 }
 

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -97,9 +97,6 @@ struct ForcedBy {
     }
 
     bool escape(Value* val) {
-        if (forcedBy.count(val) && forcedBy.at(val) != ambiguous())
-            return false;
-
         if (!escaped.count(val)) {
             escaped.insert(val);
             return true;
@@ -294,6 +291,17 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
 
     AbstractResult apply(ForcedBy& state, Instruction* i) const override {
         AbstractResult res;
+        auto apply = [&](Instruction* i) {
+            i->eachArg([&](Value* v) {
+                v = v->followCasts();
+                if (auto arg = MkArg::Cast(v))
+                    if (state.escape(arg))
+                        res.update();
+                if (auto arg = LdArg::Cast(v))
+                    if (state.escape(arg))
+                        res.update();
+            });
+        };
         if (auto f = Force::Cast(i)) {
             if (MkArg* arg = MkArg::Cast(f->arg<0>().val()->followCasts()))
                 if (state.forcedAt(arg, f))
@@ -315,35 +323,12 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
         } else if (auto ld = LdArg::Cast(i)) {
             if (state.declare(ld))
                 res.update();
-        } else if (MkEnv::Cast(i)) {
-            // Promises assigned to envs is only relevant when the env leaks.
-            // This case is handled below.
+        } else if (auto e = MkEnv::Cast(i)) {
+            if (!e->stub)
+                apply(e);
         } else if (CastType::Cast(i)) {
-            // This is a whitelist of instructions that get a promise as
-            // argument, but don't change it in any way.
         } else {
-            auto apply = [&](Instruction* i) {
-                i->eachArg([&](Value* v) {
-                    v = v->followCasts();
-                    if (auto arg = MkArg::Cast(v))
-                        if (state.escape(arg))
-                            res.update();
-                    if (auto arg = LdArg::Cast(v))
-                        if (state.escape(arg))
-                            res.update();
-                });
-            };
             apply(i);
-
-            if (i->leaksEnv()) {
-                auto env = i->env();
-                while (auto mk = MkEnv::Cast(env)) {
-                    // Stub cannot leak
-                    if (!mk->stub)
-                        apply(mk);
-                    env = mk->lexicalEnv();
-                }
-            }
 
             if (i->effects.contains(Effect::Force))
                 if (state.sideeffect())
@@ -370,13 +355,40 @@ namespace pir {
 void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
                            LogStream& log) const {
     auto apply = [&](Code* code) {
-        ForceDominanceAnalysis analysis(cls, code, log);
-        analysis();
+        std::unordered_set<Force*> toInline;
+        ForcedBy result;
 
-        auto& result = analysis.result();
-        if (result.eagerLikeFunction(cls))
-            cls->properties.set(ClosureVersion::Property::IsEager);
-        cls->properties.argumentForceOrder = result.argumentForceOrder;
+        {
+            ForceDominanceAnalysis analysis(cls, code, log);
+            analysis();
+
+            result = analysis.result();
+            if (result.eagerLikeFunction(cls))
+                cls->properties.set(ClosureVersion::Property::IsEager);
+            cls->properties.argumentForceOrder = result.argumentForceOrder;
+
+            Visitor::run(code->entry, [&](BB* bb) {
+                for (const auto& i : *bb) {
+                    if (auto f = Force::Cast(i)) {
+                        if (result.isDominatingForce(f)) {
+                            f->strict = true;
+                            if (auto mkarg =
+                                    MkArg::Cast(f->followCastsAndForce())) {
+                                if (!mkarg->isEager()) {
+                                    if (analysis
+                                            .at<ForceDominanceAnalysis::
+                                                    PositioningStyle::
+                                                        BeforeInstruction>(f)
+                                            .isSafeToInline(mkarg)) {
+                                        toInline.insert(f);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
 
         std::unordered_map<Force*, Value*> inlinedPromise;
         std::unordered_map<Instruction*, MkArg*> forcedMkArg;
@@ -387,52 +399,45 @@ void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
             while (ip != bb->end()) {
                 auto next = ip + 1;
                 if (auto f = Force::Cast(*ip)) {
-                    if (result.isDominatingForce(f))
-                        f->strict = true;
-
                     if (auto mkarg = MkArg::Cast(f->followCastsAndForce())) {
                         if (mkarg->isEager()) {
                             Value* eager = mkarg->eagerArg();
                             f->replaceUsesWith(eager);
                             next = bb->remove(ip);
-                        } else if (result.isDominatingForce(f)) {
-                            if (result.isSafeToInline(mkarg)) {
-                                Promise* prom = mkarg->prom();
-                                BB* split = BBTransform::split(code->nextBBId++,
-                                                               bb, ip, code);
-                                BB* prom_copy =
-                                    BBTransform::clone(prom->entry, code, cls);
-                                bb->overrideNext(prom_copy);
+                        } else if (toInline.count(f)) {
+                            Promise* prom = mkarg->prom();
+                            BB* split = BBTransform::split(code->nextBBId++, bb,
+                                                           ip, code);
+                            BB* prom_copy =
+                                BBTransform::clone(prom->entry, code, cls);
+                            bb->overrideNext(prom_copy);
 
-                                // For now we assume every promise starts with a
-                                // LdFunctionEnv instruction. We replace it's
-                                // usages with the caller environment.
-                                LdFunctionEnv* e =
-                                    LdFunctionEnv::Cast(*prom_copy->begin());
-                                assert(e);
-                                Replace::usesOfValue(prom_copy, e,
-                                                     mkarg->promEnv());
-                                prom_copy->remove(prom_copy->begin());
+                            // For now we assume every promise starts with a
+                            // LdFunctionEnv instruction. We replace it's
+                            // usages with the caller environment.
+                            LdFunctionEnv* e =
+                                LdFunctionEnv::Cast(*prom_copy->begin());
+                            assert(e);
+                            Replace::usesOfValue(prom_copy, e,
+                                                 mkarg->promEnv());
+                            prom_copy->remove(prom_copy->begin());
 
-                                // Create a return value phi of the promise
-                                Value* promRes =
-                                    BBTransform::forInline(prom_copy, split)
-                                        .first;
+                            // Create a return value phi of the promise
+                            Value* promRes =
+                                BBTransform::forInline(prom_copy, split).first;
 
-                                f = Force::Cast(*split->begin());
-                                assert(f);
-                                f->replaceUsesWith(promRes);
-                                split->remove(split->begin());
+                            f = Force::Cast(*split->begin());
+                            assert(f);
+                            f->replaceUsesWith(promRes);
+                            split->remove(split->begin());
 
-                                MkArg* fixedMkArg = new MkArg(
-                                    mkarg->prom(), promRes, mkarg->promEnv());
-                                next =
-                                    split->insert(split->begin(), fixedMkArg);
-                                forcedMkArg[mkarg] = fixedMkArg;
+                            MkArg* fixedMkArg = new MkArg(
+                                mkarg->prom(), promRes, mkarg->promEnv());
+                            next = split->insert(split->begin(), fixedMkArg);
+                            forcedMkArg[mkarg] = fixedMkArg;
 
-                                inlinedPromise[f] = promRes;
-                                break;
-                            }
+                            inlinedPromise[f] = promRes;
+                            break;
                         }
                     }
                 } else if (auto cast = CastType::Cast(*ip)) {
@@ -480,7 +485,7 @@ void ForceDominance::apply(RirCompiler&, ClosureVersion* cls,
 
         // 3. replace remaining uses of the mkarg itself
         for (auto m : forcedMkArg) {
-            m.first->replaceUsesWithLimits(m.second, m.second->bb(), m.first);
+            m.first->replaceReachableUses(m.second);
             if (m.first->unused())
                 m.first->eraseAndRemove();
         }

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -97,10 +97,14 @@ struct ForcedBy {
     }
 
     bool escape(Value* val) {
+        if (forcedBy.count(val) && forcedBy.at(val) != ambiguous())
+            return false;
+
         if (!escaped.count(val)) {
             escaped.insert(val);
             return true;
         }
+
         return false;
     }
 

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -57,7 +57,6 @@ PassScheduler::PassScheduler() {
     // This pass is scheduled second, since we want to first try to do this
     // statically in Phase 1
     add<TypeSpeculation>();
-    add<ElideEnvSpec>();
     addDefaultOpt();
     add<TypeSpeculation>();
     add<ElideEnvSpec>();

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -365,7 +365,7 @@ class TheScopeResolution {
                                         ip = bb->insert(ip, deoptEnv);
                                         ip++;
                                         next = ip + 1;
-                                        mk->replaceUsesWithLimits(deoptEnv, bb);
+                                        mk->replaceReachableUses(deoptEnv);
                                     });
                             }
                         }

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -212,7 +212,7 @@ class TheScopeResolution {
             }
 
             for (auto& phi : thePhis)
-                phi.second->updateType();
+                phi.second->updateTypeAndEffects();
 
             return thePhis.at(pl.targetPhiPosition);
         };

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -333,8 +333,7 @@ class TheScopeResolution {
                 if (bb->isDeopt()) {
                     if (auto fs = FrameState::Cast(i)) {
                         if (auto mk = MkEnv::Cast(fs->env())) {
-                            if (mk->context == 1 && !mk->stub &&
-                                mk->bb() != bb &&
+                            if (mk->context == 1 && mk->bb() != bb &&
                                 mk->usesAreOnly(
                                     function->entry,
                                     {Tag::FrameState, Tag::StVar})) {

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -25,8 +25,9 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
             auto next = ip + 1;
             auto i = *ip;
             bool trigger = false;
-            if (Force::Cast(i)) {
-                if (!i->type.isA(i->typeFeedback)) {
+            if (!i->typeFeedback.isVoid() && !i->type.isA(i->typeFeedback)) {
+                switch (i->tag) {
+                case Tag::Force: {
                     auto arg = i->arg(0).val()->followCasts();
                     // Blacklist of where it is not worthwhile
                     if (!LdConst::Cast(arg) &&
@@ -36,21 +37,29 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                         !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
                         trigger = true;
                     }
+                    break;
+                }
+                case Tag::Add:
+                case Tag::Mul:
+                case Tag::Sub:
+                case Tag::Div:
+                    trigger = true;
+                    break;
+                default: {}
                 }
             }
             if (trigger) {
-                PirType type = i->typeFeedback;
-                if (!type.isVoid() && !i->type.isA(type)) {
+                PirType seen = i->typeFeedback;
+                if (!seen.isVoid() && !seen.maybeObj() && !i->type.isA(seen)) {
                     if (auto cp = checkpoint.next(i)) {
-                        if (!type.maybeObj()) {
-                            PirType specType = (type.isA(RType::integer) ||
-                                                type.isA(RType::real))
-                                                   ? type
-                                                   : i->type.notObject();
-                            speculate[cp][i] = specType;
-                            // Prevent redundant speculation
-                            i->typeFeedback = i->type;
-                        }
+                        auto assume =
+                            (seen.isA(RType::integer) || seen.isA(RType::real))
+                                ? seen
+                                : i->type.notObject();
+                        if (!i->type.isA(assume))
+                            speculate[cp][i] = assume;
+                        // Prevent redundant speculation
+                        i->typeFeedback = i->type;
                     }
                 }
             }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -109,9 +109,8 @@ void Instruction::printEffects(std::ostream& out, bool tty) const {
             CASE(LeaksEnv, "L")
             CASE(TriggerDeopt, "D")
             CASE(ExecuteCode, "X")
+            CASE(DependsOnAssume, "d")
 #undef CASE
-        default:
-            assert(false);
         }
     }
 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -45,6 +45,8 @@ extern std::ostream& operator<<(std::ostream& out,
     return out;
 }
 
+constexpr Effects Instruction::errorWarnVisible;
+
 void Instruction::printRef(std::ostream& out) const {
     if (type == RType::env)
         out << "e" << id();
@@ -486,15 +488,6 @@ void Is::printArgs(std::ostream& out, bool tty) const {
 void IsType::printArgs(std::ostream& out, bool tty) const {
     arg<0>().val()->printRef(out);
     out << " isA " << typeTest;
-}
-
-void Phi::updateType() {
-    type = arg(0).val()->type;
-    eachArg([&](BB*, Value* v) -> void { type = type | v->type; });
-    typeFeedback = arg(0).val()->type;
-    eachArg([&](BB*, Value* v) -> void {
-        typeFeedback = typeFeedback | v->typeFeedback;
-    });
 }
 
 void Phi::printArgs(std::ostream& out, bool tty) const {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1067,7 +1067,9 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() const { return arg(2).val(); }
 
     PirType inferType(const TypeOf& typeof) const override final {
-        return ifNonObjectArgs(typeof, type & typeof(rhs()), type);
+        return ifNonObjectArgs(typeof,
+            type & (typeof(rhs()) | typeof(lhs())),
+            type);
     }
     Effects inferEffects(const TypeOf& typeof) const override final {
         return ifNonObjectArgs(typeof, effects & errorWarnVisible, effects);
@@ -1087,7 +1089,9 @@ class FLIE(Subassign2_1D, 4, Effects::Any()) {
     Value* idx() const { return arg(2).val(); }
 
     PirType inferType(const TypeOf& typeof) const override final {
-        return ifNonObjectArgs(typeof, type & typeof(rhs()), type);
+        return ifNonObjectArgs(typeof,
+            type & (typeof(rhs()) | typeof(lhs())),
+            type);
     }
     Effects inferEffects(const TypeOf& typeof) const override final {
         return ifNonObjectArgs(typeof, effects & errorWarnVisible, effects);
@@ -1109,7 +1113,9 @@ class FLIE(Subassign1_2D, 5, Effects::Any()) {
     Value* idx2() const { return arg(3).val(); }
 
     PirType inferType(const TypeOf& typeof) const override final {
-        return ifNonObjectArgs(typeof, type & typeof(rhs()), type);
+        return ifNonObjectArgs(typeof,
+            type & (typeof(rhs()) | typeof(lhs())),
+            type);
     }
     Effects inferEffects(const TypeOf& typeof) const override final {
         return ifNonObjectArgs(typeof, effects & errorWarnVisible, effects);
@@ -1131,7 +1137,9 @@ class FLIE(Subassign2_2D, 5, Effects::Any()) {
     Value* idx2() const { return arg(3).val(); }
 
     PirType inferType(const TypeOf& typeof) const override final {
-        return ifNonObjectArgs(typeof, type & typeof(rhs()), type);
+        return ifNonObjectArgs(typeof,
+            type & (typeof(rhs()) | typeof(lhs())),
+            type);
     }
     Effects inferEffects(const TypeOf& typeof) const override final {
         return ifNonObjectArgs(typeof, effects & errorWarnVisible, effects);
@@ -1625,7 +1633,7 @@ struct RirStack {
  *  Collects metadata about the current state of variables
  *  eventually needed for deoptimization purposes
  */
-class VLIE(FrameState, Effect::LeaksEnv) {
+class VLIE(FrameState, Effects(Effect::LeaksEnv) | Effect::ReadsEnv) {
   public:
     bool inlined = false;
     Opcode* pc;

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -458,6 +458,11 @@ struct PirType {
     bool isInstance(SEXP val) const;
 
     void print(std::ostream& out = std::cout) const;
+
+    size_t hash() const {
+        return hash_combine(flags_.to_i(),
+                            isRType() ? t_.r.to_i() : t_.n.to_i());
+    }
 };
 
 inline std::ostream& operator<<(std::ostream& out, NativeType t) {
@@ -599,5 +604,12 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
 }
 } // namespace pir
 } // namespace rir
+
+namespace std {
+template <>
+struct hash<rir::pir::PirType> {
+    size_t operator()(const rir::pir::PirType& t) const { return t.hash(); }
+};
+}
 
 #endif

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -571,6 +571,9 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
         out << "val";
     } else if (t.isRType() && PirType::val().baseType() == t.baseType()) {
         out << "val?";
+    } else if (t.isRType() &&
+               PirType::num().notMissing().baseType() == t.baseType()) {
+        out << "num";
     } else {
         if (t.t_.r.count() > 1)
             out << "(";

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -353,10 +353,8 @@ struct PirType {
             return RType::nil;
         }
         if (isA(num() | RType::str | RType::cons | RType::code)) {
-            if (idx.isScalar())
-                return scalar();
-            else
-                return orNotScalar();
+            // e.g. c(1,2,3)[-1] returns c(2,3)
+            return orNotScalar();
         } else if (isA(RType::vec)) {
             return RType::vec;
         } else if (!maybeObj() && !PirType(RType::prom).isA(*this)) {

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -41,7 +41,6 @@ static ClosureVersion* recompilePir(SEXP f, Module* m) {
         []() { Rf_warning("pir check failed: couldn't compile"); });
 
     cmp.optimizeModule();
-    cmp.optimizeModule(); // TODO: Why is this needed twice?
     return res;
 }
 

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -542,7 +542,7 @@ bool testTypeRules() {
     assert(r2.subsetType(RType::real).isA(RType::logical));
     assert(!r2.subsetType(RType::integer).isScalar());
     assert(!r2.scalar().subsetType(RType::integer).isScalar());
-    assert(r2.subsetType(PirType(RType::integer).scalar()).isScalar());
+    assert(!r2.subsetType(PirType(RType::integer).scalar()).isScalar());
     assert(r2.extractType(RType::integer).isScalar());
     assert(!r2.subsetType(PirType::any()).maybeObj());
     return true;

--- a/rir/src/compiler/transform/insert_cast.cpp
+++ b/rir/src/compiler/transform/insert_cast.cpp
@@ -33,7 +33,7 @@ void InsertCast::apply(BB* bb) {
         Instruction* instr = *ip;
         Phi* p = nullptr;
         if ((p = Phi::Cast(instr))) {
-            p->updateType();
+            p->updateTypeAndEffects();
         }
         instr->eachArg([&](InstrArg& arg) {
             while (!arg.type().isSuper(arg.val()->type)) {

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -700,7 +700,7 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                     else
                         cb.add(BC::is(TypeChecks::RealNonObject));
                 } else {
-                    assert(false);
+                    t.print(std::cout);
                 }
                 break;
             }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -1119,7 +1119,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) const {
             r.first->setNext(merge);
             phi->addInput(r.first, r.second);
         }
-        phi->updateType();
+        phi->updateTypeAndEffects();
         res = phi;
     }
 
@@ -1170,7 +1170,7 @@ void Rir2Pir::finalize(Value* ret, Builder& insert) {
                     continue;
                 }
                 auto t = p->type;
-                p->updateType();
+                p->updateTypeAndEffects();
                 if (t != p->type)
                     changed = true;
                 it++;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3772,6 +3772,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
                 std::cerr << "type " << typ << " not accurate for value ("
                           << pir::PirType(val) << "):\n";
                 Rf_PrintValue(val);
+                std::cout << "\n";
                 assert(false);
             }
             NEXT();


### PR DESCRIPTION
unify all the type inference logic in Intruction, let the type inference
pass reuse the logic from the instruction.

cleanup and disentangle effect and type inference.

fix type inference for binops (did cast away object flag). Fix
regressions by adding binops to speculated on instructions.