### PR TITLE
expose force code to RIR

### DIFF
--- a/rir/src/R/r.h
+++ b/rir/src/R/r.h
@@ -80,4 +80,9 @@ LibExtern AccuracyInfo R_AccuracyInfo;
 
 extern int R_PPStackTop;
 
+typedef struct RPRSTACK {
+    SEXP promise;
+    struct RPRSTACK* next;
+} RPRSTACK;
+
 #endif

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -17,7 +17,7 @@ namespace pir {
 
 static SEXP forcePromiseImpl(SEXP prom) {
     SLOWASSERT(TYPEOF(prom) == PROMSXP);
-    return forcePromise(prom);
+    return rirForcePromise(prom, globalContext());
 }
 static jit_type_t sxp1[1] = {sxp};
 static jit_type_t sxp2[2] = {sxp, sxp};

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -143,7 +143,7 @@ static RIR_INLINE SEXP promiseValue(SEXP promise, InterpreterInstance* ctx) {
         assert(TYPEOF(promise) != PROMSXP);
         return promise;
     } else {
-        SEXP res = forcePromise(promise);
+        SEXP res = rirForcePromise(promise, ctx);
         assert(TYPEOF(res) != PROMSXP && "promise returned promise");
         return res;
     }
@@ -239,7 +239,7 @@ SEXP createLegacyArgsListFromStackValues(size_t length, const R_bcstack_t* args,
         SEXP arg = ostack_at_cell(args + i);
 
         if (eagerCallee && TYPEOF(arg) == PROMSXP) {
-            arg = forcePromise(arg);
+            arg = rirForcePromise(arg, ctx);
         }
         // This is to ensure we pass named arguments to GNU-R builtins because
         // who knows what assumptions does GNU-R do??? We SHOULD test this.

--- a/rir/src/interpreter/safe_force.cpp
+++ b/rir/src/interpreter/safe_force.cpp
@@ -33,4 +33,108 @@ SEXP safeForcePromise(SEXP e) {
     }
 }
 
+static SEXP promiseEval(SEXP e, SEXP env, InterpreterInstance* ctx) {
+// #define DEBUG_EVAL
+#ifdef DEBUG_EVAL
+    std::cout << "Custom eval of " << TYPEOF(e) << ": ";
+    Rf_PrintValue(e);
+#endif
+    // From GNU-R eval
+    /* handle self-evaluating objects with minimal overhead */
+    switch (TYPEOF(e)) {
+    case NILSXP:
+    case LISTSXP:
+    case LGLSXP:
+    case INTSXP:
+    case REALSXP:
+    case STRSXP:
+    case CPLXSXP:
+    case RAWSXP:
+    case S4SXP:
+    case SPECIALSXP:
+    case BUILTINSXP:
+    case ENVSXP:
+    case CLOSXP:
+    case VECSXP:
+    case EXTPTRSXP:
+    case WEAKREFSXP:
+    case EXPRSXP:
+        /* Make sure constants in expressions are NAMED before being
+           used as values.  Setting NAMED to NAMEDMAX makes sure weird calls
+           to replacement functions won't modify constants in
+           expressions.  */
+        ENSURE_NAMEDMAX(e);
+        return e;
+    default:
+        break;
+    }
+    int bcintactivesave = R_BCIntActive;
+    R_BCIntActive = 0;
+    SEXP srcrefsave = R_Srcref;
+    int depthsave = R_EvalDepth++;
+    if (R_EvalDepth > R_Expressions) {
+        R_Expressions = R_Expressions_keep + 500;
+        errorcall(R_NilValue, "evaluation nested too deeply: infinite "
+                              "recursion / options(expressions=)?");
+    }
+
+    // Not from GNU-R
+    SEXP res = NULL;
+    switch (TYPEOF(e)) {
+    case EXTERNALSXP:
+        res = rirEval_f(e, env);
+        break;
+    default:
+        // Fallback to GNU-R
+        res = Rf_eval(e, env);
+        break;
+    }
+
+    R_EvalDepth = depthsave;
+    R_Srcref = srcrefsave;
+    R_BCIntActive = bcintactivesave;
+    return res;
+}
+
+SEXP rirForcePromise(SEXP e, InterpreterInstance* ctx) {
+    // From GNU-R
+    if (PRVALUE(e) != R_UnboundValue)
+        return PRVALUE(e);
+    RPRSTACK prstack;
+    SEXP val;
+    if (PRSEEN(e)) {
+        if (PRSEEN(e) == 1)
+            Rf_errorcall(R_GlobalContext->call,
+                         "promise already under evaluation: recursive default "
+                         "argument reference or earlier problems?");
+        else {
+            /* set PRSEEN to 1 to avoid infinite recursion */
+            SET_PRSEEN(e, 1);
+            warningcall(R_GlobalContext->call,
+                        "restarting interrupted promise evaluation");
+        }
+    }
+    /* Mark the promise as under evaluation and push it on a stack
+       that can be used to unmark pending promises if a jump out
+       of the evaluation occurs. */
+    SET_PRSEEN(e, 1);
+    prstack.promise = e;
+    prstack.next = R_PendingPromises;
+    R_PendingPromises = &prstack;
+
+    // The original code is eval(PRCODE(e), PRENV(e))
+    val = promiseEval(PRCODE(e), PRENV(e), ctx);
+
+    /* Pop the stack, unmark the promise and set its value field.
+       Also set the environment to R_NilValue to allow GC to
+       reclaim the promise environment; this is also useful for
+       fancy games with delayedAssign() */
+    R_PendingPromises = prstack.next;
+    SET_PRSEEN(e, 0);
+    SET_PRVALUE(e, val);
+    ENSURE_NAMEDMAX(val);
+    SET_PRENV(e, R_NilValue);
+    return PRVALUE(e);
+}
+
 } // namespace rir

--- a/rir/src/interpreter/safe_force.h
+++ b/rir/src/interpreter/safe_force.h
@@ -1,6 +1,7 @@
 #ifndef RIR_SAFE_FORCE_H
 #define RIR_SAFE_FORCE_H
 
+#include "interp_incl.h"
 #include <R/r.h>
 
 namespace rir {
@@ -10,6 +11,8 @@ namespace rir {
 SEXP safeEval(SEXP e, SEXP rho);
 // Will try to evaluate the promise if it definitely doesn't cause side effects
 SEXP safeForcePromise(SEXP e);
+
+SEXP rirForcePromise(SEXP e, InterpreterInstance* ctx);
 
 } // namespace rir
 


### PR DESCRIPTION
this makes it so, when we force promises, we can guard against certain things (e.g. overwrites) because all of the code passes through RIR. If we force a promise from GNU-R we still have to execute arbitrary code and "give up", but more often we force PIR code