### PR TITLE
test serialization only on ./bin/tests, and fix memory leaks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ tests_fullverify:
     - bin/tests
     - bin/gnur-make-tests check-devel
 
-# Test particular features, like deoptimization
+# Test particular features, like deoptimization and serialization
 test_features:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
@@ -110,6 +110,8 @@ test_features:
     - PIR_NATIVE_BACKEND=1 ./bin/tests
     - PIR_DEOPT_CHAOS=1 PIR_INLINER_MAX_INLINEE_SIZE=800 bin/gnur-make-tests check
     - PIR_WARMUP=2 PIR_DEOPT_CHAOS=1 ./bin/gnur-make-tests check
+    - RIR_SERIALIZE_CHAOS=1 ./bin/tests
+    - RIR_SERIALIZE_CHAOS=3 ./bin/tests
 
 # Run ubsan and gc torture
 test_sanitize:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ test_features:
     - PIR_DEOPT_CHAOS=1 PIR_INLINER_MAX_INLINEE_SIZE=800 bin/gnur-make-tests check
     - PIR_WARMUP=2 PIR_DEOPT_CHAOS=1 ./bin/gnur-make-tests check
     - RIR_SERIALIZE_CHAOS=1 ./bin/tests
-    - RIR_SERIALIZE_CHAOS=3 ./bin/tests
+    - RIR_SERIALIZE_CHAOS=10 ./bin/tests
 
 # Run ubsan and gc torture
 test_sanitize:

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -259,7 +259,8 @@ void BC::deserialize(SEXP refTable, R_inpstream_t inp, Opcode* code,
             SEXP store = Rf_allocVector(RAWSXP, size);
             memcpy(DATAPTR(store), meta, size);
             i.pool = Pool::insert(store);
-            delete meta;
+            meta->~DeoptMetadata();
+            ::operator delete(meta, size);
             break;
         }
         case Opcode::assert_type_:

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -455,7 +455,8 @@ BC_NOARGS(V, _)
     struct MkEnvExtraInformation : public ExtraInformation {
         std::vector<BC::PoolIdx> names;
     };
-    std::unique_ptr<ExtraInformation> extraInformation = nullptr;
+    std::unique_ptr<ExtraInformation, std::function<void(ExtraInformation*)>>
+        extraInformation = nullptr;
 
   public:
     MkEnvExtraInformation& mkEnvExtra() const {
@@ -501,15 +502,27 @@ BC_NOARGS(V, _)
         case Opcode::call_implicit_:
         case Opcode::named_call_implicit_:
         case Opcode::named_call_: {
+            extraInformation.get_deleter() = [](auto x) {
+                auto y = (CallInstructionExtraInformation*)x;
+                delete y;
+            };
             extraInformation.reset(new CallInstructionExtraInformation);
             break;
         }
         case Opcode::record_call_: {
+            extraInformation.get_deleter() = [](auto x) {
+                auto y = (CallFeedbackExtraInformation*)x;
+                delete y;
+            };
             extraInformation.reset(new CallFeedbackExtraInformation);
             break;
         }
         case Opcode::mk_stub_env_:
         case Opcode::mk_env_: {
+            extraInformation.get_deleter() = [](auto x) {
+                auto y = (MkEnvExtraInformation*)x;
+                delete y;
+            };
             extraInformation.reset(new MkEnvExtraInformation);
             break;
         }

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -455,8 +455,7 @@ BC_NOARGS(V, _)
     struct MkEnvExtraInformation : public ExtraInformation {
         std::vector<BC::PoolIdx> names;
     };
-    std::unique_ptr<ExtraInformation, std::function<void(ExtraInformation*)>>
-        extraInformation = nullptr;
+    std::unique_ptr<ExtraInformation> extraInformation = nullptr;
 
   public:
     MkEnvExtraInformation& mkEnvExtra() const {
@@ -502,27 +501,15 @@ BC_NOARGS(V, _)
         case Opcode::call_implicit_:
         case Opcode::named_call_implicit_:
         case Opcode::named_call_: {
-            extraInformation.get_deleter() = [](auto x) {
-                auto y = (CallInstructionExtraInformation*)x;
-                delete y;
-            };
             extraInformation.reset(new CallInstructionExtraInformation);
             break;
         }
         case Opcode::record_call_: {
-            extraInformation.get_deleter() = [](auto x) {
-                auto y = (CallFeedbackExtraInformation*)x;
-                delete y;
-            };
             extraInformation.reset(new CallFeedbackExtraInformation);
             break;
         }
         case Opcode::mk_stub_env_:
         case Opcode::mk_env_: {
-            extraInformation.get_deleter() = [](auto x) {
-                auto y = (MkEnvExtraInformation*)x;
-                delete y;
-            };
             extraInformation.reset(new MkEnvExtraInformation);
             break;
         }

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -79,6 +79,7 @@ unsigned Code::getSrcIdxAt(const Opcode* pc, bool allowMissing) const {
 Code* Code::deserialize(SEXP refTable, R_inpstream_t inp) {
     size_t size = InInteger(inp);
     Code* code = (Code*)::operator new(size);
+    code->nativeCode = NULL; // TODO Serialize/deserialize native if possible
     code->uid = UUID::deserialize(refTable, inp) ^ uidHash;
     code->funInvocationCount = InInteger(inp);
     code->src = InInteger(inp);

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -105,7 +105,8 @@ Code* Code::deserialize(SEXP refTable, R_inpstream_t inp) {
     memcpy(DATAPTR(store), code, size);
     Code* old = code;
     code = (Code*)DATAPTR(store);
-    delete old;
+    old->~Code();
+    ::operator delete(old, size);
     code->info = {// GC area starts just after the header
                   (uint32_t)((intptr_t)&code->locals_ - (intptr_t)code),
                   // GC area has only 1 pointer


### PR DESCRIPTION
this should use much less RAM than gnur-tests