### PR TITLE
don't hoist typechecks over forces

### DIFF
--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -230,6 +230,7 @@ class Instruction : public Value {
     virtual bool exits() const = 0;
     virtual bool branches() const = 0;
     virtual bool branchOrExit() const = 0;
+    virtual bool isTypecheck() const = 0;
     virtual VisibilityFlag visibilityFlag() const = 0;
 
     virtual size_t nargs() const = 0;
@@ -510,6 +511,7 @@ class InstructionImplementation : public Instruction {
     bool hasEnv() const override final {
         return mayHaveEnv() && env() != Env::elided();
     }
+    bool isTypecheck() const override { return false; }
     bool exits() const override final { return CF == Controlflow::Exit; }
     bool branches() const override final { return CF == Controlflow::Branch; }
     bool branchOrExit() const override final { return branches() || exits(); }
@@ -1412,6 +1414,7 @@ class FLI(IsType, 1, Effects::None()) {
 
     void printArgs(std::ostream& out, bool tty) const override;
 
+    bool isTypecheck() const override final { return true; }
     size_t gvnBase() const override {
         return hash_combine(tagHash(), typeTest);
     }
@@ -2175,6 +2178,7 @@ class FLI(IsObject, 1, Effects::None()) {
     explicit IsObject(Value* v)
         : FixedLenInstruction(NativeType::test, {{PirType::any()}}, {{v}}) {}
 
+    bool isTypecheck() const override final { return true; }
     size_t gvnBase() const override { return tagHash(); }
 };
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -371,6 +371,15 @@ void recordDeoptReason(SEXP val, const DeoptReason& reason) {
         assert(*pos == Opcode::record_type_);
         ObservedValues* feedback = (ObservedValues*)(pos + 1);
         feedback->record(val);
+        if (TYPEOF(val) == PROMSXP) {
+            if (PRVALUE(val) == R_UnboundValue &&
+                feedback->stateBeforeLastForce < ObservedValues::promise)
+                feedback->stateBeforeLastForce = ObservedValues::promise;
+            else if (feedback->stateBeforeLastForce <
+                     ObservedValues::evaluatedPromise)
+                feedback->stateBeforeLastForce =
+                    ObservedValues::evaluatedPromise;
+        }
         break;
     }
     case DeoptReason::Calltarget: {


### PR DESCRIPTION
assume the following code:

    %0  = LdArg(0)
    force(%0)
    ...
    <int~> %1 = ldvar(args)
    force(%1)

so the second load has typefeedback that the promise is evaluated, so we do:

    %0  = LdArg(0)
    force(%0)
    ...
    %1 = ldvar(args)
    %2 = istype(int~, %1)
    assume(%2)
    force(%1)

then we scope resolve ldvar:

    %0  = LdArg(0)
    force(%0)
    ...
    %2 = istype(int~, %0)
    assume(%2)
    force(%0)

and now the istype is directly on the %0 argument
so we hoist the type test (since it is pure) above the first force, which actually forces the argument

    %0  = LdArg(0)
    %2 = istype(int~, %0)
    force(%0)
    ...
    assume(%2)
    force(%0)

and it fails, since before the first force, the promise has no value in the value slot...