### PR TITLE
fix eager call pass

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -175,6 +175,28 @@ class TheVerifier {
             }
         }
 
+        if (auto call = CallSafeBuiltin::Cast(i)) {
+            call->eachCallArg([&](Value* v) {
+                if (v->type.maybePromiseWrapped()) {
+                    std::cerr << "Error: instruction '";
+                    i->print(std::cerr);
+                    std::cerr << "' has prom wrapped arg\n";
+                    ok = false;
+                }
+            });
+        }
+
+        if (auto call = CallBuiltin::Cast(i)) {
+            call->eachCallArg([&](Value* v) {
+                if (v->type.maybePromiseWrapped()) {
+                    std::cerr << "Error: instruction '";
+                    i->print(std::cerr);
+                    std::cerr << "' has prom wrapped arg\n";
+                    ok = false;
+                }
+            });
+        }
+
         if (auto assume = Assume::Cast(i)) {
             if (IsType::Cast(assume->arg(0).val())) {
                 if (assume->feedbackOrigin.empty()) {


### PR DESCRIPTION
the pass was missing an upcast, which caused:

    Force(MkArg(...))

Since MkArg has an eager type (it returns a promise-as-a-value), the force
is a noop, and the whole thing returns a promise. This caused
promises to flow into eager builtins.

Instead we need:

    Force(CastType(lazy, MkArg(...)))

With this the promise-as-a-value is castet to a lazy-value and
force actually evaluates it.