### PR TITLE
explicitly document our decision from where contexts can be observed

### DIFF
--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -117,7 +117,8 @@ class TheInliner {
                                 return false;
                             }
                         }
-                        if (CallInstruction::CastCall(i)) {
+                        if (allowInline == SafeToInline::Yes &&
+                            i->mayObserveContext()) {
                             allowInline = SafeToInline::NeedsContext;
                         }
                         if (auto mk = MkArg::Cast(i)) {

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -62,6 +62,27 @@ void Instruction::printRef(std::ostream& out) const {
         out << "%" << id();
 };
 
+bool Instruction::mayObserveContext(MkEnv* e) const {
+    if (!hasEnv())
+        return false;
+    if (!effects.contains(Effect::Reflection))
+        return false;
+    // This diverges slightly from gnur. We consider that promises cannot
+    // observe contexts of the evaluating context. In gnur it so happens
+    // that they can, but it is unclear if that is intended.
+    // See pir_regression9.r tests for a counterexample.
+    if (tag == Tag::Force)
+        return false;
+    if (e == nullptr)
+        return true;
+    while (e) {
+        if (e == env())
+            return true;
+        e = MkEnv::Cast(e->lexicalEnv());
+    }
+    return false;
+};
+
 void printPaddedInstructionName(std::ostream& out, const std::string& name) {
     out << std::left << std::setw(maxInstructionNameLength + 1) << name << " ";
 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -137,6 +137,7 @@ enum class VisibilityFlag : uint8_t {
     Unknown,
 };
 
+class MkEnv;
 class Instruction : public Value {
   public:
     struct InstructionUID : public std::pair<unsigned, unsigned> {
@@ -199,6 +200,8 @@ class Instruction : public Value {
         e.reset(Effect::TriggerDeopt);
         return !e.empty();
     }
+
+    bool mayObserveContext(MkEnv* c = nullptr) const;
 
     // TODO: Add verify, then replace with effects.includes(Effect::LeakArg)
     bool leaksArg(Value* val) const {
@@ -1017,8 +1020,10 @@ class FLIE(Force, 2, Effects::Any()) {
         : FixedLenInstructionWithEnvSlot(in->type.forced(), {{PirType::any()}},
                                          {{in}}, env) {
         if (auto mk = MkArg::Cast(in)) {
-            if (mk->noReflection)
+            if (mk->noReflection) {
                 elideEnv();
+                effects.reset(Effect::Reflection);
+            }
         }
     }
     Value* input() const { return arg(0).val(); }

--- a/rir/tests/pir_regression9.R
+++ b/rir/tests/pir_regression9.R
@@ -35,3 +35,16 @@ f <- function() {
 }
 for(i in 1:10)
   f()
+
+
+g <- function(a) a
+f <- function(b) g(b)
+bad = function() {e = sys.frame(-1); ls(envir=e)}
+f(bad())
+f(bad())
+f(bad())
+f(bad())
+f(bad())
+# Here we slightly depart from gnur semantics.
+# See Instruction::mayObserveContext exception for Force
+# stopifnot(f(bad()) == "a")


### PR DESCRIPTION
this just better documents the current status.

if we want to keep it this way, or if we consider promise evaluation
to observe the context is an open question.

the regression test contains a commented out repro.

for the record, performance wise this only affects fastaredux.