### PR TITLE
two bytecodes for promises with and without eager value

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -532,10 +532,13 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         break;
     }
 
-    case Opcode::promise_: {
+    case Opcode::mk_eager_promise_:
+    case Opcode::mk_promise_: {
         unsigned promi = bc.immediate.i;
         rir::Code* promiseCode = srcCode->getPromise(promi);
-        Value* val = pop();
+        Value* val = UnboundValue::instance();
+        if (bc.bc == Opcode::mk_eager_promise_)
+            val = pop();
         Promise* prom = insert.function->createProm(promiseCode);
         {
             Builder promiseBuilder(insert.function, prom);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -2417,11 +2417,19 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             NEXT();
         }
 
-        INSTRUCTION(promise_) {
+        INSTRUCTION(mk_eager_promise_) {
             Immediate id = readImmediate();
             advanceImmediate();
             SEXP prom = Rf_mkPROMISE(c->getPromise(id)->container(), env);
             SET_PRVALUE(prom, ostack_pop(ctx));
+            ostack_push(ctx, prom);
+            NEXT();
+        }
+
+        INSTRUCTION(mk_promise_) {
+            Immediate id = readImmediate();
+            advanceImmediate();
+            SEXP prom = Rf_mkPROMISE(c->getPromise(id)->container(), env);
             ostack_push(ctx, prom);
             NEXT();
         }

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -98,7 +98,8 @@ BC_NOARGS(V, _)
         cs.insert(immediate.callBuiltinFixedArgs);
         break;
 
-    case Opcode::promise_:
+    case Opcode::mk_promise_:
+    case Opcode::mk_eager_promise_:
     case Opcode::push_code_:
         cs.insert(immediate.fun);
         return;
@@ -272,7 +273,8 @@ void BC::deserialize(SEXP refTable, R_inpstream_t inp, Opcode* code,
             break;
         case Opcode::record_call_:
         case Opcode::record_type_:
-        case Opcode::promise_:
+        case Opcode::mk_promise_:
+        case Opcode::mk_eager_promise_:
         case Opcode::push_code_:
         case Opcode::br_:
         case Opcode::brtrue_:
@@ -410,7 +412,8 @@ void BC::serialize(SEXP refTable, R_outpstream_t out, const Opcode* code,
             break;
         case Opcode::record_call_:
         case Opcode::record_type_:
-        case Opcode::promise_:
+        case Opcode::mk_promise_:
+        case Opcode::mk_eager_promise_:
         case Opcode::push_code_:
         case Opcode::br_:
         case Opcode::brtrue_:
@@ -658,7 +661,8 @@ void BC::print(std::ostream& out) const {
 BC_NOARGS(V, _)
 #undef V
         break;
-    case Opcode::promise_:
+    case Opcode::mk_promise_:
+    case Opcode::mk_eager_promise_:
     case Opcode::push_code_:
         out << std::hex << immediate.fun << std::dec;
         break;

--- a/rir/src/ir/BC.h
+++ b/rir/src/ir/BC.h
@@ -172,10 +172,15 @@ BC BC::push_code(FunIdx prom) {
     i.fun = prom;
     return BC(Opcode::push_code_, i);
 }
-BC BC::promise(FunIdx prom) {
+BC BC::mkEagerPromise(FunIdx prom) {
     ImmediateArguments i;
     i.fun = prom;
-    return BC(Opcode::promise_, i);
+    return BC(Opcode::mk_eager_promise_, i);
+}
+BC BC::mkPromise(FunIdx prom) {
+    ImmediateArguments i;
+    i.fun = prom;
+    return BC(Opcode::mk_promise_, i);
 }
 BC BC::missing(SEXP sym) {
     assert(TYPEOF(sym) == SYMSXP);

--- a/rir/src/ir/BC_inc.h
+++ b/rir/src/ir/BC_inc.h
@@ -272,14 +272,16 @@ class BC {
 
     bool hasPromargs() const {
         return bc == Opcode::call_implicit_ ||
-               bc == Opcode::named_call_implicit_ || bc == Opcode::promise_ ||
+               bc == Opcode::named_call_implicit_ ||
+               bc == Opcode::mk_promise_ || bc == Opcode::mk_eager_promise_ ||
                bc == Opcode::push_code_;
     }
 
     void addMyPromArgsTo(std::vector<FunIdx>& proms) {
         switch (bc) {
         case Opcode::push_code_:
-        case Opcode::promise_:
+        case Opcode::mk_promise_:
+        case Opcode::mk_eager_promise_:
             proms.push_back(immediate.arg_idx);
             break;
         case Opcode::named_call_implicit_:
@@ -384,7 +386,8 @@ BC_NOARGS(V, _)
     inline static BC ldloc(uint32_t offset);
     inline static BC stloc(uint32_t offset);
     inline static BC copyloc(uint32_t target, uint32_t source);
-    inline static BC promise(FunIdx prom);
+    inline static BC mkPromise(FunIdx prom);
+    inline static BC mkEagerPromise(FunIdx prom);
     inline static BC starg(SEXP sym);
     inline static BC stvarStubbed(unsigned stubbed);
     inline static BC stvar(SEXP sym);
@@ -688,7 +691,8 @@ BC_NOARGS(V, _)
         case Opcode::guard_fun_:
             memcpy(&immediate.guard_fun_args, pc, sizeof(GuardFunArgs));
             break;
-        case Opcode::promise_:
+        case Opcode::mk_promise_:
+        case Opcode::mk_eager_promise_:
         case Opcode::push_code_:
             memcpy(&immediate.fun, pc, sizeof(FunIdx));
             break;

--- a/rir/src/ir/CodeVerifier.cpp
+++ b/rir/src/ir/CodeVerifier.cpp
@@ -129,7 +129,8 @@ static Sources hasSources(Opcode bc) {
     case Opcode::named_call_:
     case Opcode::static_call_:
     case Opcode::call_builtin_:
-    case Opcode::promise_:
+    case Opcode::mk_promise_:
+    case Opcode::mk_eager_promise_:
     case Opcode::push_code_:
     case Opcode::br_:
     case Opcode::brtrue_:
@@ -348,7 +349,8 @@ void CodeVerifier::verifyFunctionLayout(SEXP sexp, InterpreterInstance* ctx) {
                              "invalid index");
             }
 
-            if (*cptr == Opcode::promise_) {
+            if (*cptr == Opcode::mk_promise_ ||
+                *cptr == Opcode::mk_eager_promise_) {
                 unsigned* promidx = reinterpret_cast<Immediate*>(cptr + 1);
                 objs.push_back(c->getPromise(*promidx));
             }

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -219,7 +219,8 @@ DEF_INSTR(isfun_, 0, 1, 1, 1)
  * promise_:: take immediate CP index of Code, create promise & push on object
  * stack
  */
-DEF_INSTR(promise_, 1, 1, 1, 1)
+DEF_INSTR(mk_eager_promise_, 1, 1, 1, 1)
+DEF_INSTR(mk_promise_, 1, 0, 1, 1)
 
 /**
  * force_:: pop from objet stack, evaluate, push promise's value


### PR DESCRIPTION
this should shrink the baseline codesize quite a bit by avoiding a
lot of unnecessary push(R_UnboundValue)