### PR TITLE
Revert "Instead of returning the earliest avaialable checkpoint (which is not…"

### DIFF
--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -11,12 +11,13 @@ namespace pir {
 struct AvailableCheckpointsApply {
     static AbstractResult apply(AbstractUnique<Checkpoint>& state,
                                 Instruction* i) {
-        if (state.get() && i->isDeoptBarrier()) {
-            state.clear();
-            return AbstractResult::Updated;
-        }
-        if (auto cp = Checkpoint::Cast(i)) {
-            if (cp != state.get()) {
+        if (state.get()) {
+            if (i->isDeoptBarrier()) {
+                state.clear();
+                return AbstractResult::Updated;
+            }
+        } else {
+            if (auto cp = Checkpoint::Cast(i)) {
                 state.set(cp);
                 return AbstractResult::Updated;
             }


### PR DESCRIPTION
Reverts reactorlabs/rir#703

I believe that the actual fix is #708

let's see if that is true...