### PR TITLE
trying to (ab)use hotCold spltting for deopts

### DIFF
--- a/rir/src/compiler/native/jit_llvm.cpp
+++ b/rir/src/compiler/native/jit_llvm.cpp
@@ -38,6 +38,8 @@
 #include <llvm/Transforms/IPO.h>
 #include <unordered_map>
 
+#include <iostream>
+
 namespace {
 
 using namespace llvm;
@@ -237,6 +239,53 @@ static void pirPassSchedule(const PassManagerBuilder&,
     PM.add(createAggressiveDCEPass());
 }
 
+// Pass to run after hotCold splitting:
+// We use cold functions for bailout branches, thus we set the optnone attribute
+// on cold functions and uses the coldcc calling convention to call them.
+struct NooptCold : public ModulePass {
+    static char ID;
+    NooptCold() : ModulePass(ID) {}
+
+    bool runOnModule(Module& module) override {
+        bool changed = false;
+        for (auto& fun : module) {
+            if (fun.hasName()) {
+                if (fun.getName().contains(".cold.")) {
+                    if (!fun.hasFnAttribute(Attribute::OptimizeNone)) {
+                        fun.addAttribute(AttributeList::FunctionIndex,
+                                         Attribute::OptimizeNone);
+                        fun.setCallingConv(CallingConv::Cold);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        for (auto& fun : module) {
+            for (auto& bb : fun) {
+                for (auto& instr : bb) {
+                    if (CallInst* call = llvm::dyn_cast<CallInst>(&instr)) {
+                        if (call->getCallingConv() != CallingConv::Cold) {
+                            if (auto callee = call->getCalledFunction()) {
+                                if (callee->getCallingConv() ==
+                                    CallingConv::Cold) {
+                                    call->setCallingConv(CallingConv::Cold);
+                                    changed = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return changed;
+    }
+};
+
+char NooptCold::ID = 0;
+static RegisterPass<NooptCold> X("noopt-cold", "Don't optimize cold functions",
+                                 false /* Only looks at CFG */,
+                                 false /* Analysis Pass */);
+
 std::unique_ptr<llvm::Module>
 JitLLVMImplementation::optimizeModule(std::unique_ptr<llvm::Module> M) {
 
@@ -257,6 +306,12 @@ JitLLVMImplementation::optimizeModule(std::unique_ptr<llvm::Module> M) {
         // Start with some custom passes tailored to our backend
         builder.addExtension(PassManagerBuilder::EP_EarlyAsPossible,
                              pirPassSchedule);
+        builder.addExtension(
+            PassManagerBuilder::EP_ModuleOptimizerEarly,
+            [](const PassManagerBuilder&, PassManagerBase& PM) {
+                PM.add(createHotColdSplittingPass());
+                PM.add(new NooptCold());
+            });
 
         builder.populateFunctionPassManager(*PM);
         builder.populateModulePassManager(MPM);


### PR DESCRIPTION
let's use hotCold splitting to get deopt branches in their own function,
that we then mark as optnone and also call using the cold-cc calling
convention, which should favor caller perf over call overhead.