### PR TITLE
fix precision in static reference count analysis

### DIFF
--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -236,6 +236,8 @@ class StaticReferenceCount : public StaticAnalysis<AUses> {
         case Tag::Length:
         case Tag::Seq:
         case Tag::Colon:
+        case Tag::CastType:
+        case Tag::IsType:
         case Tag::IsObject:
         case Tag::IsEnvStub:
         case Tag::Deopt:


### PR DESCRIPTION
type checks never change the value