### PR TITLE
Properly fix #539

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -129,9 +129,9 @@ AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
         env = aliases.at(env);
     while (env != AbstractREnvironment::UnknownParent) {
         assert(env);
-        if (envs.count(env) == 0)
-            return AbstractLoad(AbstractREnvironment::UnknownParent,
-                                AbstractPirValue::tainted());
+        if (envs.count(env) == 0) {
+            return AbstractLoad(env, AbstractPirValue::tainted());
+        }
         auto aenv = envs.at(env);
         if (!aenv.absent(e)) {
             const AbstractPirValue& res = aenv.get(e);

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -121,6 +121,8 @@ struct AbstractPirValue {
     }
 
     bool isUnboundValue() const {
+        if (unknown)
+            return false;
         if (vals.empty())
             return false;
         for (auto& v : vals)
@@ -130,6 +132,8 @@ struct AbstractPirValue {
     }
 
     bool maybeUnboundValue() const {
+        if (unknown)
+            return true;
         if (vals.empty())
             return false;
         for (auto& v : vals)
@@ -233,6 +237,7 @@ struct AbstractREnvironment {
                                  res.max(copy.merge(AbstractPirValue(
                                      UnboundValue::instance(), nullptr, 0)));
                                  entries.insert(name, copy);
+                                 res.update();
                              });
         }
         for (auto& entry : entries) {

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -92,7 +92,6 @@ class ScopeAnalysis
     static constexpr size_t MAX_RESULTS = 1000;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();
-    using StaticAnalysis::PositioningStyle;
 
     AbstractResult doCompute(ScopeAnalysisState& state, Instruction* i,
                              bool updateGlobalState);
@@ -109,6 +108,8 @@ class ScopeAnalysis
     }
 
   public:
+    using StaticAnalysis::PositioningStyle;
+
     // Default
     ScopeAnalysis(ClosureVersion* cls, LogStream& log)
         : StaticAnalysis("Scope", cls, cls, log), depth(0) {

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -97,6 +97,7 @@ stopifnot(pir.check(function(x) {
   (function() a <<- 1)()
 }, NoStore))
 stopifnot(!pir.check(function(x) {
+  leak()
   (function() a <<- 1)()
 }, NoStSuper))
 stopifnot(!pir.check(function(x) {


### PR DESCRIPTION
The "fix" in #539 was just masking another bug:

When merging two abstract environments in scope analysis and one of them
contains a binding and the other one does not, it can happen that the
merged environment was not marked as updated and subsequently the
analysis would terminate before reaching a fix point.