### PR TITLE
prevent accidental materialization of stubs

### DIFF
--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -147,7 +147,8 @@ class TheCleanup {
                     }
                 } else if (auto test = IsEnvStub::Cast(i)) {
                     if (test->env() == Env::elided()) {
-                        i->replaceUsesWith(False::instance());
+                        // Assuming only env stubs are elided, see case above
+                        i->replaceUsesWith(True::instance());
                         removed = true;
                         next = bb->remove(ip);
                     }

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -235,16 +235,6 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
                 }
             }
 
-            if (auto isTest = IsEnvStub::Cast(i)) {
-                if (auto environment = MkEnv::Cast(isTest->env())) {
-                    static std::unordered_set<Tag> tags{Tag::Force};
-                    if (environment->usesDoNotInclude(bb, tags)) {
-                        i->replaceUsesWith(True::instance());
-                        next = bb->remove(ip);
-                    }
-                }
-            }
-
             if (auto assume = Assume::Cast(i)) {
                 if (assume->arg<0>().val() == True::instance() &&
                     assume->assumeTrue)

--- a/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
+++ b/rir/src/compiler/translations/pir_2_rir/pir_2_rir.cpp
@@ -580,10 +580,11 @@ rir::Code* Pir2Rir::compileCode(Context& ctx, Code* code) {
                         }
                         argNumber++;
                     });
+
                     // This is needed to prevent builtin calls from
                     // materializing env stubs
                     if (CallSafeBuiltin::Cast(instr) ||
-                        (CallInstruction::CastCall(instr) &&
+                        (instr->mayHaveEnv() &&
                          instr->env() == Env::elided())) {
                         auto cur = lastEnv.currentEnv(instr);
                         if (!cur ||

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1952,8 +1952,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(materialize_env_) {
             auto lazyEnv = LazyEnvironment::check(env);
-            assert(lazyEnv);
-            if (!lazyEnv->materialized())
+            if (lazyEnv && !lazyEnv->materialized())
                 env = materialize(env);
             ostack_push(ctx, env);
             NEXT();
@@ -2383,6 +2382,7 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
             SLOWASSERT(TYPEOF(sym) == SYMSXP);
             SEXP val = ostack_pop(ctx);
             auto le = LazyEnvironment::check(env);
+            assert(!le || !le->materialized());
             SEXP superEnv;
             if (le)
                 superEnv = le->getParent();

--- a/rir/tests/fasta_regression.r
+++ b/rir/tests/fasta_regression.r
@@ -1,0 +1,105 @@
+# ------------------------------------------------------------------
+# The Computer Language Shootout
+# http://shootout.alioth.debian.org/
+#
+# Contributed by Leo Osvald
+# ------------------------------------------------------------------
+width <- 60L
+myrandom_last <- 42L
+myrandom <- function(m) {
+    myrandom_last <<- (myrandom_last * 3877L + 29573L) %% 139968L
+    return(m * myrandom_last / 139968)
+}
+
+alu <- paste(
+    "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGG",
+    "GAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGTTCGAGA",
+    "CCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAAT",
+    "ACAAAAATTAGCCGGGCGTGGTGGCGCGCGCCTGTAATCCCA",
+    "GCTACTCGGGAGGCTGAGGCAGGAGAATCGCTTGAACCCGGG",
+    "AGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCC",
+    "AGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA",
+    sep="", collapse="")
+
+iub <- matrix(c(
+    c(0.27, 'a'),
+    c(0.12, 'c'),
+    c(0.12, 'g'),
+    c(0.27, 't'),
+    c(0.02, 'B'),
+    c(0.02, 'D'),
+    c(0.02, 'H'),
+    c(0.02, 'K'),
+    c(0.02, 'M'),
+    c(0.02, 'N'),
+    c(0.02, 'R'),
+    c(0.02, 'S'),
+    c(0.02, 'V'),
+    c(0.02, 'W'),
+    c(0.02, 'Y')
+), 2)
+
+homosapiens <- matrix(c(
+    c(0.3029549426680, 'a'),
+    c(0.1979883004921, 'c'),
+    c(0.1975473066391, 'g'),
+    c(0.3015094502008, 't')
+), 2)
+
+repeat_fasta <- function(s, count) {
+    chars = strsplit(s, split="")[[1]]
+    len = nchar(s)
+    s2 <- character(len + width)
+    for (i in 1:len)
+        s2[[i]] <- chars[[i]]
+    for (i in 1:width)
+        s2[[len + i]] <- chars[[i]]
+    pos <- 1L
+    while (count) {
+	line = min(width, count)
+        next_pos <- pos + line
+        pos <- next_pos
+        if (pos > len) pos <- pos - len
+	count <- count - line
+    }
+}
+
+random_fasta <- function(genelist, count) {
+    psum = cumsum(genelist[1,])
+    n = length(psum)
+    while (count) {
+	line = min(width, count)
+       	seq <- character(line)
+        for (i in 1:line) {
+            r <- myrandom(1)
+            # Binary search
+            lo <- 1L; hi <- n
+	    while (lo < hi) {
+	        mid1 <- lo + hi
+	        mid2 <- mid1 - 1L
+	        mid <- mid2 %/% 2
+                if (mid > hi)
+                  error("")
+	        if (psum[[mid]] >= r) hi <- mid
+                else lo <- mid + 1L
+	    }
+            seq[[i]] <- genelist[[2, hi]]
+        }
+	count <- count - line
+    }
+}
+
+fasta_naive_2 <- function(args) {
+    n = if (length(args)) as.integer(args[[1]]) else 1000L
+    repeat_fasta(alu, 2 * n)
+    random_fasta(iub, 3L * n)
+    random_fasta(homosapiens, 5L * n)
+}
+
+execute <- function(n) {
+    fasta_naive_2(n)
+}
+
+execute(800)
+execute(800)
+execute(800)

--- a/rir/tests/regression_bounce.r
+++ b/rir/tests/regression_bounce.r
@@ -1,0 +1,77 @@
+execute <- function () {
+    seed <- NaN
+
+    resetSeed <- function() seed <<- 74755
+
+    nextRandom <- function() {
+      seed <<- bitwAnd((seed * 1309) + 13849, 65535)
+      return (seed)
+    }
+
+    ballCount <- 100
+    bounces   <- 0
+    balls     = vector("list", length = ballCount)
+    resetSeed()
+
+    for (i in 1:ballCount) {
+        random1 <- nextRandom()
+        random2 <- nextRandom()
+        random3 <- nextRandom()
+        random4 <- nextRandom()
+        balls[[i]] = c(random1 %% 500, random2 %% 500, 
+                             (random3 %% 300) - 150, (random4 %% 300) - 150)
+    }
+
+    ball <- function(ball) {
+        results <- bounce(ball)
+        if (results[[2]]) bounces <<- bounces + 1
+        return (results[[1]])
+    }
+
+    for (i in 1:50) {
+      balls <- lapply(balls, ball)
+    }
+
+    return (bounces)
+}
+
+verifyResult <- function(result) {
+    print (result)
+    return (result == 1331);
+}
+
+bounce <- function(ball) {
+    xLimit  <- 500
+    yLimit  <- 500
+    bounced <- FALSE
+
+    ball[1] <- ball[1] + ball[3];
+    ball[2] <- ball[2] + ball[4];
+
+    if (ball[1] > xLimit) {
+        ball[1] <- xLimit 
+        ball[3] <- 0 - abs(ball[3]) 
+        bounced <- TRUE
+    }
+    if (ball[1] < 0) {
+        ball[1] <- 0
+        ball[3] <- abs(ball[3])
+        bounced <- TRUE
+    }
+    if (ball[2] > yLimit) {
+        ball[2] <- yLimit
+        ball[4] <- 0 - abs(ball[4])
+        bounced <- TRUE
+    }
+    if (ball[2] < 0) {
+        ball[2] <- 0 
+        ball[4] <- abs(ball[4])
+        bounced <- TRUE
+    }
+    return (list(ball, bounced))
+}
+
+for (i in 1:4) {
+  r=execute()
+  stopifnot(verifyResult(r))
+}


### PR DESCRIPTION
stub envs were still left in the env slot way too often. This caused a
lot of unneccessary deoptimization due to env stubs being materialized
and hence covered a lot of bugs regarding them.

In particular constant folding assumed that only Force instructions can
materialize env stubs, cleanup wrongly replaces isEnvStub by false, and
instructions which depend on having stub envs were not marked as
depending on the assume.