### PR TITLE
fix build for clang on linux

### DIFF
--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -231,14 +231,8 @@ void BC::deserialize(SEXP refTable, R_inpstream_t inp, Opcode* code,
                 Pool::insert(ReadItem(refTable, inp));
             break;
         case Opcode::deopt_: {
-            DeoptMetadata* meta =
-                DeoptMetadata::deserialize(code, refTable, inp);
-            size_t size =
-                sizeof(DeoptMetadata) + meta->numFrames * sizeof(FrameInfo);
-            SEXP store = Rf_allocVector(RAWSXP, size);
-            memcpy(DATAPTR(store), meta, size);
-            i.pool = Pool::insert(store);
-            ::operator delete(meta, size);
+            SEXP meta = DeoptMetadata::deserialize(code, refTable, inp);
+            i.pool = Pool::insert(meta);
             break;
         }
         case Opcode::assert_type_:

--- a/rir/src/ir/Deoptimization.cpp
+++ b/rir/src/ir/Deoptimization.cpp
@@ -20,15 +20,18 @@ void FrameInfo::serialize(const Opcode* anchor, SEXP refTable,
     OutInteger(out, stackSize);
 }
 
-DeoptMetadata* DeoptMetadata::deserialize(const Opcode* anchor, SEXP refTable,
-                                          R_inpstream_t inp) {
+SEXP DeoptMetadata::deserialize(const Opcode* anchor, SEXP refTable,
+                                R_inpstream_t inp) {
     unsigned numFrames = InInteger(inp);
     size_t size = sizeof(DeoptMetadata) + numFrames * sizeof(FrameInfo);
-    DeoptMetadata* res = (DeoptMetadata*)::operator new(size);
+    SEXP store = Rf_allocVector(RAWSXP, size);
+
+    DeoptMetadata* res = new (DATAPTR(store)) DeoptMetadata;
     res->numFrames = numFrames;
     for (unsigned i = 0; i < numFrames; i++)
         res->frames[i] = FrameInfo::deserialize(anchor, refTable, inp);
-    return res;
+
+    return store;
 }
 
 void DeoptMetadata::serialize(const Opcode* anchor, SEXP refTable,

--- a/rir/src/ir/Deoptimization.h
+++ b/rir/src/ir/Deoptimization.h
@@ -28,8 +28,8 @@ struct DeoptMetadata {
     FrameInfo frames[];
 
     // Must be manually deallocated
-    static DeoptMetadata* deserialize(const Opcode* anchor, SEXP refTable,
-                                      R_inpstream_t inp);
+    static SEXP deserialize(const Opcode* anchor, SEXP refTable,
+                            R_inpstream_t inp);
     void serialize(const Opcode* anchor, SEXP refTable,
                    R_outpstream_t out) const;
 };


### PR DESCRIPTION
The `operator delete  ( void* ptr, std::size_t sz )` is a c++14 thing
that gcc happens to accept even in c++11. Anyway it is not necessary if
we use placement new to deserialize in the correct buffer from the
beginning.