### PR TITLE
bump number of pir opts

### DIFF
--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -111,7 +111,7 @@ PassScheduler::PassScheduler() {
 
     // ==== Phase 4) Final round of default opts
     addDefaultPrePhaseOpt();
-    for (size_t i = 0; i < 3; ++i) {
+    for (size_t i = 0; i < 4; ++i) {
         addDefaultOpt();
         add<ElideEnvSpec>();
         add<CleanupCheckpoints>();


### PR DESCRIPTION
it seems in some benchmarks we are getting not all the optimizations we
want