### PR TITLE
Limit debug output

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -89,6 +89,7 @@ pir.debugFlags <- function(ShowWarnings = FALSE,
                            PrintIntoFiles = FALSE,
                            PrintIntoStdout = FALSE,
                            OmitDeoptBranches = FALSE,
+                           OnlyChanges = FALSE,
                            PrintEarlyRir = FALSE,
                            PrintEarlyPir = FALSE,
                            PrintOptimizationPasses = FALSE,
@@ -101,7 +102,7 @@ pir.debugFlags <- function(ShowWarnings = FALSE,
     # !!!  This list of arguments *must* be exactly equal to the   !!!
     # !!!    LIST_OF_PIR_DEBUGGING_FLAGS in compiler/debugging.h   !!!
     .Call("pir_debugFlags", ShowWarnings, DryRun,
-          PrintIntoFiles, PrintIntoStdout, OmitDeoptBranches, PrintEarlyRir, PrintEarlyPir,
+          PrintIntoFiles, PrintIntoStdout, OmitDeoptBranches, OnlyChanges, PrintEarlyRir, PrintEarlyPir,
           PrintOptimizationPasses, PrintOptimizationPhases, PrintPirAfterOpt, PrintCSSA, PrintAllocator, PrintFinalPir,
           PrintFinalRir,
           # wants a dummy parameter at the end for technical reasons

--- a/rir/src/compiler/debugging/debugging.h
+++ b/rir/src/compiler/debugging/debugging.h
@@ -28,6 +28,7 @@ namespace pir {
     V(PrintIntoFiles)                                                          \
     V(PrintIntoStdout)                                                         \
     V(OmitDeoptBranches)                                                       \
+    V(OnlyChanges)                                                             \
     LIST_OF_PIR_PRINT_DEBUGGING_FLAGS(V)
 
 #define LIST_OF_DEBUG_STYLES(V)                                                \

--- a/rir/src/compiler/debugging/stream_logger.cpp
+++ b/rir/src/compiler/debugging/stream_logger.cpp
@@ -113,8 +113,19 @@ void LogStream::pirOptimizationsHeader(ClosureVersion* closure,
 void LogStream::pirOptimizations(ClosureVersion* closure,
                                  const PirTranslator* pass) {
     if (shouldLog(closure, pass, options)) {
-        closure->print(options.style, out, tty(),
-                       options.includes(DebugFlag::OmitDeoptBranches));
+        if (options.includes(DebugFlag::OnlyChanges)) {
+            static std::string last = "";
+            std::stringstream ss;
+            closure->print(options.style, ss, tty(),
+                           options.includes(DebugFlag::OmitDeoptBranches));
+            if (last != ss.str()) {
+                last = ss.str();
+                out << last;
+            }
+        } else {
+            closure->print(options.style, out, tty(),
+                           options.includes(DebugFlag::OmitDeoptBranches));
+        }
     }
 }
 


### PR DESCRIPTION
Only print passes that change the code.

This is super inefficient, it stores a string with the last pass output and then buffers the current pass and compares before writing it out.. But for debugging it should be fine.