### PR TITLE
fix scope resolution to not use worse results

### DIFF
--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -55,6 +55,12 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                         break;
                     }
 
+                    if ("length" == name) {
+                        inferred =
+                            (PirType() | RType::integer | RType::real).scalar();
+                        break;
+                    }
+
                     if ("typeof" == name) {
                         inferred = PirType(RType::str).scalar();
                         break;

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -191,7 +191,8 @@ struct PirType {
             return false;
         };
 
-        fixup(*this, other) || fixup(other, *this);
+        if (!isVoid() && !other.isVoid())
+            fixup(*this, other) || fixup(other, *this);
 
         return res;
     }

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -663,6 +663,21 @@ bool testTypeRules() {
     assert(!r2.subsetType(PirType::any()).maybeObj());
     auto t = PirType(RType::logical).notObject().notMissing().scalar();
     assert(t.mergeWithConversion(t).isA(t));
+
+    auto a = (PirType() | RType::real | RType::integer)
+                 .notPromiseWrapped()
+                 .notObject();
+    auto b = (PirType() | RType::integer).notPromiseWrapped().notObject();
+    assert(a.mergeWithConversion(b) == a);
+    assert(b.mergeWithConversion(a) == a);
+    t = PirType::bottom();
+    t = t.mergeWithConversion(a);
+    t = t.mergeWithConversion(b);
+    assert(t == a);
+    t = t & PirType::num().notMissing();
+    assert(t == a);
+    t = PirType::any() & t;
+    assert(t == a);
     return true;
 }
 


### PR DESCRIPTION
this bug caused a tainted value in the global cache to override a better
value from the actual lookup and prevents some ldvars from being
resolved.

e.g. when we have:

    %a = force
    stvar "x" %a
    ldvar "x"

then the analysis would report (for the ldvar) the tainted result from
force, instead of just %a.