### PR TITLE
fix gfortran path, revert, checkout named custom-R branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,29 +17,13 @@ set(LLVM_COMPONENTS_USED core orcjit native vectorize lto)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-# use GCC 9 on macOS. Otherwise we use clang
-if(APPLE)
-    option(MACOS_USE_GCC_9 "Use GCC 9 on macOS." FALSE)
-endif(APPLE)
-
-if(${MACOS_USE_GCC_9})
-    set(CMAKE_C_COMPILER /usr/local/bin/gcc-9 CACHE PATH "" FORCE)
-    set(CMAKE_CXX_COMPILER /usr/local/bin/g++-9 CACHE PATH "" FORCE)
-endif()
-
 add_definitions(-g3)
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Werror")
 set(CMAKE_CXX_FLAGS_RELEASENOASSERT "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 set(CMAKE_CXX_FLAGS_FULLVERIFIER "${CMAKE_CXX_FLAGS_RELEASE} -DFULLVERIFIER")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -DENABLE_SLOWASSERT -DMEASURE")
 set(CMAKE_CXX_FLAGS_DEBUGOPT "-Og -DENABLE_SLOWASSERT -DMEASURE")
-# with macOS GCC 9 we need to explicitly use libc++, since llvm does. See https://libcxx.llvm.org/docs/UsingLibcxx.html#using-libc-with-gcc
-if(${MACOS_USE_GCC_9})
-    set(CMAKE_CXX_FLAGS_LIBCXX "-nostdinc++ -nodefaultlibs -lc++ -lc++abi -lm -lc -lgcc_s.1 -lgcc")
-else()
-    set(CMAKE_CXX_FLAGS_LIBCXX "")
-endif()
-set(CMAKE_CXX_FLAGS "${LLVM_CXX_FLAGS} ${CMAKE_CXX_FLAGS_LIBCXX} -Wall -Wuninitialized -Wundef -Winit-self -Wcast-align -Woverloaded-virtual -Wmissing-include-dirs -Wstrict-overflow=5 -std=c++14 -fno-rtti -fno-exceptions -Wimplicit-fallthrough")
+set(CMAKE_CXX_FLAGS "${LLVM_CXX_FLAGS} -Wall -Wuninitialized -Wundef -Winit-self -Wcast-align -Woverloaded-virtual -Wmissing-include-dirs -Wstrict-overflow=5 -std=c++14 -fno-rtti -fno-exceptions -Wimplicit-fallthrough")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 set(CMAKE_C_FLAGS_RELEASENOASSERT "${CMAKE_C_FLAGS_RELEASE} -DNDEBUG")
 set(CMAKE_C_FLAGS_FULLVERIFIER "${CMAKE_CXX_FLAGS_RELEASE} -DFULLVERIFIER")
@@ -109,16 +93,9 @@ message(STATUS "Using R from ${R_HOME}")
 add_custom_target(setup-build-dir
     COMMAND ${CMAKE_SOURCE_DIR}/tools/setup-build-dir ${CMAKE_SOURCE_DIR} ${R_HOME}
 )
-
-if(${MACOS_USE_GCC_9})
-    add_custom_target(dependencies
-        COMMAND ${CMAKE_SOURCE_DIR}/tools/sync.sh --macos_gcc9
-    )
-else()
-    add_custom_target(dependencies
-        COMMAND ${CMAKE_SOURCE_DIR}/tools/sync.sh
-    )
-endif()
+add_custom_target(dependencies
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/sync.sh
+)
 
 add_custom_target(default-gnur
     DEPENDS dependencies

--- a/README.md
+++ b/README.md
@@ -87,13 +87,6 @@ For faster build use ninja. To generate ninja files instead of makefiles add `-G
 
 Using ninja means GCC and Clang will disable color output. To force color, run cmake with `-DFORCE_COLORED_OUTPUT=true`.
 
-### Building on macOS with GCC 9
-
-By default macOS will build gnuR and rir with clang, while Linux always uses GCC. There might be some differences between the 2 compilers. However, you can force macOS to use GCC via the following:
-
-- Install GCC 9 with homebrew (`brew install gcc@9`)
-- Pass `-GMACOS_USE_GCC_9` to `cmake`
-
 ### Making changes to gnur
 
 R with RIR patches is a submodule under external/custom-r. This is how you edit:

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -113,7 +113,7 @@ LLVM_DIR="${SRC_DIR}/external/llvm-8.0.0"
 if [ ! -d $LLVM_DIR ]; then
     echo "-> unpacking LLVM"
     cd "${SRC_DIR}/external"
-    if [ $USING_OSX -eq 1 ]; then
+    if [ -n "$USING_OSX" ]; then
         if [ ! -f "clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz" ]; then
             curl http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz > clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz
         fi

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -11,13 +11,8 @@ fi
 SRC_DIR=`cd ${SCRIPTPATH}/.. && pwd`
 . "${SCRIPTPATH}/script_include.sh"
 
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
     USING_OSX=1
-fi
-
-if [[ "$1" == "--macos_gcc9" ]]; then
-    MACOS_GCC9=1
 fi
 
 echo "-> update submodules"
@@ -63,13 +58,9 @@ function build_r {
     if [ ! -f $R_DIR/Makefile ]; then
         echo "-> configure $NAME"
         cd $R_DIR
-        if [ $USING_OSX -eq 1 ]; then
+        if [ -n "$USING_OSX" ]; then
             # Mac OSX
-            if [ $MACOS_GCC9 -eq 1 ]; then
-                MACOS_GCC9=1 ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no --without-aqua || cat config.log
-            else
-                ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no || cat config.log
-            fi
+            ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no || cat config.log
         else
             ./configure --with-ICU=no
         fi

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -64,7 +64,12 @@ function build_r {
         echo "-> configure $NAME"
         cd $R_DIR
         if [ $USING_OSX -eq 1 ]; then
-            ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no || cat config.log
+            # Mac OSX
+            if [ $MACOS_GCC9 -eq 1 ]; then
+                MACOS_GCC9=1 ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no --without-aqua || cat config.log
+            else
+                ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no || cat config.log
+            fi
         else
             ./configure --with-ICU=no
         fi


### PR DESCRIPTION
I think this fixes the travis config. The error in the failing builds was that the path to gfortran didn't exist - it was installed using homebrew but I suppose homebrew installed to a different location on my machine. However I can't guarantee this fixes the actual bug, or if there are other bugs, and I forget how to disable the travis cache.