### PR TITLE
bugfixes (probably better to merge in fix-serialize instead)

### DIFF
--- a/rir/src/compiler/analysis/dead.cpp
+++ b/rir/src/compiler/analysis/dead.cpp
@@ -18,7 +18,7 @@ DeadInstructions::DeadInstructions(Code* code) {
 bool DeadInstructions::used(Instruction* i) {
     if (i->branchOrExit())
         return true;
-    return !i->type.isVoid() && used_.count(i);
+    return (i->type != PirType::voyd()) && used_.count(i);
 }
 
 bool DeadInstructions::unused(Instruction* i) { return !used(i); }

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -26,7 +26,8 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
             auto i = *ip;
             bool trigger = false;
             if (!i->type.maybePromiseWrapped() && !i->typeFeedback.isVoid() &&
-                !i->type.isA(i->typeFeedback)) {
+                !i->type.isA(i->typeFeedback) &&
+                !(i->type & i->typeFeedback).isVoid()) {
                 switch (i->tag) {
                 case Tag::Force: {
                     auto arg = i->arg(0).val()->followCasts();


### PR DESCRIPTION
dead store analysis was removing bottom-type instructions which were actually used,
and these were created because TypeFeedback was inferring an impossible type (due to serialization).
This was why serialization was failing