### PR TITLE
fix cleanup of visibility instructions

### DIFF
--- a/rir/src/compiler/analysis/dead.cpp
+++ b/rir/src/compiler/analysis/dead.cpp
@@ -16,8 +16,9 @@ DeadInstructions::DeadInstructions(Code* code, uint8_t maxBurstSize,
         // unused ldfun must be a left over from a guard where ldfun was
         // converted into ldvar.
         if (dataDependencies.at(i).empty() &&
-            (LdFun::Cast(i) || (i->getObservableEffects() <= ignoreEffects &&
-                                !i->branchOrExit())))
+            (LdFun::Cast(i) ||
+             ((i->getObservableEffects() / ignoreEffects).empty() &&
+              !i->branchOrExit())))
             unused_.insert(i);
     });
     auto i = 1;
@@ -27,8 +28,8 @@ DeadInstructions::DeadInstructions(Code* code, uint8_t maxBurstSize,
             auto candidate = instructionUses.first;
             auto addToDead = true;
             if (unused_.count(candidate) ||
-                (candidate->getObservableEffects() > ignoreEffects) ||
-                candidate->branchOrExit())
+                (!(candidate->getObservableEffects() / ignoreEffects).empty() ||
+                 candidate->branchOrExit()))
                 continue;
             auto uses = instructionUses.second;
             for (auto use : uses) {

--- a/rir/src/utils/EnumSet.h
+++ b/rir/src/utils/EnumSet.h
@@ -95,9 +95,9 @@ class EnumSet {
         return EnumSet(~set_ & Any());
     }
 
-    RIR_INLINE bool operator<(const EnumSet& s) const { return set_ < s.set_; }
-
-    RIR_INLINE bool operator>(const EnumSet& s) const { return set_ > s.set_; }
+    constexpr EnumSet operator/(const EnumSet& other) const {
+        return *this & ~other;
+    }
 
     RIR_INLINE bool operator!=(const EnumSet& s) const {
         return set_ != s.set_;


### PR DESCRIPTION
Invisible and Visible cannot be removed just like that. We need to
preserve their effects. There is a separate visibility optimizations
that correctly deals with them.

Also effects are a set!