### PR TITLE
ensure there are checkpoints when forcing arguments

### DIFF
--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -206,6 +206,12 @@ NativeBuiltin NativeBuiltins::stvar = {
     (void*)&stvarImpl,
 };
 
+void stvarImplI(SEXP a, int val, SEXP c) { rirDefineVarWrapperI(a, val, c); };
+NativeBuiltin NativeBuiltins::stvari = {
+    "stvari",
+    (void*)&stvarImplI,
+};
+
 void stargImpl(SEXP sym, SEXP val, SEXP env) {
     // In case there is a local binding we must honor missingness which
     // defineVar does not

--- a/rir/src/compiler/native/builtins.h
+++ b/rir/src/compiler/native/builtins.h
@@ -59,6 +59,7 @@ struct NativeBuiltins {
     static NativeBuiltin ldvarForUpdate;
     static NativeBuiltin ldvarCacheMiss;
     static NativeBuiltin stvar;
+    static NativeBuiltin stvari;
     static NativeBuiltin defvar;
     static NativeBuiltin starg;
     static NativeBuiltin ldfun;

--- a/rir/src/compiler/native/types_llvm.cpp
+++ b/rir/src/compiler/native/types_llvm.cpp
@@ -154,6 +154,8 @@ int initializeTypes(LLVMContext& context) {
     NativeBuiltins::ldvarCacheMiss.llvmSignature = llvm::FunctionType::get(
         t::SEXP, {t::SEXP, t::SEXP, t::SEXP_ptr}, false);
     NativeBuiltins::stvar.llvmSignature = t::void_sexpsexpsexp;
+    NativeBuiltins::stvari.llvmSignature =
+        llvm::FunctionType::get(t::Void, {t::SEXP, t::Int, t::SEXP}, false);
     NativeBuiltins::defvar.llvmSignature = t::void_sexpsexpsexp;
     NativeBuiltins::starg.llvmSignature = t::void_sexpsexpsexp;
     NativeBuiltins::ldfun.llvmSignature = t::sexp_sexpsexp;

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -68,6 +68,7 @@ class BB {
 
     void replace(Instrs::iterator it, Instruction* i);
 
+    void eraseLast() { instrs.pop_back(); }
     void remove(Instruction* i);
 
     Instrs::iterator atPosition(Instruction* i);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1042,6 +1042,7 @@ class FLIE(Force, 2, Effects::Any()) {
                 effects.reset(Effect::Reflection);
             }
         }
+        updateTypeAndEffects();
     }
     Value* input() const { return arg(0).val(); }
 

--- a/rir/src/compiler/transform/insert_cast.cpp
+++ b/rir/src/compiler/transform/insert_cast.cpp
@@ -33,28 +33,18 @@ void InsertCast::apply(BB* bb, AvailableCheckpoints& cp) {
     auto ip = bb->begin();
     while (ip != bb->end()) {
         Instruction* instr = *ip;
-        Phi* p = nullptr;
-        if ((p = Phi::Cast(instr))) {
+        if (auto p = Phi::Cast(instr))
             p->updateTypeAndEffects();
-        }
+        if (auto f = Force::Cast(instr))
+            f->updateTypeAndEffects();
         instr->eachArg([&](InstrArg& arg) {
             while (!arg.type().isSuper(arg.val()->type)) {
                 auto c = cast(arg.val(), arg.type(), env);
                 if (!c) {
                     bb->print(std::cerr, true);
-                    bb->owner->printCode(std::cerr, true, false);
                     assert(false);
                 }
-                auto argument = Instruction::Cast(arg.val());
-                if (argument && !instr->bb()->isDeopt() && Force::Cast(c) &&
-                    !cp.next(instr) && cp.next(argument)) {
-                    auto iterator = argument->bb()->insert(
-                        argument->bb()->atPosition(argument) + 1, c);
-                    if (argument->bb() == bb)
-                        ip = iterator;
-                } else {
-                    ip = bb->insert(ip, c) + 1;
-                }
+                ip = bb->insert(ip, c) + 1;
                 arg.val() = c;
             }
         });


### PR DESCRIPTION
the cast insertion pass cannot insert checkpoints. since it may insert
side-effecting instructions, we end up with side effecting instructions
without checkpoint in between. long term we should get rid of it completely.
for now this PR ensures that at least the force instructions are inserted
eagerly and with checkpoints in between.