### PR TITLE
fix dead store anaylsis for promises

### DIFF
--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -10,8 +10,97 @@ namespace rir {
 namespace pir {
 
 class DeadStoreAnalysis {
+    template <class State>
+    class SubAnalysis {
+      protected:
+        SubAnalysis() {}
 
-    // 1. perfom an escape analysis on the environment.
+        AbstractResult applyCommon(State& state, Instruction* i) const {
+            AbstractResult effect;
+            if (auto force = Force::Cast(i)) {
+                if (auto mk = MkArg::Cast(force->input()->followCasts())) {
+                    if (!mk->isEager()) {
+                        BB* bb = mk->prom()->entry;
+                        if (bb->size() > 0 &&
+                            LdFunctionEnv::Cast(*bb->begin())) {
+                            // The promise could get forced here and
+                            // use variables in the parent environment
+                            effect.max(
+                                recurse(state, i, mk->prom(), mk->promEnv()));
+                        }
+                    }
+                }
+            }
+            return effect;
+        }
+
+        virtual AbstractResult recurse(State& state, Instruction* i,
+                                       Promise* prom, Value* env) const = 0;
+    };
+
+    // 1. keep track of LdFunctionEnv aliases.
+    class AliasSet {
+      public:
+        std::unordered_map<Value*, Value*> aliases;
+
+        AbstractResult mergeExit(const AliasSet& other) { return merge(other); }
+        AbstractResult merge(const AliasSet& other) {
+            AbstractResult res;
+            for (const auto& x : other.aliases) {
+                if (!aliases.count(x.first)) {
+                    aliases[x.first] = x.second;
+                    res.update();
+                }
+            }
+            return res;
+        }
+        void print(std::ostream& out, bool tty) const {
+            // TODO
+        }
+    };
+
+    class AliasAnalysis : public StaticAnalysis<AliasSet>,
+                          private SubAnalysis<AliasSet> {
+        Value* resolveEnv(const AliasSet& state, Value* env) const {
+            if (LdFunctionEnv::Cast(env)) {
+                env = state.aliases.at(env);
+            }
+            return env;
+        }
+
+        AbstractResult apply(AliasSet& state, Instruction* i) const override {
+            return applyCommon(state, i);
+        }
+
+        AbstractResult recurse(AliasSet& state, Instruction* i, Promise* prom,
+                               Value* env) const override {
+            AbstractResult res;
+
+            auto ld = LdFunctionEnv::Cast(*prom->entry->begin());
+            assert(ld != NULL);
+            if (!state.aliases.count(ld)) {
+                state.aliases[ld] = resolveEnv(state, env);
+                res.update();
+            }
+
+            AliasAnalysis analysis(closure, prom, log);
+            analysis();
+            res.max(state.merge(analysis.result()));
+
+            return res;
+        }
+
+      public:
+        AliasAnalysis(ClosureVersion* cls, Code* code, LogStream& log)
+            : StaticAnalysis("aliasEnv", cls, code, log),
+              SubAnalysis<AliasSet>() {}
+
+        Value* resolveEnv(Value* env) const {
+            return resolveEnv(result(), env);
+        }
+    };
+
+    // 2. perfom an escape analysis on the environment.
     class EnvSet {
       public:
         typedef std::unordered_set<Value*> Envs;
@@ -32,10 +121,20 @@ class DeadStoreAnalysis {
         }
     };
 
-    class EnvLeakAnalysis : public StaticAnalysis<EnvSet> {
+    class EnvLeakAnalysis : public StaticAnalysis<EnvSet>,
+                            private SubAnalysis<EnvSet> {
+        const AliasAnalysis& aliases;
+
       public:
-        EnvLeakAnalysis(ClosureVersion* cls, LogStream& log)
-            : StaticAnalysis("envLeak", cls, cls, log) {}
+        EnvLeakAnalysis(ClosureVersion* cls, Code* code,
+                        const AliasAnalysis& aliases, LogStream& log)
+            : EnvLeakAnalysis(cls, code, EnvSet(), aliases, log) {}
+
+        EnvLeakAnalysis(ClosureVersion* cls, Code* code,
+                        const EnvSet& initialState,
+                        const AliasAnalysis& aliases, LogStream& log)
+            : StaticAnalysis("envLeak", cls, code, initialState, NULL, log),
+              SubAnalysis(), aliases(aliases) {}
 
         EnvSet leakedAt(Instruction* i) const {
             return at<StaticAnalysis::PositioningStyle::BeforeInstruction>(i);
@@ -45,21 +144,30 @@ class DeadStoreAnalysis {
         AbstractResult apply(EnvSet& state, Instruction* i) const override {
             AbstractResult effect;
             if (i->leaksEnv()) {
-                if (auto mk = MkEnv::Cast(i->env())) {
+                Value* env = aliases.resolveEnv(i->env());
+                if (auto mk = MkEnv::Cast(env)) {
                     // stubs cannot leak, or we deopt
                     if (mk->stub)
                         return effect;
                 }
-                if (!state.envs.count(i->env())) {
-                    state.envs.insert(i->env());
+                if (!state.envs.count(env)) {
+                    state.envs.insert(env);
                     effect.update();
                 }
             }
+            effect.max(applyCommon(state, i));
             return effect;
+        }
+
+        AbstractResult recurse(EnvSet& state, Instruction* i, Promise* prom,
+                               Value* env) const override {
+            EnvLeakAnalysis analysis(closure, prom, aliases, log);
+            analysis();
+            return state.merge(analysis.result());
         }
     };
 
-    /* 2. find all possible observations for stores.
+    /* 3. find all possible observations for stores.
      *
      * This is a backwards analysis with the following rules:
      *
@@ -110,15 +218,17 @@ class DeadStoreAnalysis {
         }
     };
 
-    class ObservedStoreAnalysis
-        : public BackwardStaticAnalysis<ObservedStores> {
+    class ObservedStoreAnalysis : public BackwardStaticAnalysis<ObservedStores>,
+                                  private SubAnalysis<ObservedStores> {
+        const AliasAnalysis& aliases;
         const EnvLeakAnalysis& leaked;
 
       public:
-        ObservedStoreAnalysis(ClosureVersion* cls, const CFG& cfg,
+        ObservedStoreAnalysis(ClosureVersion* cls, Code* code, const CFG& cfg,
+                              const AliasAnalysis& aliases,
                               const EnvLeakAnalysis& leaked, LogStream& log)
-            : BackwardStaticAnalysis("observedEnv", cls, cls, cfg, log),
-              leaked(leaked) {}
+            : BackwardStaticAnalysis("observedEnv", cls, code, cfg, log),
+              SubAnalysis(), aliases(aliases), leaked(leaked) {}
 
       private:
         static std::unordered_set<Value*> withPotentialParents(Value* env) {
@@ -136,6 +246,11 @@ class DeadStoreAnalysis {
       protected:
         AbstractResult apply(ObservedStores& state,
                              Instruction* i) const override {
+            return apply(state, i, NULL);
+        }
+
+        AbstractResult apply(ObservedStores& state, Instruction* i,
+                             Value* alias) const {
             AbstractResult effect;
             auto observeFullEnv = [&](Value* env) {
                 for (auto& e : withPotentialParents(env)) {
@@ -156,7 +271,8 @@ class DeadStoreAnalysis {
             };
 
             if (auto ld = LdVar::Cast(i)) {
-                for (auto& e : withPotentialParents(i->env())) {
+                for (auto& e :
+                     withPotentialParents(aliases.resolveEnv(i->env()))) {
                     Variable var({ld->varName, e});
                     if (!state.partiallyObserved.count(var)) {
                         state.partiallyObserved.insert(var);
@@ -177,13 +293,26 @@ class DeadStoreAnalysis {
                     effect.update();
                 }
             } else if (i->readsEnv()) {
-                observeFullEnv(i->env());
+                observeFullEnv(aliases.resolveEnv(i->env()));
             } else if (i->exits() || i->effects.contains(Effect::ExecuteCode)) {
                 auto leakedEnvs = leaked.leakedAt(i);
                 for (auto& l : leakedEnvs.envs)
                     observeFullEnv(l);
             }
+
+            effect.max(applyCommon(state, i));
             return effect;
+        }
+
+        AbstractResult recurse(ObservedStores& state, Instruction* i,
+                               Promise* prom, Value* env) const override {
+            CFG cfg(prom);
+            EnvLeakAnalysis subLeak(closure, prom, leaked.leakedAt(i), aliases,
+                                    log);
+            ObservedStoreAnalysis analysis(closure, prom, cfg, aliases, subLeak,
+                                           log);
+            analysis();
+            return state.merge(analysis.result());
         }
 
       public:
@@ -198,6 +327,7 @@ class DeadStoreAnalysis {
         }
     };
 
+    AliasAnalysis aliases;
     EnvLeakAnalysis leak;
     ObservedStoreAnalysis observed;
 
@@ -205,7 +335,8 @@ class DeadStoreAnalysis {
 
   public:
     DeadStoreAnalysis(ClosureVersion* cls, const CFG& cfg, LogStream& log)
-        : leak(cls, log), observed(cls, cfg, leak, log) {}
+        : aliases(cls, cls, log), leak(cls, cls, aliases, log),
+          observed(cls, cls, cfg, aliases, leak, log) {}
 
     bool isDead(StVar* st) const {
         if (!isLocal(st->env()))

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -453,21 +453,6 @@ bool MkArg::usesPromEnv() const {
     return false;
 }
 
-Effects Force::inferEffects(const GetType& getType) const {
-    Effects effects = this->effects;
-    if (!getType(input()).maybeLazy())
-        return Effect::DependsOnAssume;
-    if (auto mk = MkArg::Cast(input())) {
-        if (Visitor::check(mk->prom()->entry, [&](Instruction* i) {
-                return !i->effects.contains(Effect::ExecuteCode);
-            })) {
-            // We know what code we're executing
-            effects.reset(Effect::ExecuteCode);
-        }
-    }
-    return effects;
-}
-
 void Missing::printArgs(std::ostream& out, bool tty) const {
     out << CHAR(PRINTNAME(varName)) << ", ";
 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -426,8 +426,7 @@ class Instruction : public Value {
             COMPILER_INSTRUCTIONS(V)
 #undef V
             return static_cast<Instruction*>(v);
-        default: {
-        }
+        default: {}
         }
         return nullptr;
     }
@@ -941,6 +940,8 @@ class FLIE(MkArg, 2, Effects::None()) {
     size_t gvnBase() const override { return hash_combine(tagHash(), prom_); }
 
     int minReferenceCount() const override { return MAX_REFCOUNT; }
+
+    bool usesPromEnv() const;
 };
 
 class FLI(Seq, 3, Effects::Any()) {
@@ -1010,9 +1011,7 @@ class FLIE(Force, 2, Effects::Any()) {
     PirType inferType(const GetType& getType) const override final {
         return getType(input()).forced();
     }
-    Effects inferEffects(const GetType& getType) const override final {
-        return getType(input()).maybeLazy() ? effects : Effect::DependsOnAssume;
-    }
+    Effects inferEffects(const GetType& getType) const override final;
     int minReferenceCount() const override { return MAX_REFCOUNT; }
 
     size_t gvnBase() const override {
@@ -1880,9 +1879,8 @@ class VLIE(CallBuiltin, Effects::Any()), public CallInstruction {
     friend class BuiltinCallFactory;
 };
 
-class VLI(CallSafeBuiltin,
-          Effects(Effect::Warn) | Effect::Error | Effect::Visibility |
-              Effect::DependsOnAssume),
+class VLI(CallSafeBuiltin, Effects(Effect::Warn) | Effect::Error |
+                               Effect::Visibility | Effect::DependsOnAssume),
     public CallInstruction {
   public:
     SEXP blt;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1011,7 +1011,9 @@ class FLIE(Force, 2, Effects::Any()) {
     PirType inferType(const GetType& getType) const override final {
         return getType(input()).forced();
     }
-    Effects inferEffects(const GetType& getType) const override final;
+    Effects inferEffects(const GetType& getType) const override final {
+        return getType(input()).maybeLazy() ? effects : Effect::DependsOnAssume;
+    }
     int minReferenceCount() const override { return MAX_REFCOUNT; }
 
     size_t gvnBase() const override {


### PR DESCRIPTION
A promise can load a variable in the parent environment, so that the last store isn't actually "dead".