### PR TITLE
rewrite the static named count approximation

### DIFF
--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -127,6 +127,8 @@ class StaticAnalysis {
             snapshots[e->id].entry = initialState;
     }
 
+    const GlobalAbstractState& getGlobalState() { return *globalState; }
+
     const AbstractState& result() const {
         if (!done)
             const_cast<StaticAnalysis*>(this)->operator()();

--- a/rir/src/compiler/native/lower_llvm.h
+++ b/rir/src/compiler/native/lower_llvm.h
@@ -1,6 +1,7 @@
 #ifndef PIR_COMPILER_LOWER_LLVM_H
 #define PIR_COMPILER_LOWER_LLVM_H
 
+#include "../analysis/reference_count.h"
 #include "compiler/pir/pir.h"
 #include "runtime/Code.h"
 #include <unordered_map>
@@ -15,10 +16,8 @@ class LowerLLVM {
     void*
     tryCompile(ClosureVersion* cls, Code* code,
                const std::unordered_map<Promise*, unsigned>&,
-               const std::unordered_set<Instruction*>& needsEnsureNamed,
-               const std::unordered_set<Instruction*>& needsSetShared,
-               const std::unordered_set<Instruction*>& needsLdVarForUpdate,
-               bool refcountAnalysisOverflow);
+               const NeedsRefcountAdjustment& refcount,
+               const std::unordered_set<Instruction*>& needsLdVarForUpdate);
 };
 
 } // namespace pir

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -420,6 +420,8 @@ bool Instruction::usesDoNotInclude(BB* target, std::unordered_set<Tag> tags) {
 }
 
 const Value* Instruction::cFollowCasts() const {
+    if (auto cast = PirCopy::Cast(this))
+        return cast->arg<0>().val()->followCasts();
     if (auto cast = CastType::Cast(this))
         return cast->arg<0>().val()->followCasts();
     if (auto chk = ChkClosure::Cast(this))
@@ -430,6 +432,8 @@ const Value* Instruction::cFollowCasts() const {
 }
 
 const Value* Instruction::cFollowCastsAndForce() const {
+    if (auto cast = PirCopy::Cast(this))
+        return cast->arg<0>().val()->followCasts();
     if (auto cast = CastType::Cast(this))
         return cast->arg<0>().val()->followCastsAndForce();
     if (auto force = Force::Cast(this))


### PR DESCRIPTION
the previous analysis was mostly broken. In particular it did not
correctly detect cases where values overwritten by subassign are use.
For example:

    subassign(..., x, ...)
    use(x)

when translated naively to rir, will cause x to be overwritten by
subassign and then used later in modified form, when actually ssa
semantics would demand that it is unmodified.

the new analysis is based on a taint analysis, that tries to detect
values that are tainted and then used after that.

it improves the precision by correctly modeling how values flow into
phis and how phis get tainted or not.