### PR TITLE
Call with explicit promises

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -186,11 +186,6 @@ class TheVerifier {
                           << p->owner->name() << "\n";
                 ok = false;
             }
-            if (mk->isEager() && mk->hasEnv()) {
-                mk->printRef(std::cerr);
-                std::cerr << " is evaluated, but still has env reference\n";
-                ok = false;
-            }
         }
 
         if (i->branchOrExit())

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -33,7 +33,9 @@ class TheCleanup {
                 auto next = ip + 1;
                 bool removed = false;
                 bool isDead = dead.unused(i);
-                if (!i->hasObservableEffects() && isDead) {
+                // unused ldfun is a left over from a guard where ldfun was
+                // converted into ldvar.
+                if ((!i->hasObservableEffects() || LdFun::Cast(i)) && isDead) {
                     removed = true;
                     next = bb->remove(ip);
                 } else if (isDead &&

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -5,6 +5,7 @@
 #include "../util/visitor.h"
 #include "R/r.h"
 #include "compiler/util/safe_builtins_list.h"
+#include "interpreter/builtins.h"
 #include "pass_definitions.h"
 
 #include <unordered_map>
@@ -62,11 +63,10 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                     return;
                 if (CallInstruction::CastCall(i)) {
                     if (auto bt = CallBuiltin::Cast(i)) {
-                        if (SafeBuiltinsList::forInline(bt->builtinId)) {
+                        // Calling a builtin materializes environment, except
+                        // for the fastcases
+                        if (supportsFastBuiltinCall(bt->blt))
                             return;
-                        }
-                        // reflective builtins will trigger deopt, so let's not
-                        // stub those environemtns
                     } else {
                         return;
                     }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -267,7 +267,7 @@ class TheInliner {
                                         version->promises().at(newPromId[id]));
                                 } else {
                                     Promise* clone = version->createProm(
-                                        mk->prom()->srcPoolIdx());
+                                        mk->prom()->rirSrc());
                                     BB* promCopy = BBTransform::clone(
                                         mk->prom()->entry, clone, version);
                                     clone->entry = promCopy;

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -74,8 +74,8 @@ void ClosureVersion::printBBGraph(std::ostream& out,
     out << "}\n";
 }
 
-Promise* ClosureVersion::createProm(unsigned srcPoolIdx) {
-    Promise* p = new Promise(this, promises_.size(), srcPoolIdx);
+Promise* ClosureVersion::createProm(rir::Code* rirSrc) {
+    Promise* p = new Promise(this, promises_.size(), rirSrc);
     promises_.push_back(p);
     return p;
 }

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -78,7 +78,7 @@ class ClosureVersion : public Code {
     void printGraph(std::ostream& out, bool omitDeoptBranches) const;
     void printBBGraph(std::ostream& out, bool omitDeoptBranches) const;
 
-    Promise* createProm(unsigned srcPoolIdx);
+    Promise* createProm(rir::Code* rirSrc);
 
     Promise* promise(unsigned id) const { return promises_.at(id); }
     const std::vector<Promise*>& promises() { return promises_; }

--- a/rir/src/compiler/pir/env.cpp
+++ b/rir/src/compiler/pir/env.cpp
@@ -19,14 +19,19 @@ void Env::printRef(std::ostream& out) const {
         out << "nil";
         return;
     }
+
     assert(rho);
-    std::string val;
-    {
+    if (rho == R_GlobalEnv) {
+        out << "GlobalEnv";
+    } else if (rho == R_BaseNamespace) {
+        out << "BaseNamespace";
+    } else {
+        std::string val;
         CaptureOut rec;
         Rf_PrintValue(rho);
         val = rec();
+        out << val.substr(0, val.length() - 1);
     }
-    out << val.substr(0, val.length() - 1);
 }
 
 bool Env::isStaticEnv(Value* v) {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -845,6 +845,7 @@ void Checkpoint::printGraphBranches(std::ostream& out, size_t bbId) const {
 }
 
 BB* Checkpoint::deoptBranch() { return bb()->falseBranch(); }
+BB* Checkpoint::nextBB() { return bb()->trueBranch(); }
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -912,20 +912,8 @@ class FLIE(MkArg, 2, Effects::None()) {
                                          env),
           prom_(prom) {
         assert(eagerArg() == v);
-        if (isEager()) {
+        if (isEager())
             noReflection = true;
-            elideEnv();
-        }
-    }
-    MkArg(Value* v, Value* env)
-        : FixedLenInstructionWithEnvSlot(RType::prom, {{PirType::val()}}, {{v}},
-                                         env),
-          prom_(nullptr) {
-        assert(eagerArg() == v);
-        if (isEager()) {
-            noReflection = true;
-            elideEnv();
-        }
     }
 
     Value* eagerArg() const { return arg(0).val(); }
@@ -2077,6 +2065,7 @@ class Checkpoint : public FixedLenInstruction<Tag::Checkpoint, Checkpoint, 0,
     void printGraphArgs(std::ostream& out, bool tty) const override;
     void printGraphBranches(std::ostream& out, size_t bbId) const override;
     BB* deoptBranch();
+    BB* nextBB();
 };
 
 /*

--- a/rir/src/compiler/pir/promise.cpp
+++ b/rir/src/compiler/pir/promise.cpp
@@ -1,11 +1,12 @@
 #include "promise.h"
 #include "interpreter/instance.h"
+#include "ir/BC.h"
 
 namespace rir {
 namespace pir {
 
-Promise::Promise(ClosureVersion* owner, unsigned id, unsigned src)
-    : id(id), owner(owner), srcPoolIdx_(src) {
+Promise::Promise(ClosureVersion* owner, unsigned id, rir::Code* rirSrc)
+    : id(id), owner(owner), rirSrc_(rirSrc), srcPoolIdx_(rirSrc->src) {
     assert(src_pool_at(globalContext(), srcPoolIdx_));
 }
 

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -17,11 +17,13 @@ class Promise : public Code {
     }
 
     unsigned srcPoolIdx() const;
+    rir::Code* rirSrc() { return rirSrc_; }
 
   private:
+    rir::Code* rirSrc_;
     const unsigned srcPoolIdx_;
     friend class ClosureVersion;
-    Promise(ClosureVersion* owner, unsigned id, unsigned src);
+    Promise(ClosureVersion* owner, unsigned id, rir::Code* rirSrc);
 };
 
 } // namespace pir

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -84,8 +84,8 @@ static bool testNoEnvSpec(ClosureVersion* f) { return Query::noEnvSpec(f); }
 static bool testNoEnv(ClosureVersion* f) { return Query::noEnv(f); }
 
 static bool testNoPromise(ClosureVersion* f) {
-    return Visitor::check(f->entry,
-                          [&](Instruction* i) { return !MkArg::Cast(i); });
+    return VisitorNoDeoptBranch::check(
+        f->entry, [&](Instruction* i) { return !MkArg::Cast(i); });
 }
 
 static bool testNoExternalCalls(ClosureVersion* f) {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -48,7 +48,8 @@ class Rir2Pir {
     LogStream& log;
     std::string name;
 
-    typedef std::unordered_map<Value*, ObservedCallees> CallTargetFeedback;
+    typedef std::unordered_map<Value*, std::pair<Checkpoint*, ObservedCallees>>
+        CallTargetFeedback;
 
     bool compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                    rir::Code* srcCode, RirStack&, Builder&,

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -101,7 +101,6 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
     auto& log = logger.begin(version);
     Rir2Pir rir2pir(*this, closure->rirFunction(), log, closure->name());
 
-    Protect protect;
     auto& assumptions = version->assumptions();
 
     bool failedToCompileDefaultArgs = false;
@@ -113,7 +112,7 @@ void Rir2PirCompiler::compileClosure(Closure* closure,
             // are not compiled.
             // TODO: why are they sometimes not compiled??
             auto funexp = rir::Compiler::compileExpression(arg);
-            protect(funexp);
+            preserve_(funexp);
             arg = Function::unpack(funexp)->body()->container();
         }
         if (rir::Code::check(arg)) {

--- a/rir/src/interpreter/builtins.cpp
+++ b/rir/src/interpreter/builtins.cpp
@@ -464,4 +464,34 @@ SEXP tryFastBuiltinCall(const CallContext& call, InterpreterInstance* ctx) {
     }
     return nullptr;
 }
+
+bool supportsFastBuiltinCall(SEXP blt) {
+    switch (blt->u.primsxp.offset) {
+    case 88:  // "length"
+    case 90:  // "c"
+    case 109: // "vector"
+    case 136: // "which"
+    case 301: // "min"
+    case 384: // "is.object"
+    case 386: // "is.numeric"
+    case 387: // "is.matrix"
+    case 388: // "is.array"
+    case 389: // "is.atomic"
+    case 393: // "is.function"
+    case 395: // "is.na"
+    case 399: // "is.vector"
+    case 412: // "list"
+    case 407: // "rep.int"
+    case 507: // "islistfactor"
+    case 678: // "bitwiseAnd"
+    case 680: // "bitwiseOr"
+    case 681: // "bitwiseXor"
+    case 682: // "bitwiseShiftL"
+    case 683: // "bitwiseShiftL"
+        return true;
+    default: {}
+    }
+    return false;
+}
+
 } // namespace rir

--- a/rir/src/interpreter/builtins.h
+++ b/rir/src/interpreter/builtins.h
@@ -7,6 +7,7 @@ namespace rir {
 
 SEXP tryFastSpecialCall(const CallContext& call, InterpreterInstance* ctx);
 SEXP tryFastBuiltinCall(const CallContext& call, InterpreterInstance* ctx);
+bool supportsFastBuiltinCall(SEXP blt);
 
 } // namespace rir
 

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1021,15 +1021,19 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args,
     // Process arguments:
     // Arguments can be optionally named
     std::vector<BC::FunIdx> callArgs;
+    std::vector<SEXP> eagerVal;
     std::vector<SEXP> names;
     Assumptions assumptions;
 
     bool hasNames = false;
     int i = 0;
+    bool unroll = true;
     for (RListIter arg = RList(args).begin(); arg != RList::end(); ++i, ++arg) {
         if (*arg == R_DotsSymbol) {
             callArgs.push_back(DOTS_ARG_IDX);
             names.push_back(R_NilValue);
+            // TODO: figure out how to support dots symbol in call_ bytecode
+            unroll = false;
             continue;
         }
         if (*arg == R_MissingArg) {
@@ -1063,17 +1067,40 @@ void compileCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args,
                     assumptions.setSimpleInt(i);
             }
         }
+        if (known)
+            eagerVal.push_back(known);
+        else
+            eagerVal.push_back(R_UnboundValue);
     }
     assert(callArgs.size() < BC::MAX_NUM_ARGS);
 
-    if (Compiler::profile) {
+    if (Compiler::profile)
         cs << BC::recordCall();
+
+    if (unroll) {
+        size_t i = 0;
+        for (auto& a : callArgs) {
+            if (a == MISSING_ARG_IDX) {
+                cs << BC::push(R_MissingArg);
+            } else {
+                cs << BC::push(eagerVal[i++]);
+                cs << BC::promise(a);
+            }
+        }
     }
     if (hasNames) {
-        cs << BC::callImplicit(callArgs, names, ast, assumptions);
+        if (unroll) {
+            cs << BC::call(callArgs.size(), names, ast, assumptions);
+        } else {
+            cs << BC::callImplicit(callArgs, names, ast, assumptions);
+        }
     } else {
         assumptions.add(Assumption::CorrectOrderOfArguments);
-        cs << BC::callImplicit(callArgs, ast, assumptions);
+        if (unroll) {
+            cs << BC::call(callArgs.size(), ast, assumptions);
+        } else {
+            cs << BC::callImplicit(callArgs, ast, assumptions);
+        }
     }
     if (voidContext)
         cs << BC::pop();


### PR DESCRIPTION
use `call_` in rir instead of `call_implicit_`. Since pir is tuned for `call_implicit_` this needs a whole bunch of changes to the pir optimizer to make speculative inlining still work.