### PR TITLE
fix a number of warnings, ignore warnings from llvm and gnur fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(R_COMMAND ${R_HOME}/bin/R)
 include(${LLVM_DIR}/lib/cmake/llvm/LLVMConfig.cmake OPTIONAL)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 set(LLVM_COMPONENTS_USED core orcjit native vectorize)
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 add_definitions(-g3)
@@ -23,7 +23,7 @@ set(CMAKE_CXX_FLAGS_RELEASENOASSERT "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 set(CMAKE_CXX_FLAGS_FULLVERIFIER "${CMAKE_CXX_FLAGS_RELEASE} -DFULLVERIFIER")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -DENABLE_SLOWASSERT -DMEASURE")
 set(CMAKE_CXX_FLAGS_DEBUGOPT "-Og -DENABLE_SLOWASSERT -DMEASURE")
-set(CMAKE_CXX_FLAGS "${LLVM_CXX_FLAGS} -Wall -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 -Wuninitialized -Wundef -Winit-self -Wcast-align -Woverloaded-virtual -Wmissing-include-dirs -Wstrict-overflow=5 -std=c++14 -fno-rtti -fno-exceptions -Wimplicit-fallthrough -Wno-init-list-lifetime -Wno-unknown-warning-option")
+set(CMAKE_CXX_FLAGS "${LLVM_CXX_FLAGS} -Wall -Wundef -Wstrict-overflow=5 -std=c++14 -fno-rtti -fno-exceptions -Wimplicit-fallthrough")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 set(CMAKE_C_FLAGS_RELEASENOASSERT "${CMAKE_C_FLAGS_RELEASE} -DNDEBUG")
 set(CMAKE_C_FLAGS_FULLVERIFIER "${CMAKE_CXX_FLAGS_RELEASE} -DFULLVERIFIER")
@@ -43,7 +43,8 @@ MARK_AS_ADVANCED(
     CMAKE_C_FLAGS_FULLVERIFIER
 )
 
-set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_SOURCE_DIR}/tools/compiler_wrapper.sh")
+# Currently not needed
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_SOURCE_DIR}/tools/compiler_wrapper.sh")
 
 # Update the documentation string of CMAKE_BUILD_TYPE for GUIs
 SET( CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING

--- a/rir/src/compiler/analysis/dead.cpp
+++ b/rir/src/compiler/analysis/dead.cpp
@@ -6,17 +6,15 @@
 namespace rir {
 namespace pir {
 
-constexpr std::initializer_list<Tag> DeadInstructions::typecheckInstrs;
-
 DeadInstructions::DeadInstructions(Code* code, DeadInstructionsMode mode) {
     Visitor::run(code->entry, [&](Instruction* i) {
         i->eachArg([&](Value* v) {
             if (auto j = Instruction::Cast(v)) {
                 switch (mode) {
                 case IgnoreTypeTests:
-                    if (std::find(typecheckInstrs.begin(),
-                                  typecheckInstrs.end(),
-                                  i->tag) == typecheckInstrs.end() &&
+                    if (std::find(TypecheckInstrsList.begin(),
+                                  TypecheckInstrsList.end(),
+                                  i->tag) == TypecheckInstrsList.end() &&
                         v == i->arg(0).val())
                         return;
                     break;

--- a/rir/src/compiler/analysis/dead.h
+++ b/rir/src/compiler/analysis/dead.h
@@ -8,13 +8,12 @@
 namespace rir {
 namespace pir {
 
+constexpr static std::initializer_list<Tag> TypecheckInstrsList = {
+    Tag::IsObject, Tag::IsType, Tag::CastType, Tag::FrameState};
 class DeadInstructions {
     std::unordered_set<Instruction*> used_;
 
   public:
-    constexpr static std::initializer_list<Tag> typecheckInstrs = {
-        Tag::IsObject, Tag::IsType, Tag::CastType, Tag::FrameState};
-
     enum DeadInstructionsMode {
         CountAll,
         IgnoreUpdatePromise,

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -187,7 +187,7 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
                                 cast->effects.set(Effect::DependsOnAssume);
                                 ip = bb->insert(ip, cast);
                                 tested->replaceDominatedUses(
-                                    *ip, DeadInstructions::typecheckInstrs);
+                                    *ip, TypecheckInstrsList);
                                 next = ip + 1;
                             }
                         }

--- a/tools/compiler_wrapper.sh
+++ b/tools/compiler_wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# filter annoying messages
-"${@}" 2>&1 | grep -v 'note: the ABI of passing union with long double has changed'
-
-# return code of the compiler, rather than grep
-exit "${PIPESTATUS[0]}"


### PR DESCRIPTION
gnur fix includes a wrong type in a header that causes packages that
include Rinterface.h to fail when compiling.