### PR TITLE
temporarily disable loop peeling to un-break master

### DIFF
--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1273,6 +1273,6 @@ bool Compiler::profile =
     !(getenv("RIR_PROFILING") &&
       std::string(getenv("RIR_PROFILING")).compare("off") == 0);
 
-bool Compiler::loopPeelingEnabled = true;
+bool Compiler::loopPeelingEnabled = false;
 
 } // namespace rir

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -7,29 +7,30 @@ if (!jitOn)
 # Sanity check for loop peeling, and testing that enabling/disabling works
 # These loop peeling tests may be a bit brittle.
 # Loop peeling should be enabled by default
-stopifnot(pir.check(
-  f <- function(x) {
-    i <- 0
-    while (i < 5) {
-      i <- i + x
-    }
-  }, TwoAdd, warmup=function(f) f(2)))
-rir.disableLoopPeeling()
-stopifnot(pir.check(
-  f <- function(x) {
-    i <- 0
-    while (i < 5) {
-      i <- i + x
-    }
-  }, OneAdd, warmup=function(f) f(2)))
-rir.enableLoopPeeling()
-stopifnot(pir.check(
-  f <- function(x) {
-    i <- 0
-    while (i < 5) {
-      i <- i + x
-    }
-  }, TwoAdd, warmup=function(f) f(2)))
+# TODO: enable again:
+# stopifnot(pir.check(
+#   f <- function(x) {
+#     i <- 0
+#     while (i < 5) {
+#       i <- i + x
+#     }
+#   }, TwoAdd, warmup=function(f) f(2)))
+# rir.disableLoopPeeling()
+# stopifnot(pir.check(
+#   f <- function(x) {
+#     i <- 0
+#     while (i < 5) {
+#       i <- i + x
+#     }
+#   }, OneAdd, warmup=function(f) f(2)))
+# rir.enableLoopPeeling()
+# stopifnot(pir.check(
+#   f <- function(x) {
+#     i <- 0
+#     while (i < 5) {
+#       i <- i + x
+#     }
+#   }, TwoAdd, warmup=function(f) f(2)))
 
 # Copied / cross-validated from pir_tests
 


### PR DESCRIPTION
@mhyee just put this in quickly so I can merge the rest of the pending things. I had a similar issue recently (ie. same error in the same benchmark), maybe I can help debugging.