### PR TITLE
Revert "fix printing abstract unbound values"

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -87,13 +87,8 @@ void AbstractPirValue::print(std::ostream& out, bool tty) const {
     for (auto it = vals.begin(); it != vals.end();) {
         auto vo = *it;
         vo.val->printRef(out);
-        if (vo.val != UnboundValue::instance()) {
-            out << "@";
-            vo.origin->printRef(out);
-        } else {
-            assert(vo.origin == NULL);
-            out << "unbound";
-        }
+        out << "@";
+        vo.origin->printRef(out);
         it++;
         if (it != vals.end())
             out << "|";

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -21,9 +21,7 @@ struct ValOrig {
     unsigned recursionLevel;
 
     ValOrig(Value* v, Instruction* o, unsigned recursionLevel)
-        : val(v), origin(o), recursionLevel(recursionLevel) {
-        assert((val == UnboundValue::instance()) == (origin == NULL));
-    }
+        : val(v), origin(o), recursionLevel(recursionLevel) {}
 
     bool operator<(const ValOrig& other) const {
         if (origin == other.origin && recursionLevel == other.recursionLevel)


### PR DESCRIPTION
Reverts reactorlabs/rir#540

@Jakobeha this broke the mandelbrot benchmark. see: https://gitlab.com/rirvm/rir_mirror/-/jobs/252651736