### PR TITLE
typecheck for promise wrapped eager values

### DIFF
--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -136,8 +136,11 @@ bool PirType::isInstance(SEXP val) const {
     if (isRType()) {
         if (TYPEOF(val) == PROMSXP) {
             assert(!Rf_isObject(val));
-            return maybePromiseWrapped() || maybeLazy() ||
-                   PirType(RType::prom).isA(*this);
+            if (maybePromiseWrapped() && !maybeLazy()) {
+                auto v = PRVALUE(val);
+                return v != R_UnboundValue && forced().isInstance(v);
+            }
+            return maybe(RType::prom) || (maybeLazy() && maybePromiseWrapped());
         }
         if (LazyEnvironment::check(val))
             return PirType(RType::env).isA(*this);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3789,8 +3789,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             advanceImmediate();
             if (!typ.isInstance(val)) {
                 std::cerr << "type assert failed in:\n" << instr << "\n";
-                std::cerr << "type " << typ << " not accurate for value ("
-                          << pir::PirType(val) << "):\n";
+                std::cerr << "got " << pir::PirType(val) << " but expexted a "
+                          << typ << ":\n";
                 Rf_PrintValue(val);
                 std::cout << "\n";
                 assert(false);


### PR DESCRIPTION
extend the RIR_CHECK_PIR_TYPES options to check if promise wrapped
but eager values have the right type.