### PR TITLE
Maybe better cast insert

### DIFF
--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -29,8 +29,8 @@ struct AvailableCheckpointsApply {
 class FwdAvailableCheckpoints
     : public StaticAnalysis<AbstractUnique<Checkpoint>> {
   public:
-    FwdAvailableCheckpoints(ClosureVersion* cls, LogStream& log)
-        : StaticAnalysis("FwdAvailableCheckpoints", cls, cls, log) {}
+    FwdAvailableCheckpoints(ClosureVersion* cls, Code* code, LogStream& log)
+        : StaticAnalysis("FwdAvailableCheckpoints", cls, code, log) {}
 
     AbstractResult apply(AbstractUnique<Checkpoint>& state,
                          Instruction* i) const override {
@@ -45,8 +45,9 @@ class FwdAvailableCheckpoints
 class RwdAvailableCheckpoints
     : public BackwardStaticAnalysis<AbstractUnique<Checkpoint>> {
   public:
-    RwdAvailableCheckpoints(ClosureVersion* cls, const CFG& cfg, LogStream& log)
-        : BackwardStaticAnalysis("RwdAvailableCheckpoints", cls, cls, cfg,
+    RwdAvailableCheckpoints(ClosureVersion* cls, Code* code, const CFG& cfg,
+                            LogStream& log)
+        : BackwardStaticAnalysis("RwdAvailableCheckpoints", cls, code, cfg,
                                  log) {}
 
     AbstractResult apply(AbstractUnique<Checkpoint>& state,
@@ -71,8 +72,8 @@ class AvailableCheckpoints {
     RwdAvailableCheckpoints rwd;
 
   public:
-    AvailableCheckpoints(ClosureVersion* cls, LogStream& log)
-        : cfg(cls), fwd(cls, log), rwd(cls, cfg, log) {}
+    AvailableCheckpoints(ClosureVersion* cls, Code* code, LogStream& log)
+        : cfg(code), fwd(cls, code, log), rwd(cls, code, cfg, log) {}
 
     Checkpoint* at(Instruction* i) { return fwd.reaching(i); }
     Checkpoint* next(Instruction* i, Instruction* dependency,

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -75,7 +75,7 @@ void OptimizeAssumptions::apply(RirCompiler&, ClosureVersion* function,
 
     DeadInstructions exceptTypecheck(function, 1, Effects(),
                                      DeadInstructions::IgnoreTypeTests);
-    AvailableCheckpoints checkpoint(function, log);
+    AvailableCheckpoints checkpoint(function, function, log);
     AvailableAssumptions assumptions(function, log);
     DominanceGraph dom(function);
     std::unordered_map<Checkpoint*, Checkpoint*> replaced;

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -19,7 +19,7 @@ namespace pir {
 void EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                        LogStream& log) const {
     auto code = closure->entry;
-    AvailableCheckpoints checkpoint(closure, log);
+    AvailableCheckpoints checkpoint(closure, closure, log);
 
     auto replaceLdFunBuiltinWithDeopt = [&](BB* bb, BB::Instrs::iterator ip,
                                             Checkpoint* cp, SEXP builtin,

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -17,7 +17,7 @@ namespace pir {
 void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                          LogStream& log) const {
 
-    AvailableCheckpoints checkpoint(function, log);
+    AvailableCheckpoints checkpoint(function, function, log);
     DominanceGraph dom(function);
 
     auto envOnlyForObj = [&](Instruction* i) {

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -252,7 +252,7 @@ struct ForcedBy {
 
     PromiseInlineable isSafeToInline(MkArg* a) const {
         // To inline promises with a deopt instruction we need to be able to
-        // synthesize promises and promise call framse.
+        // synthesize promises and promise call frames.
         auto prom = a->prom();
         if (hasDeopt.count(prom)) {
             if (hasDeopt.at(prom))

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -15,7 +15,7 @@ namespace pir {
 void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                             LogStream& log) const {
 
-    AvailableCheckpoints checkpoint(function, log);
+    AvailableCheckpoints checkpoint(function, function, log);
 
     std::unordered_map<
         BB*, std::unordered_map<Instruction*,

--- a/rir/src/compiler/transform/insert_cast.h
+++ b/rir/src/compiler/transform/insert_cast.h
@@ -1,6 +1,7 @@
 #ifndef COMPILER_PIR_INSERT_CAST_H
 #define COMPILER_PIR_INSERT_CAST_H
 
+#include "../analysis/available_checkpoints.h"
 #include "../pir/pir.h"
 
 namespace rir {
@@ -14,14 +15,14 @@ namespace pir {
  *
  */
 class InsertCast {
-    BB* start;
+    Code* code;
     Value* env;
-    void apply(BB* b);
+    void apply(BB* b, AvailableCheckpoints& cp);
 
   public:
     static pir::Instruction* cast(pir::Value* v, PirType t, Value* env);
 
-    InsertCast(BB* s, Value* e) : start(s), env(e) {}
+    InsertCast(Code* s, Value* e) : code(s), env(e) {}
     void operator()();
 };
 }

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -1331,7 +1331,7 @@ void Rir2Pir::finalize(Value* ret, Builder& insert) {
     // to find the context to return to.
     insert(new Return(ret));
 
-    InsertCast c(insert.code->entry, insert.env);
+    InsertCast c(insert.code, insert.env);
     c();
 
     finalized = true;


### PR DESCRIPTION
It was usually inserted where it is required. But in case there is no checkpoint, we can also try to insert it near the original instruction if there a cp is available.