### PR TITLE
Add gdb pretty printing for pir

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -137,3 +137,5 @@ end
 define ds
   dumpsxp $arg0 1
 end
+
+source .pirpp.py

--- a/tools/pirpp.py
+++ b/tools/pirpp.py
@@ -1,0 +1,64 @@
+# source: http://bazaar.launchpad.net/~maria-captains/mariadb-tools/trunk/view/head:/serg/gdb.py
+
+import gdb.printing
+
+# in python2 gdb.Value can only be converted to long(), python3 only has int()
+try:
+    a=long(1)
+except:
+    long=int
+
+def PrettyPrinter(arg):
+
+    name = getattr(arg, '__name__', arg)
+
+    def PrettyPrinterWrapperWrapperWrapper(func):
+
+        class PrettyPrinterWrapperWrapper:
+
+            class PrettyPrinterWrapper:
+                def __init__(self, prefix, val, cb):
+                    self.prefix = prefix
+                    self.val = val
+                    self.cb = cb
+                def to_string(self):
+                    return self.prefix + self.cb(self.val)
+
+            def __init__(self, name, cb):
+                self.name = name
+                self.enabled = True
+                self.cb = cb
+
+            def __call__(self, val):
+                prefix = ''
+                if val.type.code == gdb.TYPE_CODE_PTR:
+                    prefix = '({}) {:#08x} '.format(str(val.type), long(val))
+                    try: val = val.dereference()
+                    except: return None
+                valtype=val.type.unqualified()
+                if valtype.name == self.name:
+                    return self.PrettyPrinterWrapper(prefix, val, self.cb)
+                if valtype.strip_typedefs().name == self.name:
+                    return self.PrettyPrinterWrapper(prefix, val, self.cb)
+                return None
+
+        pp=PrettyPrinterWrapperWrapper(name, func)
+        gdb.printing.register_pretty_printer(None, pp, True)
+        return func
+
+    if callable(arg):
+        return PrettyPrinterWrapperWrapperWrapper(arg)
+
+    return PrettyPrinterWrapperWrapperWrapper
+
+@PrettyPrinter('rir::pir::BB')
+def BB(val):
+    return "BB" + str(val['id'])
+
+@PrettyPrinter('rir::pir::Value')
+def Value(val):
+    return '<Value ' + str(val['tag']).split("::")[-1] + '>'
+
+@PrettyPrinter('rir::pir::Instruction')
+def Instruction(val):
+    return '<Instruction ' + str(val['tag']).split("::")[-1] + ' (' + str(val['bb_']) + ')>'

--- a/tools/setup-build-dir
+++ b/tools/setup-build-dir
@@ -9,5 +9,6 @@ echo $R_HOME > .R_HOME
 if [ $ROOT_DIR != $BUILD_DIR ]; then
     if [ ! -f .gdbinit ]; then
         ln -s $ROOT_DIR/.gdbinit
+        ln -s $ROOT_DIR/tools/pirpp.py .pirpp.py
     fi
 fi


### PR DESCRIPTION
Kinda, it's very limited... Got tired of typing `p ((BB*)0x561804bc1fa0)->id` all the time

Do we want this?

```
(rr) p bb
$1 = (rir::pir::BB *) 0x561804bc1fa0 BB0
(rr) p bb->next1
$5 = (rir::pir::BB *) 0x561804ba36b0 BB4
(rr) p bb->instrs
$9 = std::vector of length 7, capacity 8 = {[0] = (rir::pir::Instruction *) 0x561804418b60 <Instruction LdArg ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [1] = (rir::pir::Instruction *) 0x561804965230 <Instruction ChkMissing ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [2] = (rir::pir::Instruction *) 0x5618040718d0 <Instruction MkEnv ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [3] = (rir::pir::Instruction *) 0x56180403c7e0 <Instruction Force ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [4] = (rir::pir::Instruction *) 0x561804f94eb0 <Instruction IsType ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [5] = (rir::pir::Instruction *) 0x561804ba5ed0 <Instruction CastType ((rir::pir::BB *) 0x561804bc1fa0 BB0)>, 
  [6] = (rir::pir::Instruction *) 0x56180498c0e0 <Instruction Branch ((rir::pir::BB *) 0x561804bc1fa0 BB0)>}
```