### PR TITLE
Use more precise type checks in elide_env_spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ matrix:
       env:
         - CXX_OVERRIDE=clang++
         - CC_OVERRIDE=clang
+        - PIR_MAX_INPUT_SIZE=1000
+        - PIR_INLINER_MAX_SIZE=800
         - BUILD=debugopt
         - CHECK=check
-        - PIR_WARMUP=2
+
       compiler: clang
 
     - env:

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -64,20 +64,22 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
             auto instr = *ip;
 
             // Remove Unneccessary checkpoints. If we arrive at a checkpoint and
-            // the previous checkpoint is still available, we might as well take
-            // this one.
+            // the previous checkpoint is still available, and there is also a
+            // next checkpoint available we might as well remove this one.
             if (auto cp = Checkpoint::Cast(instr)) {
                 if (auto cp0 = checkpoint.at(instr)) {
-                    while (replaced.count(cp0))
-                        cp0 = replaced.at(cp0);
-                    replaced[cp] = cp0;
+                    if (checkpoint.next(instr)) {
+                        while (replaced.count(cp0))
+                            cp0 = replaced.at(cp0);
+                        replaced[cp] = cp0;
 
-                    assert(bb->last() == instr);
-                    cp->replaceUsesWith(cp0);
-                    bb->remove(ip);
-                    delete bb->next1;
-                    bb->next1 = nullptr;
-                    return;
+                        assert(bb->last() == instr);
+                        cp->replaceUsesWith(cp0);
+                        bb->remove(ip);
+                        delete bb->next1;
+                        bb->next1 = nullptr;
+                        return;
+                    }
                 }
             }
 

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -39,6 +39,7 @@ PassScheduler::PassScheduler() {
         add<OptimizeContexts>();
         add<LoadElision>();
         add<GVN>();
+        add<OptimizeAssumptions>();
         add<Cleanup>();
         add<TypeInference>();
     };
@@ -59,7 +60,6 @@ PassScheduler::PassScheduler() {
     addDefaultOpt();
     add<TypeSpeculation>();
     add<ElideEnvSpec>();
-    add<OptimizeAssumptions>();
 
     add<PhaseMarker>("Phase 2: Env speculation");
 
@@ -81,7 +81,6 @@ PassScheduler::PassScheduler() {
     //
     // After this pass it is no longer possible to inline callees with deopts
     add<CleanupFramestate>();
-    add<OptimizeAssumptions>();
     add<CleanupCheckpoints>();
 
     add<PhaseMarker>("Phase 3: Cleanup Checkpoints");
@@ -89,7 +88,6 @@ PassScheduler::PassScheduler() {
     // ==== Phase 4) Final round of default opts
     for (size_t i = 0; i < 3; ++i) {
         addDefaultOpt();
-        add<OptimizeAssumptions>();
         add<CleanupCheckpoints>();
     }
     add<PhaseMarker>("Phase 4: finished");


### PR DESCRIPTION
this allows for more unboxing in the native backend.

also fix the optimize assumptions pass: don't remove checkpoints that might be needed for elide_env_spec