### PR TITLE
scope and deadStore analysis for static envs

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -341,7 +341,12 @@ class AbstractREnvironmentHierarchy {
                           [&](AbstractREnvironment& env) {
                               res.max(env.merge(e.second));
                           },
-                          [&]() { envs.insert(e.first, e.second); });
+                          [&]() {
+                              // Env only known on one branch -> merge with
+                              // empty environment.
+                              auto& n = envs.insert(e.first, e.second)->second;
+                              res.max(n.merge(AbstractREnvironment()));
+                          });
 
         for (auto& entry : other.aliases) {
             if (!aliases.count(entry.first)) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -144,6 +144,18 @@ class TheCleanup {
                         env->replaceUsesWith(Env::elided());
                         removed = true;
                         next = bb->remove(ip);
+                    } else if (bb->isDeopt() && env->stub) {
+                        env->stub = false;
+                    }
+                } else if (auto m = MaterializeEnv::Cast(i)) {
+                    if (auto mk = MkEnv::Cast(m->env())) {
+                        // We un-stub envs which moved to deopt branches. Thus
+                        // we need to also remove the materialize instr.
+                        if (!mk->stub) {
+                            i->replaceUsesWith(mk);
+                            removed = true;
+                            next = bb->remove(ip);
+                        }
                     }
                 } else if (auto test = IsEnvStub::Cast(i)) {
                     if (test->env() == Env::elided()) {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2110,6 +2110,17 @@ class VLIE(MkEnv, Effects::None()) {
     bool stub = false;
     int context = 1;
 
+    size_t gvnBase() const override {
+        size_t res = tagHash();
+        res = hash_combine(res, stub);
+        res = hash_combine(res, context);
+        for (auto& n : varName)
+            res = hash_combine(res, n);
+        for (auto n : missing)
+            res = hash_combine(res, (int)n);
+        return res;
+    }
+
     typedef std::function<void(SEXP name, Value* val, bool missing)> LocalVarIt;
     typedef std::function<void(SEXP name, InstrArg&, bool& missing)>
         MutableLocalVarIt;


### PR DESCRIPTION
partial scope analysis and dead store analysis is possible for the
first static environment in the chain of a function.

this allows us to elide loads such as in:

    a <- 1
    function() {
        a <<- 2
        a
    }

or stores such as

    function() {
      a <<- 1
      a <<- 2
    }