### PR TITLE
fix a bug in checkpoint.next

### DIFF
--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -75,6 +75,14 @@ class AvailableCheckpoints {
         : cfg(cls), fwd(cls, log), rwd(cls, cfg, log) {}
 
     Checkpoint* at(Instruction* i) { return fwd.reaching(i); }
+    Checkpoint* next(Instruction* i, Instruction* dependency,
+                     const DominanceGraph& dom) {
+        Checkpoint* res = next(i);
+        if (res && (dependency->bb() == res->bb() ||
+                    dom.dominates(dependency->bb(), res->bb())))
+            return res;
+        return nullptr;
+    }
     Checkpoint* next(Instruction* i) {
         // Search for the next cp only in main path, not the deopt branch
         if (auto cp = Checkpoint::Cast(i)) {

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -18,6 +18,7 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                          LogStream& log) const {
 
     AvailableCheckpoints checkpoint(function, log);
+    DominanceGraph dom(function);
 
     auto envOnlyForObj = [&](Instruction* i) {
         if (i->envOnlyForObj())
@@ -160,7 +161,7 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                 } else {
                     // We can only stub an environment if all uses have a
                     // checkpoint available after every use.
-                    if (auto cp = checkpoint.next(i))
+                    if (auto cp = checkpoint.next(i, mk, dom))
                         checks[i] = std::pair<Checkpoint*, MkEnv*>(cp, mk);
                     else
                         bannedEnvs.insert(mk);

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -22,6 +22,7 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                                 std::pair<Checkpoint*, TypeTest::Info>>>
         speculate;
 
+    auto dom = DominanceGraph(function);
     Visitor::run(function->entry, [&](Instruction* i) {
         if (i->typeFeedback.type.isVoid() || i->type.isA(i->typeFeedback.type))
             return;
@@ -66,7 +67,7 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                         break;
                     case Force::ArgumentKind::promise:
                     case Force::ArgumentKind::unknown:
-                        guardPos = checkpoint.next(i);
+                        guardPos = checkpoint.next(i, speculateOn, dom);
                         if (guardPos)
                             typecheckPos = guardPos->nextBB();
                         break;

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -241,11 +241,11 @@ BB* BBTransform::lowerExpect(Code* code, BB* src, BB::Instrs::iterator position,
     return split;
 }
 
-void BBTransform::insertAssume(Value* condition, Checkpoint* cp, BB* bb,
+void BBTransform::insertAssume(Instruction* condition, Checkpoint* cp, BB* bb,
                                BB::Instrs::iterator& position,
                                bool assumePositive, rir::Code* srcCode,
                                Opcode* origin) {
-    position = bb->insert(position, (Instruction*)condition);
+    position = bb->insert(position, condition);
     auto assume = new Assume(condition, cp);
     if (srcCode) {
         assert(origin);
@@ -257,7 +257,7 @@ void BBTransform::insertAssume(Value* condition, Checkpoint* cp, BB* bb,
     position++;
 };
 
-void BBTransform::insertAssume(Value* condition, Checkpoint* cp,
+void BBTransform::insertAssume(Instruction* condition, Checkpoint* cp,
                                bool assumePositive, rir::Code* srcCode,
                                Opcode* origin) {
     auto contBB = cp->bb()->trueBranch();

--- a/rir/src/compiler/transform/bb.h
+++ b/rir/src/compiler/transform/bb.h
@@ -28,11 +28,11 @@ class BBTransform {
                            bool condition, BB* deoptBlock,
                            const std::string& debugMesage,
                            bool triggerAnyway = false);
-    static void insertAssume(Value* condition, Checkpoint* cp, BB* bb,
+    static void insertAssume(Instruction* condition, Checkpoint* cp, BB* bb,
                              BB::Instrs::iterator& position,
                              bool assumePositive, rir::Code* srcCode = nullptr,
                              Opcode* origin = nullptr);
-    static void insertAssume(Value* condition, Checkpoint* cp,
+    static void insertAssume(Instruction* condition, Checkpoint* cp,
                              bool assumePositive, rir::Code* srcCode = nullptr,
                              Opcode* origin = nullptr);
 


### PR DESCRIPTION
that would return checkpoints, which are not dominated by the place
we want to speculate.