### PR TITLE
scope analysis reports wrong environment

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -123,14 +123,16 @@ AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
     while (env != AbstractREnvironment::UnknownParent) {
         assert(env);
         if (envs.count(env) == 0)
-            return AbstractLoad(env, AbstractPirValue::tainted());
+            return AbstractLoad(AbstractREnvironment::UnknownParent,
+                                AbstractPirValue::tainted());
         auto aenv = envs.at(env);
         if (!aenv.absent(e)) {
             const AbstractPirValue& res = aenv.get(e);
             // UnboundValue has fall-through semantics which cause lookup to
             // fall through.
             if (res.maybeUnboundValue())
-                return AbstractLoad(env, AbstractPirValue::tainted());
+                return AbstractLoad(AbstractREnvironment::UnknownParent,
+                                    AbstractPirValue::tainted());
             if (!res.isUnboundValue())
                 return AbstractLoad(env, res);
         }

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -135,4 +135,15 @@ g(TRUE)
 g(FALSE)
 g(TRUE)
 delayedAssign("c", fail())
-g(FALSE)  
+g(FALSE)
+
+f0 <- function() {
+    for (i in 1:10)
+        last <- i
+    last
+}
+f0()
+f0()
+f0()
+f0()
+


### PR DESCRIPTION
two cases where scope analysis does not know from which environment a
variable originates, but still claimed it did know. This caused
scope_resolution to erroneously update the environment of load
instructions.