### PR TITLE
fix hoist instruction condition

### DIFF
--- a/rir/src/compiler/opt/hoist_instruction.cpp
+++ b/rir/src/compiler/opt/hoist_instruction.cpp
@@ -123,7 +123,7 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                     if (!x || x == target)
                         return true;
 
-                    if (!x->isEmpty()) {
+                    if (!x->isEmpty() && x != bb) {
                         // We can only hoist effects over branches if both
                         // branch targets will trigger the effect
                         if (x->last()->branches()) {


### PR DESCRIPTION
hoist instruction was blocked by bogus dominance check, when
the target block is already reached.

fixes mandelbrot regression