### PR TITLE
We should not materialize environments when calling a known builtin. …

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -472,8 +472,9 @@ static RIR_INLINE SEXP legacyCallWithArgslist(CallContext& call, SEXP argslist,
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
         // call it
-        SEXP result =
-            f(call.ast, call.callee, argslist, materializeCallerEnv(call, ctx));
+        auto builtinEnv =
+            LazyEnvironment::check(call.callerEnv) ? R_BaseEnv : call.callerEnv;
+        SEXP result = f(call.ast, call.callee, argslist, builtinEnv);
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
         return result;


### PR DESCRIPTION
…Some may need the base env for errorhanlding so we pass them directly that one