### PR TITLE
don't treat error as a deopt barrier

### DIFF
--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -98,12 +98,10 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
                 } else {
                     // We are trying to group multiple assumes into the same
                     // checkpoint by finding for each assume the topmost
-                    // compatible
-                    // checkpoint.
+                    // compatible checkpoint.
                     // TODO: we could also try to move up the assume itself,
-                    // since
-                    // if we move both at the same time, we could even jump over
-                    // effectful instructions.
+                    // since if we move both at the same time, we could even
+                    // jump over effectful instructions.
                     if (auto cp0 = checkpoint.at(instr)) {
                         while (replaced.count(cp0))
                             cp0 = replaced.at(cp0);
@@ -185,12 +183,12 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
         // next checkpoint available we might as well remove this one.
         if (auto cp = Checkpoint::Cast(bb->last())) {
             if (checkpoint.next(cp))
-                if (auto cp0 = checkpoint.at(cp)) {
-                    while (replaced.count(cp0))
-                        cp0 = replaced.at(cp0);
-                    replaced[cp] = cp0;
+                if (auto previousCP = checkpoint.at(cp)) {
+                    while (replaced.count(previousCP))
+                        previousCP = replaced.at(previousCP);
+                    replaced[cp] = previousCP;
 
-                    cp->replaceUsesWith(cp0);
+                    cp->replaceUsesWith(previousCP);
                     bb->remove(bb->end() - 1);
                     delete bb->next1;
                     bb->next1 = nullptr;

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -98,7 +98,10 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                         "is.atomic",   "is.recursive", "is.call",
                         "is.language", "is.function",  "is.single"};
                     if (tests.count(name)) {
-                        inferred = PirType(RType::logical).scalar();
+                        if (!c->arg(0).type().maybeObj())
+                            inferred = PirType(RType::logical).scalar();
+                        else
+                            inferred = i->inferType(getType);
                         break;
                     }
 

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -82,9 +82,13 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                     static const std::unordered_set<std::string> vecTests = {
                         "is.na", "is.nan", "is.finite", "is.infinite"};
                     if (vecTests.count(name)) {
-                        inferred = PirType(RType::logical);
-                        if (getType(c->arg(0).val()).isScalar())
-                            inferred.setScalar();
+                        if (!c->arg(0).type().maybeObj()) {
+                            inferred = PirType(RType::logical);
+                            if (getType(c->arg(0).val()).isScalar())
+                                inferred.setScalar();
+                        } else {
+                            inferred = i->inferType(getType);
+                        }
                         break;
                     }
 

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -62,7 +62,10 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                     }
 
                     if ("abs" == name) {
-                        inferred = c->arg(0).type() & PirType::num();
+                        if (!c->arg(0).type().maybeObj())
+                            inferred = c->arg(0).type() & PirType::num();
+                        else
+                            inferred = i->inferType(getType);
                         break;
                     }
 

--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -182,7 +182,11 @@ bool BB::before(Instruction* a, Instruction* b) const {
     }
     assert(false);
     return false;
-};
+}
+
+// TODO: More robust version. Should be based on real cfg. But on some analysis
+// it is expensive to compute it only for this behavior.
+bool BB::beforeInCfg(BB* otherBB) const { return this->id < otherBB->id; }
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -184,9 +184,5 @@ bool BB::before(Instruction* a, Instruction* b) const {
     return false;
 }
 
-// TODO: More robust version. Should be based on real cfg. But on some analysis
-// it is expensive to compute it only for this behavior.
-bool BB::beforeInCfg(BB* otherBB) const { return this->id < otherBB->id; }
-
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -78,6 +78,7 @@ class BB {
     void swapWithNext(Instrs::iterator);
 
     bool before(Instruction*, Instruction*) const;
+    bool beforeInCfg(BB*) const;
 
     void print(std::ostream&, bool tty);
     void printGraph(std::ostream&, bool omitDeoptBranches);

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -78,7 +78,6 @@ class BB {
     void swapWithNext(Instrs::iterator);
 
     bool before(Instruction*, Instruction*) const;
-    bool beforeInCfg(BB*) const;
 
     void print(std::ostream&, bool tty);
     void printGraph(std::ostream&, bool omitDeoptBranches);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -197,6 +197,8 @@ class Instruction : public Value {
     bool isDeoptBarrier() const {
         auto e = getStrongEffects();
         e.reset(Effect::TriggerDeopt);
+        // Error exits function, so we will never roll back before that effect
+        e.reset(Effect::Error);
         return !e.empty();
     }
 


### PR DESCRIPTION
the reasoning is that errors terminate the function, so no rollback
before the error can happen, thus they can be ignored for assumes.

also this fixes a bug where the assume opt pass would remove too
many cp's since it did skip the first instr of the next bb when
serching for a next cp.

debugging and thinking by @charig