### PR TITLE
Remove dead phis

### DIFF
--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -32,7 +32,9 @@ class BBTransform {
     // from smaller id to bigger id, except for back-edges.
     static void renumber(Code* fun);
 
-    // Remove dead instructions (instead of waiting until the cleanup pass)
+    // Remove dead instructions (instead of waiting until the cleanup pass).
+    // Note that a phi is dead if it is not used by any instruction, or it is
+    // used only by dead phis.
     static void removeDeadInstrs(Code* fun);
 };
 


### PR DESCRIPTION
First commit:

```
    // Scope resolution can sometimes generate dead phis, so we remove them
    // here, before they cause errors in later compiler passes. (Sometimes, the
    // verifier will even catch these errors, but then segfault when trying to
    // print the offending instruction.)
    //
    // This happens because we use the standard phi placement algorithm but in
    // a different setting. The algorithm assumes it is examining the whole
    // program and inserting phis for all writes. In our setting, we want to
    // connect LdVars with StVars, replacing the LdVar with a phi if multiple
    // stores reach that load.
    //
    // However, if there is no LdVar to replace, that means the phi is dead;
    // none of the successor instructions needs that value. The problem is when
    // dead phis are malformed.
```

Second commit:

```
... [A] phi that refers to itself is considered live.
Furthermore, a phi referred to by a dead phi would also be considered
live. Therefore, we have to construct a dependency graph and then do a
DFS traversal -- if we reach a non-phi instruction then the phi is
alive. Otherwise, nothing live refers to the phi, so it can be removed.
```