### PR TITLE
speculate on all ldvars

### DIFF
--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -37,18 +37,9 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                 // Blacklist of where it is not worthwhile
                 if (!LdConst::Cast(arg) &&
                     // leave this to the promise inliner
-                    !MkArg::Cast(arg) && !Force::Cast(arg) &&
-                    // leave this to scope resolution
-                    !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
+                    !MkArg::Cast(arg) && !Force::Cast(arg)) {
                     speculateOn = i;
                 }
-                if (auto ld = LdVar::Cast(arg))
-                    if (!Env::isPirEnv(ld->env()))
-                        speculateOn = i;
-                if (auto ld = LdVarSuper::Cast(arg))
-                    if (!Env::isPirEnv(ld->env()))
-                        speculateOn = i;
-
                 if (speculateOn) {
                     feedback = i->typeFeedback;
                     typecheckPos = i->bb();


### PR DESCRIPTION
Speculate on ldvar and ldvar_super results.

in the past we didn't do that out of fear that we would introduce bogus
checks. but instead this PR adds some constant folding to remove bogus
checks should they appear later. for example this can happen if the
scope resolution pass resolved the ldvar later.