### PR TITLE
fix typecheck

### DIFF
--- a/rir/src/compiler/native/lower_llvm.cpp
+++ b/rir/src/compiler/native/lower_llvm.cpp
@@ -2193,6 +2193,14 @@ bool LowerFunctionLLVM::tryCompile() {
                                         constant(R_BaseEnv, t::SEXP));
                 };
 
+                auto fixVisibility = [&]() {
+                    if (!b->effects.contains(Effect::Visibility))
+                        return;
+                    int flag = getFlag(b->builtinId);
+                    if (flag < 2)
+                        setVisible(flag != 1);
+                };
+
                 // TODO: this should probably go somewhere else... This is
                 // an inlined version of bitwise builtins
                 if (representationOf(b) == Representation::Integer) {
@@ -2336,6 +2344,7 @@ bool LowerFunctionLLVM::tryCompile() {
 
                                 builder.SetInsertPoint(done);
                                 setVal(i, builder.CreateLoad(res));
+                                fixVisibility();
                                 break;
                             }
                         }
@@ -2502,8 +2511,10 @@ bool LowerFunctionLLVM::tryCompile() {
                     default:
                         done = false;
                     };
-                    if (done)
+                    if (done) {
+                        fixVisibility();
                         break;
+                    }
                 }
 
                 if (b->nargs() == 2) {
@@ -2584,8 +2595,10 @@ bool LowerFunctionLLVM::tryCompile() {
                         break;
                     }
                     }
-                    if (success)
+                    if (success) {
+                        fixVisibility();
                         break;
+                    }
                 }
 
                 if (b->builtinId == 90) { // "c"
@@ -2611,6 +2624,7 @@ bool LowerFunctionLLVM::tryCompile() {
                             pos++;
                         });
                         setVal(i, res);
+                        fixVisibility();
                         break;
                     }
                 }
@@ -2626,6 +2640,7 @@ bool LowerFunctionLLVM::tryCompile() {
                         pos++;
                     });
                     setVal(i, res);
+                    fixVisibility();
                     break;
                 }
 

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -64,8 +64,16 @@ void ElideEnvSpec::apply(RirCompiler&, ClosureVersion* function,
                                  !seen.type.isA(j->typeFeedback.type)))
                                 seen = j->typeFeedback;
 
+                        auto required = arg->type.notObject();
+                        auto suggested = required;
+                        // so far the only instruction where we can do more
+                        // opts if we show that the vector has no attribs
+                        if (auto e = Extract1_1D::Cast(i))
+                            if (arg == e->vec())
+                                suggested = required.noAttribs();
+
                         TypeTest::Create(
-                            arg, seen,
+                            arg, seen, suggested, required,
                             [&](TypeTest::Info info) {
                                 BBTransform::insertAssume(
                                     info.test, cp, bb, ip, info.expectation,

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -72,8 +72,7 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                     }
                 }
             }
-        } else if ((!i->type.unboxable() && i->typeFeedback.type.unboxable()) ||
-                   (i->type.maybeObj() && !i->typeFeedback.type.maybeObj())) {
+        } else if (!i->type.unboxable() && i->typeFeedback.type.unboxable()) {
             speculateOn = i;
             feedback = i->typeFeedback;
             guardPos = checkpoint.next(i, i, dom);
@@ -85,7 +84,8 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
             return;
 
         TypeTest::Create(
-            speculateOn, feedback,
+            speculateOn, feedback, speculateOn->type.notObject(),
+            PirType::any(),
             [&](TypeTest::Info info) {
                 speculate[typecheckPos][speculateOn] = {guardPos, info};
                 // Prevent redundant speculation

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -485,7 +485,7 @@ LdConst::LdConst(SEXP c, PirType t)
 LdConst::LdConst(SEXP c)
     : FixedLenInstruction(PirType(c)), idx(Pool::insert(c)) {}
 LdConst::LdConst(int num)
-    : FixedLenInstruction(PirType(RType::integer).scalar().notObject()),
+    : FixedLenInstruction(PirType(RType::integer).scalar().noAttribs()),
       idx(Pool::getInt(num)) {}
 
 SEXP LdConst::c() const { return Pool::get(idx); }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1110,7 +1110,7 @@ class FLI(AsLogical, 1, Effect::Error) {
     Effects inferEffects(const GetType& getType) const override final {
         if (getType(val()).isA((PirType() | RType::logical | RType::integer |
                                 RType::real | RType::str | RType::cplx)
-                                   .notObject())) {
+                                   .noAttribs())) {
             return Effects::None();
         }
         return effects;
@@ -1139,7 +1139,7 @@ class FLI(AsInt, 1, Effect::Error) {
     bool ceil;
 
     explicit AsInt(Value* in, bool ceil_)
-        : FixedLenInstruction(PirType(RType::integer).scalar().notObject(),
+        : FixedLenInstruction(PirType(RType::integer).scalar().noAttribs(),
                               {{PirType::any()}}, {{in}}),
           ceil(ceil_) {}
 
@@ -1392,8 +1392,8 @@ class FLIE(Extract1_3D, 5, Effects::Any()) {
 class FLI(Inc, 1, Effects::None()) {
   public:
     explicit Inc(Value* v)
-        : FixedLenInstruction(PirType(RType::integer).scalar().notObject(),
-                              {{PirType(RType::integer).scalar().notObject()}},
+        : FixedLenInstruction(PirType(RType::integer).scalar().noAttribs(),
+                              {{PirType(RType::integer).scalar().noAttribs()}},
                               {{v}}) {}
     size_t gvnBase() const override { return tagHash(); }
 };
@@ -1401,8 +1401,8 @@ class FLI(Inc, 1, Effects::None()) {
 class FLI(Dec, 1, Effects::None()) {
   public:
     explicit Dec(Value* v)
-        : FixedLenInstruction(PirType(RType::integer).scalar().notObject(),
-                              {{PirType(RType::integer).scalar().notObject()}},
+        : FixedLenInstruction(PirType(RType::integer).scalar().noAttribs(),
+                              {{PirType(RType::integer).scalar().noAttribs()}},
                               {{v}}) {}
     size_t gvnBase() const override { return tagHash(); }
 };

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -98,9 +98,10 @@ PirType::PirType(SEXP e) : flags_(defaultRTypeFlags()), t_(RTypeSet()) {
     else
         merge(TYPEOF(e));
 
-    if (!Rf_isObject(e)) {
+    if (!Rf_isObject(e))
         flags_.reset(TypeFlags::maybeObject);
-    }
+    if (fastVeceltOk(e))
+        flags_.reset(TypeFlags::maybeAttrib);
 
     if (PirType::vecs().isSuper(*this)) {
         if (Rf_length(e) == 1)

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -512,7 +512,9 @@ struct PirType {
         }
         if ((!maybeLazy() && o.maybeLazy()) ||
             (!maybePromiseWrapped() && o.maybePromiseWrapped()) ||
-            (!maybeObj() && o.maybeObj()) || (isScalar() && !o.isScalar())) {
+            (!maybeObj() && o.maybeObj()) ||
+            (!maybeHasAttrs() && o.maybeHasAttrs()) ||
+            (isScalar() && !o.isScalar())) {
             return false;
         }
         return t_.r.includes(o.t_.r);

--- a/rir/src/compiler/util/type_test.h
+++ b/rir/src/compiler/util/type_test.h
@@ -16,42 +16,54 @@ class TypeTest {
         Opcode* origin;
     };
     static void Create(Value* i, const Instruction::TypeFeedback& feedback,
+                       const PirType& suggested, const PirType& required,
                        const std::function<void(Info)>& action,
                        const std::function<void()>& failed) {
-        auto possible = i->type & feedback.type;
+        auto expected = i->type & feedback.type;
 
-        if (i->type.isA(possible))
+        if (i->type.isA(expected))
             return;
 
-        if (possible.isVoid())
-            return failed();
+        if (expected.isVoid() || expected.maybeLazy()) {
+            if (i->type.isA(required))
+                return;
+            else
+                return failed();
+        }
 
         assert(feedback.origin);
-        if (possible.isA(PirType(RType::integer).orPromiseWrapped()) ||
-            possible.isA(PirType(RType::real).orPromiseWrapped()) ||
-            possible.isA(PirType(RType::logical).orPromiseWrapped())) {
-            return action({possible, new IsType(possible, i), true,
+        // First try to refine the type
+        if (expected.orNotScalar().isA(RType::integer) ||
+            expected.orNotScalar().isA(RType::real) ||
+            expected.orNotScalar().isA(RType::logical)) {
+            return action({expected, new IsType(expected, i), true,
                            feedback.srcCode, feedback.origin});
         }
 
-        if (possible.maybeLazy())
-            return failed();
+        // Second try to test for object-ness, or attribute-ness.
+        // Let's only do that if required, to avoid testing a non-object for
+        // non-attribute. ie. convert a val' to a val'', which is technically a
+        // refinement, but hardly ever useful.
+        if (i->type.isA(suggested))
+            return;
 
-        if (i->type.maybeHasAttrs() && !possible.maybeHasAttrs()) {
-            auto expect = i->type.notLazy().noAttribs();
-            assert(!possible.maybeObj());
-            assert(!possible.maybeHasAttrs());
-            return action({expect, new IsType(expect, i), true,
+        auto checkFor = i->type.notLazy().noAttribs();
+        if (expected.isA(checkFor)) {
+            assert(!expected.maybeObj());
+            assert(!expected.maybeHasAttrs());
+            return action({checkFor, new IsType(checkFor, i), true,
                            feedback.srcCode, feedback.origin});
         }
 
-        if (i->type.maybeObj() && !possible.maybeObj()) {
-            auto expect = i->type.notLazy().notObject();
-            assert(!possible.maybeObj());
-            return action({expect, new IsType(expect, i), true,
+        checkFor = i->type.notLazy().notObject();
+        if (expected.isA(checkFor)) {
+            assert(!expected.maybeObj());
+            return action({checkFor, new IsType(checkFor, i), true,
                            feedback.srcCode, feedback.origin});
         }
 
+        if (i->type.isA(required))
+            return;
         failed();
     }
 };

--- a/rir/src/compiler/util/type_test.h
+++ b/rir/src/compiler/util/type_test.h
@@ -38,7 +38,7 @@ class TypeTest {
             return failed();
 
         if (i->type.maybeHasAttrs() && !possible.maybeHasAttrs()) {
-            auto expect = i->type.notLazy().noAttribs().notMissing();
+            auto expect = i->type.notLazy().noAttribs();
             assert(!possible.maybeObj());
             assert(!possible.maybeHasAttrs());
             return action({expect, new IsType(expect, i), true,
@@ -46,7 +46,7 @@ class TypeTest {
         }
 
         if (i->type.maybeObj() && !possible.maybeObj()) {
-            auto expect = i->type.notLazy().notObject().notMissing();
+            auto expect = i->type.notLazy().notObject();
             assert(!possible.maybeObj());
             return action({expect, new IsType(expect, i), true,
                            feedback.srcCode, feedback.origin});

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1723,7 +1723,14 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
     // some intermediate values on the stack
     ostack_ensureSize(ctx, c->stackLength + 5);
 
-    Opcode* pc = initialPC ? initialPC : c->code();
+    Opcode* pc;
+
+    if (initialPC) {
+        pc = initialPC;
+    } else {
+        R_Visible = TRUE;
+        pc = c->code();
+    }
     SEXP res;
 
     auto changeEnv = [&](SEXP e) {
@@ -1759,8 +1766,6 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
         if (feedback->stateBeforeLastForce < state)
             feedback->stateBeforeLastForce = state;
     };
-
-    R_Visible = TRUE;
 
     // main loop
     BEGIN_MACHINE {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -938,8 +938,12 @@ SlowcaseCounter SLOWCASE_COUNTER;
 SEXP builtinCall(CallContext& call, InterpreterInstance* ctx) {
     if (!call.hasNames()) {
         SEXP res = tryFastBuiltinCall(call, ctx);
-        if (res)
+        if (res) {
+            int flag = getFlag(call.callee);
+            if (flag < 2)
+                R_Visible = static_cast<Rboolean>(flag != 1);
             return res;
+        }
 #ifdef DEBUG_SLOWCASES
         SLOWCASE_COUNTER.count("builtin", call, ctx);
 #endif


### PR DESCRIPTION
the Pir typecheck assumes that we also exclude missing values, but the
implementation did not do so.