### PR TITLE
Revert "speculate on all ldvars"

### DIFF
--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -37,9 +37,18 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                 // Blacklist of where it is not worthwhile
                 if (!LdConst::Cast(arg) &&
                     // leave this to the promise inliner
-                    !MkArg::Cast(arg) && !Force::Cast(arg)) {
+                    !MkArg::Cast(arg) && !Force::Cast(arg) &&
+                    // leave this to scope resolution
+                    !LdVar::Cast(arg) && !LdVarSuper::Cast(arg)) {
                     speculateOn = i;
                 }
+                if (auto ld = LdVar::Cast(arg))
+                    if (!Env::isPirEnv(ld->env()))
+                        speculateOn = i;
+                if (auto ld = LdVarSuper::Cast(arg))
+                    if (!Env::isPirEnv(ld->env()))
+                        speculateOn = i;
+
                 if (speculateOn) {
                     feedback = i->typeFeedback;
                     typecheckPos = i->bb();


### PR DESCRIPTION
This reverts commit 5dd9317a8c527a0e81ebbbdd4e164d32fb568b67.

badly regresses a number of benchmarks. need to investigate