### PR TITLE
deduplicate created phis in scope resolution

### DIFF
--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -61,14 +61,16 @@ void TypeInference::apply(RirCompiler&, ClosureVersion* function,
                         break;
                     }
 
-                    if ("abs" == name) {
-                        if (!getType(c->callArg(0).val()).maybeObj()) {
-                            inferred =
-                                getType(c->callArg(0).val()) & PirType::num();
-                        } else {
-                            inferred = i->inferType(getType);
+                    if ("abs" == name || "min" == name || "max" == name) {
+                        if (c->nCallArgs()) {
+                            auto m = getType(c->callArg(0).val());
+                            if (c->nCallArgs() > 1)
+                                m = m.mergeWithConversion(getType(c->callArg(1).val()));
+                            if (!m.maybeObj()) {
+                                inferred = m & PirType::num();
+                                break;
+                            }
                         }
-                        break;
                     }
 
                     if ("as.integer" == name) {

--- a/rir/src/compiler/util/phi_placement.h
+++ b/rir/src/compiler/util/phi_placement.h
@@ -10,6 +10,7 @@
 namespace rir {
 namespace pir {
 
+class Phi;
 class PhiPlacement {
   public:
     struct PhiInput {
@@ -21,14 +22,15 @@ class PhiPlacement {
                    otherPhi == other.otherPhi && aValue == other.aValue;
         }
     };
-    typedef std::unordered_map<BB*, SmallSet<PhiInput>> Phis;
-    bool success = false;
-    BB* targetPhiPosition = nullptr;
-    Phis placement;
 
-    PhiPlacement(ClosureVersion* cls, BB* target,
+    PhiPlacement(ClosureVersion* cls,
                  const std::unordered_map<BB*, Value*>& inputs,
                  const DominanceGraph& dom, const DominanceFrontier&);
+
+    typedef std::unordered_map<BB*, SmallSet<PhiInput>> Phis;
+
+    Phis placement;
+    std::unordered_map<BB*, BB*> dominatingPhi;
 };
 
 } // namespace pir


### PR DESCRIPTION
Cache the phis we create in scope resolution to avoid creating the same
phis several times which makes it hard to clean up later.