### PR TITLE
Raise limits

### DIFF
--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.cpp
@@ -269,7 +269,7 @@ void Rir2PirCompiler::optimizeModule() {
 }
 
 size_t Parameter::MAX_INPUT_SIZE =
-    getenv("PIR_MAX_INPUT_SIZE") ? atoi(getenv("PIR_MAX_INPUT_SIZE")) : 3500;
+    getenv("PIR_MAX_INPUT_SIZE") ? atoi(getenv("PIR_MAX_INPUT_SIZE")) : 6000;
 
 } // namespace pir
 } // namespace rir


### PR DESCRIPTION
this explodes compile time on some benchmarks. we should work on that.

currently assumption and force_dominance seem to be really slow.