### PR TITLE
pin the benchmarks version

### DIFF
--- a/container/benchmark-baseline/Dockerfile
+++ b/container/benchmark-baseline/Dockerfile
@@ -3,7 +3,6 @@ FROM registry.gitlab.com/rirvm/rir_mirror/base
 ARG GRAAL_VERSION=1.0.0-rc16
 
 RUN git clone --depth 1 https://github.com/reactorlabs/ReBench.git -b envVarsSupport /opt/ReBench && cd /opt/ReBench && pip install .
-RUN git clone --depth 1 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking
+RUN git clone --depth 1 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking && cd /opt/rbenchmarking && git checkout 9433616928632c3ec299cc803eebbd8afecd892d
 RUN git clone --recursive https://github.com/reactorlabs/rir /opt/rir && cd /opt/rir && tools/sync.sh && git -C external/custom-r checkout R-3.5.1 && tools/build-gnur.sh custom-r && rm -rf custom-r/cache_recommended.tar custom-r/src .git
 RUN curl --fail --silent --location --retry 3 https://github.com/oracle/graal/releases/download/vm-$GRAAL_VERSION/graalvm-ce-$GRAAL_VERSION-linux-amd64.tar.gz | gunzip | tar x -C /opt/ && cd /opt && ln -s graalvm-ce-$GRAAL_VERSION graal && cd /opt/graal/bin && ./gu install R
-

--- a/container/benchmark/Dockerfile
+++ b/container/benchmark/Dockerfile
@@ -1,4 +1,4 @@
 ARG CI_COMMIT_SHA
 FROM registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
 RUN git clone --depth 1 https://github.com/reactorlabs/ReBench.git -b envVarsSupport /opt/ReBench && cd /opt/ReBench && pip install .
-RUN git clone --depth 1 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking
+RUN git clone --depth 1 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking && cd /opt/rbenchmarking && git checkout 9433616928632c3ec299cc803eebbd8afecd892d


### PR DESCRIPTION
this ensures that changes to the benchmark repo do not break PRs in
flight. This allows us to add tests, then run a full testrun on them,
while the CI other PRs are unaffected.