### PR TITLE
flag to disable assumptions in compiled code

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ tests_fullverify:
     - bin/tests
     - bin/gnur-make-tests check-devel
 
-# Test particular features, like deoptimization and serialization
+# Test particular features: deoptimization, native backend, serialization, unsound assumptions
 test_features:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
@@ -138,6 +138,7 @@ test_features:
     - PIR_NATIVE_BACKEND=2 ./bin/gnur-make-tests check
     - RIR_SERIALIZE_CHAOS=1 FAST_TESTS=1 ./bin/tests
     - RIR_SERIALIZE_CHAOS=10 FAST_TESTS=1 ./bin/tests
+    - RIR_UNSOUND_ASSUME=1 ./bin/tests
 
 # Run ubsan and gc torture
 test_sanitize:

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -81,6 +81,13 @@ completely disables the PIR optimizer. As follows are the different Options avai
         n          serialize and deserialize the dispatch table on every `n`th
                    RIR call. WARNING: This sometimes prevents optimization
 
+#### Library Optimization
+
+    RIR_UNSOUND_ASSUME=
+        1          when compiling closures, don't insert any assumption checks.
+                   Furthermore, mark properties (such as strictness) even if
+                   they can't be proved, if they were never recorded.
+
 ### Disassembly annotations
 
 #### Assumptions

--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -65,7 +65,7 @@ pir.tests <- function() {
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
 # warmup=<FUN> will call <FUN> repeatedly to get better assumptions.
 pir.check <- function(f, ..., warmup=NULL) {
-    checks <- 
+    checks <-
         as.pairlist(lapply(lapply(as.list(substitute(...())), as.character), as.name))
     if (length(checks) == 0)
         stop("pir.check: needs at least 1 check")

--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -10,8 +10,97 @@ namespace rir {
 namespace pir {
 
 class DeadStoreAnalysis {
+    template <class State>
+    class SubAnalysis {
+      protected:
+        SubAnalysis() {}
 
-    // 1. perfom an escape analysis on the environment.
+        AbstractResult applyCommon(State& state, Instruction* i) const {
+            AbstractResult effect;
+            if (auto force = Force::Cast(i)) {
+                if (auto mk = MkArg::Cast(force->input()->followCasts())) {
+                    if (!mk->isEager()) {
+                        BB* bb = mk->prom()->entry;
+                        if (bb->size() > 0 &&
+                            LdFunctionEnv::Cast(*bb->begin())) {
+                            // The promise could get forced here and
+                            // use variables in the parent environment
+                            effect.max(
+                                recurse(state, i, mk->prom(), mk->promEnv()));
+                        }
+                    }
+                }
+            }
+            return effect;
+        }
+
+        virtual AbstractResult recurse(State& state, Instruction* i,
+                                       Promise* prom, Value* env) const = 0;
+    };
+
+    // 1. keep track of LdFunctionEnv aliases.
+    class AliasSet {
+      public:
+        std::unordered_map<Value*, Value*> aliases;
+
+        AbstractResult mergeExit(const AliasSet& other) { return merge(other); }
+        AbstractResult merge(const AliasSet& other) {
+            AbstractResult res;
+            for (const auto& x : other.aliases) {
+                if (!aliases.count(x.first)) {
+                    aliases[x.first] = x.second;
+                    res.update();
+                }
+            }
+            return res;
+        }
+        void print(std::ostream& out, bool tty) const {
+            // TODO
+        }
+    };
+
+    class AliasAnalysis : public StaticAnalysis<AliasSet>,
+                          private SubAnalysis<AliasSet> {
+        Value* resolveEnv(const AliasSet& state, Value* env) const {
+            if (LdFunctionEnv::Cast(env)) {
+                env = state.aliases.at(env);
+            }
+            return env;
+        }
+
+        AbstractResult apply(AliasSet& state, Instruction* i) const override {
+            return applyCommon(state, i);
+        }
+
+        AbstractResult recurse(AliasSet& state, Instruction* i, Promise* prom,
+                               Value* env) const override {
+            AbstractResult res;
+
+            auto ld = LdFunctionEnv::Cast(*prom->entry->begin());
+            assert(ld != NULL);
+            if (!state.aliases.count(ld)) {
+                state.aliases[ld] = resolveEnv(state, env);
+                res.update();
+            }
+
+            AliasAnalysis analysis(closure, prom, log);
+            analysis();
+            res.max(state.merge(analysis.result()));
+
+            return res;
+        }
+
+      public:
+        AliasAnalysis(ClosureVersion* cls, Code* code, LogStream& log)
+            : StaticAnalysis("aliasEnv", cls, code, log),
+              SubAnalysis<AliasSet>() {}
+
+        Value* resolveEnv(Value* env) const {
+            return resolveEnv(result(), env);
+        }
+    };
+
+    // 2. perfom an escape analysis on the environment.
     class EnvSet {
       public:
         typedef std::unordered_set<Value*> Envs;
@@ -32,10 +121,20 @@ class DeadStoreAnalysis {
         }
     };
 
-    class EnvLeakAnalysis : public StaticAnalysis<EnvSet> {
+    class EnvLeakAnalysis : public StaticAnalysis<EnvSet>,
+                            private SubAnalysis<EnvSet> {
+        const AliasAnalysis& aliases;
+
       public:
-        EnvLeakAnalysis(ClosureVersion* cls, LogStream& log)
-            : StaticAnalysis("envLeak", cls, cls, log) {}
+        EnvLeakAnalysis(ClosureVersion* cls, Code* code,
+                        const AliasAnalysis& aliases, LogStream& log)
+            : EnvLeakAnalysis(cls, code, EnvSet(), aliases, log) {}
+
+        EnvLeakAnalysis(ClosureVersion* cls, Code* code,
+                        const EnvSet& initialState,
+                        const AliasAnalysis& aliases, LogStream& log)
+            : StaticAnalysis("envLeak", cls, code, initialState, NULL, log),
+              SubAnalysis(), aliases(aliases) {}
 
         EnvSet leakedAt(Instruction* i) const {
             return at<StaticAnalysis::PositioningStyle::BeforeInstruction>(i);
@@ -45,21 +144,30 @@ class DeadStoreAnalysis {
         AbstractResult apply(EnvSet& state, Instruction* i) const override {
             AbstractResult effect;
             if (i->leaksEnv()) {
-                if (auto mk = MkEnv::Cast(i->env())) {
+                Value* env = aliases.resolveEnv(i->env());
+                if (auto mk = MkEnv::Cast(env)) {
                     // stubs cannot leak, or we deopt
                     if (mk->stub)
                         return effect;
                 }
-                if (!state.envs.count(i->env())) {
-                    state.envs.insert(i->env());
+                if (!state.envs.count(env)) {
+                    state.envs.insert(env);
                     effect.update();
                 }
             }
+            effect.max(applyCommon(state, i));
             return effect;
+        }
+
+        AbstractResult recurse(EnvSet& state, Instruction* i, Promise* prom,
+                               Value* env) const override {
+            EnvLeakAnalysis analysis(closure, prom, aliases, log);
+            analysis();
+            return state.merge(analysis.result());
         }
     };
 
-    /* 2. find all possible observations for stores.
+    /* 3. find all possible observations for stores.
      *
      * This is a backwards analysis with the following rules:
      *
@@ -110,15 +218,17 @@ class DeadStoreAnalysis {
         }
     };
 
-    class ObservedStoreAnalysis
-        : public BackwardStaticAnalysis<ObservedStores> {
+    class ObservedStoreAnalysis : public BackwardStaticAnalysis<ObservedStores>,
+                                  private SubAnalysis<ObservedStores> {
+        const AliasAnalysis& aliases;
         const EnvLeakAnalysis& leaked;
 
       public:
-        ObservedStoreAnalysis(ClosureVersion* cls, const CFG& cfg,
+        ObservedStoreAnalysis(ClosureVersion* cls, Code* code, const CFG& cfg,
+                              const AliasAnalysis& aliases,
                               const EnvLeakAnalysis& leaked, LogStream& log)
-            : BackwardStaticAnalysis("observedEnv", cls, cls, cfg, log),
-              leaked(leaked) {}
+            : BackwardStaticAnalysis("observedEnv", cls, code, cfg, log),
+              SubAnalysis(), aliases(aliases), leaked(leaked) {}
 
       private:
         static std::unordered_set<Value*> withPotentialParents(Value* env) {
@@ -136,6 +246,11 @@ class DeadStoreAnalysis {
       protected:
         AbstractResult apply(ObservedStores& state,
                              Instruction* i) const override {
+            return apply(state, i, NULL);
+        }
+
+        AbstractResult apply(ObservedStores& state, Instruction* i,
+                             Value* alias) const {
             AbstractResult effect;
             auto observeFullEnv = [&](Value* env) {
                 for (auto& e : withPotentialParents(env)) {
@@ -156,7 +271,8 @@ class DeadStoreAnalysis {
             };
 
             if (auto ld = LdVar::Cast(i)) {
-                for (auto& e : withPotentialParents(i->env())) {
+                for (auto& e :
+                     withPotentialParents(aliases.resolveEnv(i->env()))) {
                     Variable var({ld->varName, e});
                     if (!state.partiallyObserved.count(var)) {
                         state.partiallyObserved.insert(var);
@@ -177,13 +293,26 @@ class DeadStoreAnalysis {
                     effect.update();
                 }
             } else if (i->readsEnv()) {
-                observeFullEnv(i->env());
+                observeFullEnv(aliases.resolveEnv(i->env()));
             } else if (i->exits() || i->effects.contains(Effect::ExecuteCode)) {
                 auto leakedEnvs = leaked.leakedAt(i);
                 for (auto& l : leakedEnvs.envs)
                     observeFullEnv(l);
             }
+
+            effect.max(applyCommon(state, i));
             return effect;
+        }
+
+        AbstractResult recurse(ObservedStores& state, Instruction* i,
+                               Promise* prom, Value* env) const override {
+            CFG cfg(prom);
+            EnvLeakAnalysis subLeak(closure, prom, leaked.leakedAt(i), aliases,
+                                    log);
+            ObservedStoreAnalysis analysis(closure, prom, cfg, aliases, subLeak,
+                                           log);
+            analysis();
+            return state.merge(analysis.result());
         }
 
       public:
@@ -198,6 +327,7 @@ class DeadStoreAnalysis {
         }
     };
 
+    AliasAnalysis aliases;
     EnvLeakAnalysis leak;
     ObservedStoreAnalysis observed;
 
@@ -205,7 +335,8 @@ class DeadStoreAnalysis {
 
   public:
     DeadStoreAnalysis(ClosureVersion* cls, const CFG& cfg, LogStream& log)
-        : leak(cls, log), observed(cls, cfg, leak, log) {}
+        : aliases(cls, cls, log), leak(cls, cls, aliases, log),
+          observed(cls, cls, cfg, aliases, leak, log) {}
 
     bool isDead(StVar* st) const {
         if (!isLocal(st->env()))

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -53,12 +53,7 @@ void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
             ip++;
         }
 
-        auto test = new Identical(given, expected);
-        ip = bb->insert(ip, test);
-        ip++;
-
-        auto assume = new Assume(test, cp);
-        ip = bb->insert(ip, assume);
+        BBTransform::insertIdenticalAssume(given, expected, cp, bb, ip);
         ip++;
 
         return ip;

--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -19,6 +19,7 @@ struct Parameter {
 
     static bool RIR_PRESERVE;
     static unsigned RIR_SERIALIZE_CHAOS;
+    static bool RIR_UNSOUND_ASSUME;
 
     static unsigned RIR_CHECK_PIR_TYPES;
 };

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -8,6 +8,7 @@
 namespace rir {
 namespace pir {
 
+class Assume;
 class FrameState;
 class Checkpoint;
 class BBTransform {
@@ -22,11 +23,14 @@ class BBTransform {
                            BB::Instrs::iterator position, Value* condition,
                            bool expected, BB* deoptBlock,
                            const std::string& debugMesage);
-    static void insertAssume(Value* condition, Checkpoint* cp, BB* bb,
-                             BB::Instrs::iterator& position,
-                             bool assumePositive);
-    static void insertAssume(Value* condition, Checkpoint* cp,
-                             bool assumePositive);
+    static Assume* insertAssume(Instruction* condition, Checkpoint* cp, BB* bb,
+                                BB::Instrs::iterator& position,
+                                bool assumePositive);
+    static Assume* insertAssume(Instruction* condition, Checkpoint* cp,
+                                bool assumePositive);
+    static Assume* insertIdenticalAssume(Value* given, Value* expected,
+                                         Checkpoint* cp, BB* bb,
+                                         BB::Instrs::iterator& position);
 
     static void mergeRedundantBBs(Code* closure);
 

--- a/rir/src/interpreter/serialize.cpp
+++ b/rir/src/interpreter/serialize.cpp
@@ -9,6 +9,8 @@ bool pir::Parameter::RIR_PRESERVE =
     getenv("RIR_PRESERVE") ? atoi(getenv("RIR_PRESERVE")) : false;
 unsigned pir::Parameter::RIR_SERIALIZE_CHAOS =
     getenv("RIR_SERIALIZE_CHAOS") ? atoi(getenv("RIR_SERIALIZE_CHAOS")) : 0;
+bool pir::Parameter::RIR_UNSOUND_ASSUME =
+    getenv("RIR_UNSOUND_ASSUME") ? atoi(getenv("RIR_UNSOUND_ASSUME")) : false;
 
 static bool oldPreserve = false;
 

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -158,8 +158,8 @@ stopifnot(pir.check(function() {
     q <- 1
   else {
     if (a)
-      q <- 3 
-    else 
+      q <- 3
+    else
       q <- 2
   }
   q
@@ -169,8 +169,8 @@ stopifnot(pir.check(function(a) {
     q <- 1
   else {
     if (a)
-      q <- 3 
-    else 
+      q <- 3
+    else
       q <- 2
   }
   q
@@ -346,7 +346,7 @@ stopifnot(pir.check(function() {
     x <- x + i
   x
 }, NoAsInt))
-                     
+
 # More dead instruction removal
 stopifnot(!pir.check(function(x) {
   x == 4

--- a/rir/tests/pir_regression.R
+++ b/rir/tests/pir_regression.R
@@ -42,12 +42,14 @@ h()  # aborts if g's environment got elided
 }
 
 # speculative binop with deopt
-rir.compile(function(){
-    f <- rir.compile(function(a) a+2);
-    f(1);
-    f <- pir.compile(f);
-    f(structure(1, class="foo"))
-})()
+if (!as.numeric(Sys.getenv("RIR_UNSOUND_ASSUME", unset="0"))) {
+  rir.compile(function(){
+      f <- rir.compile(function(a) a+2);
+      f(1);
+      f <- pir.compile(f);
+      f(structure(1, class="foo"))
+  })()
+}
 
 
 # inlined frameStates:
@@ -59,21 +61,21 @@ if (Sys.getenv("PIR_DEOPT_CHAOS") != "1" &&
     g <- rir.compile(function(x) h(x))
     h <- rir.compile(function(x) 1+i(x))
     i <- rir.compile(function(x) 40-x)
-    
+
     stopifnot(f(-1) == 42)
     stopifnot(f(-1) == 42)
-    
+
     hc1 = .Call("rir_invocation_count", h)
     ic1 = .Call("rir_invocation_count", i)
     g <- pir.compile(g)
     stopifnot(f(-1) == 42)
-    
+
     ## Assert we are really inlined (ie. h and i are not called)
     hc2 = .Call("rir_invocation_count", h)
     ic2 = .Call("rir_invocation_count", i)
     stopifnot(hc1 == hc2)
     stopifnot(ic1 == ic2)
-    
+
     ## Assert we deopt (ie. base version of h and i are invoked)
     stopifnot(f(structure(-1, class="asdf")) == 42)
     hc3 = .Call("rir_invocation_count", h)
@@ -122,11 +124,11 @@ f <- function(j){
     j <- j
     while (j < 2) {
         c(j)
-        j <- j + 1 
-    }   
+        j <- j + 1
+    }
 }
 g <- function(i) {
-  if (i) 
+  if (i)
     f(0)
   else
     f(2)

--- a/rir/tests/regression_mandelbrot.r
+++ b/rir/tests/regression_mandelbrot.r
@@ -18,7 +18,7 @@ mandelbrot <- function() {
 
     size <- 10
     while (y < size) {
-      ci = (2.0 * y / size) - 1.0 
+      ci = (2.0 * y / size) - 1.0
       x = 0
 
       while (x < size) {
@@ -27,7 +27,7 @@ mandelbrot <- function() {
         zi   = 0.0
         zizi = 0.0
         cr = (2.0 * x / size) - 1.5
-        
+
         z = 0
         notDone = TRUE
         escape = 0

--- a/rir/tests/rir_deopt.R
+++ b/rir/tests/rir_deopt.R
@@ -1,3 +1,6 @@
+if (as.numeric(Sys.getenv("RIR_UNSOUND_ASSUME", unset="0")))
+    quit() # deoptimization won't work
+
 # === modify env
 
 f <- rir.compile(


### PR DESCRIPTION
Adds a flag `RIR_UNSOUND_ASSUME`, which prevents PIR from emitting assumptions when closures are compiled. If we get to a point where PIR would deopt, instead we simply crash. However, this enables PIR to get extra optimizations.

The purpose is, you could run this on library code (e.g. internal functions) which you know won't receive unexpected arguments. We can also serialize this code then deserialize it in sound execution, so we have a library with internal functions which are faster than PIR could normally generate.

Supersedes / rebased on #581