### PR TITLE
Fix loop peeling bug

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -129,7 +129,10 @@ AbstractLoad AbstractREnvironmentHierarchy::get(Value* env, SEXP e) const {
         env = aliases.at(env);
     while (env != AbstractREnvironment::UnknownParent) {
         assert(env);
-        if (envs.count(env) == 0) {
+        // We only analyze PIR environments, not concrete R environments.
+        // TODO: If we can assume that the enclosing environments are stable,
+        // then we could just do the lookup here.
+        if (Env::Cast(env) || envs.count(env) == 0) {
             return AbstractLoad(env, AbstractPirValue::tainted());
         }
         auto aenv = envs.at(env);
@@ -166,8 +169,12 @@ AbstractLoad AbstractREnvironmentHierarchy::getFun(Value* env, SEXP e) const {
         env = aliases.at(env);
     while (env != AbstractREnvironment::UnknownParent) {
         assert(env);
-        if (envs.count(env) == 0)
+        // We only analyze PIR environments, not concrete R environments.
+        // TODO: If we can assume that the enclosing environments are stable,
+        // then we could just do the lookup here.
+        if (Env::Cast(env) || envs.count(env) == 0) {
             return AbstractLoad(env, AbstractPirValue::tainted());
+        }
         auto aenv = envs.at(env);
         if (!aenv.absent(e)) {
             const AbstractPirValue& res = aenv.get(e);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -5,6 +5,7 @@
 #include "../util/safe_builtins_list.h"
 #include "../util/visitor.h"
 #include "R/Funtab.h"
+#include "R/Symbols.h"
 #include "utils/Pool.h"
 #include "utils/Terminal.h"
 #include "utils/capture_out.h"
@@ -450,7 +451,7 @@ void LdFun::printArgs(std::ostream& out, bool tty) const {
         guessedBinding()->printRef(out);
         out << ">, ";
     }
-    if (hint) {
+    if (hint && hint != symbol::ambiguousCallTarget) {
         out << "<" << hint << ">, ";
     }
 }

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1248,6 +1248,6 @@ bool Compiler::profile =
     !(getenv("RIR_PROFILING") &&
       std::string(getenv("RIR_PROFILING")).compare("off") == 0);
 
-bool Compiler::loopPeelingEnabled = false;
+bool Compiler::loopPeelingEnabled = true;
 
 } // namespace rir

--- a/rir/src/utils/Map.h
+++ b/rir/src/utils/Map.h
@@ -117,6 +117,21 @@ class SmallMap {
         return false;
     }
 
+    const_iterator find(const K& k) const {
+        if (big) {
+            auto idx = index.find(k);
+            if (idx == index.end()) {
+                return cend();
+            } else {
+                return cbegin() + idx->second;
+            }
+        }
+        for (auto idx = cbegin(); idx != cend(); ++idx)
+            if (idx->first == k)
+                return idx;
+        return cend();
+    }
+
     void contains(const K& k, const std::function<void(V&)>& found,
                   const std::function<void()>& notFound) {
         if (big) {

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -7,30 +7,29 @@ if (!jitOn)
 # Sanity check for loop peeling, and testing that enabling/disabling works
 # These loop peeling tests may be a bit brittle.
 # Loop peeling should be enabled by default
-# TODO: enable again:
-# stopifnot(pir.check(
-#   f <- function(x) {
-#     i <- 0
-#     while (i < 5) {
-#       i <- i + x
-#     }
-#   }, TwoAdd, warmup=function(f) f(2)))
-# rir.disableLoopPeeling()
-# stopifnot(pir.check(
-#   f <- function(x) {
-#     i <- 0
-#     while (i < 5) {
-#       i <- i + x
-#     }
-#   }, OneAdd, warmup=function(f) f(2)))
-# rir.enableLoopPeeling()
-# stopifnot(pir.check(
-#   f <- function(x) {
-#     i <- 0
-#     while (i < 5) {
-#       i <- i + x
-#     }
-#   }, TwoAdd, warmup=function(f) f(2)))
+stopifnot(pir.check(
+  f <- function(x) {
+    i <- 0
+    while (i < 5) {
+      i <- i + x
+    }
+  }, TwoAdd, warmup=function(f) f(2)))
+rir.disableLoopPeeling()
+stopifnot(pir.check(
+  f <- function(x) {
+    i <- 0
+    while (i < 5) {
+      i <- i + x
+    }
+  }, OneAdd, warmup=function(f) f(2)))
+rir.enableLoopPeeling()
+stopifnot(pir.check(
+  f <- function(x) {
+    i <- 0
+    while (i < 5) {
+      i <- i + x
+    }
+  }, TwoAdd, warmup=function(f) f(2)))
 
 # Copied / cross-validated from pir_tests
 

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -157,3 +157,23 @@ xx1()
 xx1()
 xx1()
 xx1()
+
+#################
+
+s <- NaN
+h <- function() s <<- 74755
+f <- function(x) x
+g <- function() 42
+
+execute <- function () {
+    h()
+    f(g())
+}
+
+run <- function() {
+    for (i in 1:3) {
+        execute()
+    }
+}
+
+run()


### PR DESCRIPTION
@o- and I pair programmed to fix a bug in scope analysis (abstract environment lookup). As a bonus, we also implemented `find` for `SmallMap` and used it to reduce a few lookups.

Will merge this PR once CI passes and the benchmarks machine is ready.