### PR TITLE
disable wrong typefeedback

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -320,15 +320,20 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             auto feedback = bc.immediate.typeFeedback;
             at(0)->typeFeedback.merge(feedback);
 
-            if (auto force = Force::Cast(at(0))) {
-                auto arg = force->arg(0).val();
-                if (feedback.stateBeforeLastForce ==
-                    ObservedValues::StateBeforeLastForce::value)
-                    arg->typeFeedback = at(0)->typeFeedback;
-                else if (feedback.stateBeforeLastForce ==
-                         ObservedValues::StateBeforeLastForce::evaluatedPromise)
-                    arg->typeFeedback = at(0)->typeFeedback.orPromiseWrapped();
-            }
+            // TODO: This does not work, if there are multiple force
+            // instructions, then the second one will see an already evaluated
+            // promise and it will always mark the input as already evaluated...
+            // We need to do this differently. if (auto force =
+            // Force::Cast(at(0))) {
+            //     auto arg = force->arg(0).val();
+            //     if (feedback.stateBeforeLastForce ==
+            //         ObservedValues::StateBeforeLastForce::value)
+            //         arg->typeFeedback = at(0)->typeFeedback;
+            //     else if (feedback.stateBeforeLastForce ==
+            //              ObservedValues::StateBeforeLastForce::evaluatedPromise)
+            //         arg->typeFeedback =
+            //         at(0)->typeFeedback.orPromiseWrapped();
+            // }
         }
         break;
     }


### PR DESCRIPTION
the eager value recording does not work. the reason is the following:

  x = ldvar
  force(x)
  ...
  force(x)

here the second force will mark x as already evaluated and trigger
speculation on x, even though it is only evaluated *after* the first
force.

We need to remember the "forced" state per force instruction...

disables #557