### PR TITLE
speculate on vectors where we might unboxed extract

### DIFF
--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -72,7 +72,11 @@ void TypeSpeculation::apply(RirCompiler&, ClosureVersion* function,
                     }
                 }
             }
-        } else if (!i->type.unboxable() && i->typeFeedback.type.unboxable()) {
+        } else if ((!i->type.unboxable() && i->typeFeedback.type.unboxable()) ||
+                   // Vector where Extract is unboxed if we speculate
+                   (i->type.isA(PirType::num()) &&
+                    !i->type.scalar().unboxable() &&
+                    i->typeFeedback.type.scalar().unboxable())) {
             speculateOn = i;
             feedback = i->typeFeedback;
             guardPos = checkpoint.next(i, i, dom);


### PR DESCRIPTION
this will speculate on types such as `(int|real)"<int">`, because
such a speculation will let us use an unboxing `Extract`.

In particular this targets expressions such as
`for (i in 1:b)` where often `1:b` is an int vector but we don't
statically know, since it could also be a float vector
(actually, can it?).