### PR TITLE
fix deopt loop in pidigits

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -267,8 +267,11 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
     case Opcode::ldfun_: {
         auto ld = insert(new LdFun(bc.immediateConst(), env));
         if (!inPromise()) {
-            auto cp = addCheckpoint(srcCode, pos, stack, insert);
-            callTargetFeedback[ld].first = cp;
+            auto n = BC::next(pos);
+            if (*n == Opcode::record_call_) {
+                auto cp = addCheckpoint(srcCode, pos, stack, insert);
+                callTargetFeedback[ld].first = cp;
+            }
         }
         push(ld);
         break;

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -21,9 +21,10 @@ Code::Code(FunctionSEXP fun, unsigned src, unsigned cs, unsigned sourceLength,
           (intptr_t)&locals_ - (intptr_t)this,
           // GC area has only 1 pointer
           NumLocals),
-      nativeCode(nullptr), uid(UUID::random()), funInvocationCount(0), src(src),
-      stackLength(0), localsCount(localsCnt), bindingCacheSize(bindingsCnt),
-      codeSize(cs), srcLength(sourceLength), extraPoolSize(0) {
+      nativeCode(nullptr), uid(UUID::random()), funInvocationCount(0),
+      deoptCount(0), src(src), stackLength(0), localsCount(localsCnt),
+      bindingCacheSize(bindingsCnt), codeSize(cs), srcLength(sourceLength),
+      extraPoolSize(0) {
     setEntry(0, R_NilValue);
     allCodes.emplace(uid, this);
 }
@@ -81,6 +82,7 @@ Code* Code::deserialize(SEXP refTable, R_inpstream_t inp) {
     code->uid = UUID::deserialize(refTable, inp);
     code->nativeCode = nullptr; // not serialized for now
     code->funInvocationCount = InInteger(inp);
+    code->deoptCount = InInteger(inp);
     code->src = InInteger(inp);
     code->stackLength = InInteger(inp);
     *const_cast<unsigned*>(&code->localsCount) = InInteger(inp);
@@ -116,6 +118,7 @@ void Code::serialize(SEXP refTable, R_outpstream_t out) const {
     // Header
     uid.serialize(refTable, out);
     OutInteger(out, funInvocationCount);
+    OutInteger(out, deoptCount);
     OutInteger(out, src);
     OutInteger(out, stackLength);
     OutInteger(out, localsCount);

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -77,12 +77,18 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
             funInvocationCount++;
     }
 
+    void registerDeopt() {
+        if (deoptCount < UINT_MAX)
+            deoptCount++;
+    }
+
     // UID for persistence when serializing/deserializing
     UUID uid;
 
     // number of invocations. only incremented if this code object is the body
     // of a function
     unsigned funInvocationCount;
+    unsigned deoptCount;
 
     unsigned src; /// AST of the function (or promise) represented by the code
 

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -73,6 +73,8 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
 
     void registerInvocation() { body()->registerInvocation(); }
     size_t invocationCount() { return body()->funInvocationCount; }
+    void registerDeopt() { body()->registerDeopt(); }
+    size_t deoptCount() { return body()->deoptCount; }
 
     unsigned size; /// Size, in bytes, of the function and its data
 


### PR DESCRIPTION
the main improvement is that we do not optimize while still
deoptimizing. then, also add some back-off counter that delays
reoptimization for frequently deoptimizing functions.