### PR TITLE
scope and deadStore analysis for static envs

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -341,7 +341,12 @@ class AbstractREnvironmentHierarchy {
                           [&](AbstractREnvironment& env) {
                               res.max(env.merge(e.second));
                           },
-                          [&]() { envs.insert(e.first, e.second); });
+                          [&]() {
+                              // Env only known on one branch -> merge with
+                              // empty environment.
+                              auto& n = envs.insert(e.first, e.second)->second;
+                              res.max(n.merge(AbstractREnvironment()));
+                          });
 
         for (auto& entry : other.aliases) {
             if (!aliases.count(entry.first)) {

--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -224,6 +224,18 @@ class DeadStoreAnalysis {
             AbstractResult effect;
             applyRecurse(effect, state, i, promEnv);
 
+            auto observeStaticEnvs = [&]() {
+                for (auto it = state.ignoreStore.begin();
+                     it != state.ignoreStore.end();) {
+                    if (Env::isStaticEnv(it->second)) {
+                        it = state.ignoreStore.erase(it);
+                        effect.update();
+                    } else {
+                        it++;
+                    }
+                }
+            };
+
             auto observeFullEnv = [&](Value* env) {
                 for (auto& e : withPotentialParents(env)) {
                     if (!state.completelyObserved.count(e)) {
@@ -245,7 +257,8 @@ class DeadStoreAnalysis {
             if (auto ld = LdVar::Cast(i)) {
                 for (auto& e : withPotentialParents(resolveEnv(i->env()))) {
                     Variable var({ld->varName, e});
-                    if (!state.partiallyObserved.count(var)) {
+                    if (!Env::isStaticEnv(e) &&
+                        !state.partiallyObserved.count(var)) {
                         state.partiallyObserved.insert(var);
                         effect.update();
                     }
@@ -271,6 +284,10 @@ class DeadStoreAnalysis {
                 observeFullEnv(resolveEnv(i->env()));
             }
 
+            if (i->exits() || i->readsEnv()) {
+                observeStaticEnvs();
+            }
+
             return effect;
         }
 
@@ -291,7 +308,8 @@ class DeadStoreAnalysis {
                 return false;
             if (state.completelyObserved.count(st->env()))
                 return true;
-            return state.partiallyObserved.count(var);
+            return Env::isStaticEnv(st->env()) ||
+                   state.partiallyObserved.count(var);
         }
     };
 
@@ -306,8 +324,6 @@ class DeadStoreAnalysis {
     }
 
     bool isDead(StVar* st) const {
-        if (!isLocal(st->env()))
-            return false;
         return !observed.isObserved(st);
     };
 };

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -144,6 +144,8 @@ class TheCleanup {
                         env->replaceUsesWith(Env::elided());
                         removed = true;
                         next = bb->remove(ip);
+                    } else if (bb->isDeopt() && env->stub) {
+                        env->stub = false;
                     }
                 } else if (auto test = IsEnvStub::Cast(i)) {
                     if (test->env() == Env::elided()) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2110,6 +2110,17 @@ class VLIE(MkEnv, Effects::None()) {
     bool stub = false;
     int context = 1;
 
+    size_t gvnBase() const override {
+        size_t res = tagHash();
+        res = hash_combine(res, stub);
+        res = hash_combine(res, context);
+        for (auto& n : varName)
+            res = hash_combine(res, n);
+        for (auto n : missing)
+            res = hash_combine(res, n);
+        return res;
+    }
+
     typedef std::function<void(SEXP name, Value* val, bool missing)> LocalVarIt;
     typedef std::function<void(SEXP name, InstrArg&, bool& missing)>
         MutableLocalVarIt;


### PR DESCRIPTION
partial scope analysis and dead store analysis is possible for the
first static environment in the chain of a function.

this allows us to elide loads such as in:

    a <- 1
    function() {
        a <<- 2
        a
    }

or stores such as

    function() {
      a <<- 1
      a <<- 2
    }