### PR TITLE
Skip NA check in simple for increment

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -100,10 +100,12 @@ completely disables the PIR optimizer. As follows are the different Options avai
 #### Type Annotations (aka type flags)
 
 * `$` : Is scalar
+* `#` : Is never NA, never contains NA values if a vector
 * `^` : May be lazy (and wrapped in a promise)
 * `~` : May be wrapped in a promise (but evaluated)
 * `?` : May be missing
-* `'` : May not be an object
+* `'` : Not an object but may have attributes
+* `"` : Not an object and has no attributes
 
 #### Effects
 

--- a/rir/src/compiler/native/lower_llvm.cpp
+++ b/rir/src/compiler/native/lower_llvm.cpp
@@ -1732,15 +1732,18 @@ void LowerFunctionLLVM::compileBinop(
     auto a = load(lhs, lhsRep);
     auto b = load(rhs, rhsRep);
 
-    auto checkNa = [&](llvm::Value* v, Representation r) {
-        if (r == Representation::Integer) {
-            if (!isNaBr)
-                isNaBr = BasicBlock::Create(C, "isNa", fun);
-            nacheck(v, isNaBr);
+    auto checkNa = [&](llvm::Value* llvmValue, Value* pirValue,
+                       Representation r) {
+        if (pirValue->type.maybeNa()) {
+            if (r == Representation::Integer) {
+                if (!isNaBr)
+                    isNaBr = BasicBlock::Create(C, "isNa", fun);
+                nacheck(llvmValue, isNaBr);
+            }
         }
     };
-    checkNa(a, lhsRep);
-    checkNa(b, rhsRep);
+    checkNa(a, lhs, lhsRep);
+    checkNa(b, rhs, rhsRep);
 
     if (a->getType() == t::Int && b->getType() == t::Int) {
         res.addInput(intInsert(a, b));

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -495,7 +495,7 @@ LdConst::LdConst(SEXP c, PirType t)
 LdConst::LdConst(SEXP c)
     : FixedLenInstruction(PirType(c)), idx(Pool::insert(c)) {}
 LdConst::LdConst(int num)
-    : FixedLenInstruction(PirType(RType::integer).scalar().noAttribs()),
+    : FixedLenInstruction(PirType(RType::integer).scalar().notNa()),
       idx(Pool::getInt(num)) {}
 
 SEXP LdConst::c() const { return Pool::get(idx); }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1161,14 +1161,14 @@ class FLI(ColonInputEffects, 2, Effect::Error) {
 class FLI(ColonCastLhs, 1, Effect::Error) {
   public:
     explicit ColonCastLhs(Value* lhs, unsigned srcIdx)
-        : FixedLenInstruction(PirType::intReal().scalar(), {{PirType::val()}},
-                              {{lhs}}, srcIdx) {}
+        : FixedLenInstruction(PirType::intReal().scalar().notNa(),
+                              {{PirType::val()}}, {{lhs}}, srcIdx) {}
 
     Value* lhs() const { return arg<0>().val(); }
 
     PirType inferType(const GetType& getType) const override final {
         if (getType(lhs()).isA(RType::integer)) {
-            return PirType(RType::integer).scalar();
+            return PirType(RType::integer).scalar().notNa();
         } else {
             return type;
         }
@@ -1178,16 +1178,17 @@ class FLI(ColonCastLhs, 1, Effect::Error) {
 class FLI(ColonCastRhs, 2, Effect::Error) {
   public:
     explicit ColonCastRhs(Value* newLhs, Value* rhs, unsigned srcIdx)
-        : FixedLenInstruction(PirType::intReal().scalar(),
-                              {{PirType::intReal().scalar(), PirType::val()}},
-                              {{newLhs, rhs}}, srcIdx) {}
+        : FixedLenInstruction(
+              PirType::intReal().scalar().notNa(),
+              {{PirType::intReal().scalar().notNa(), PirType::val()}},
+              {{newLhs, rhs}}, srcIdx) {}
 
     Value* newLhs() const { return arg<0>().val(); }
 
     PirType inferType(const GetType& getType) const override final {
         // This is intended - lhs type determines rhs
         if (getType(newLhs()).isA(RType::integer)) {
-            return PirType(RType::integer).scalar();
+            return PirType(RType::integer).scalar().notNa();
         } else {
             return type;
         }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -95,6 +95,7 @@ enum class TypeFlags : uint8_t {
     maybeNotScalar,
     maybeObject,
     maybeAttrib,
+    maybeNa,
     rtype,
 
     FIRST = lazy,
@@ -132,13 +133,15 @@ struct PirType {
     Type t_;
 
     static constexpr FlagSet defaultRTypeFlags() {
-        return FlagSet() | TypeFlags::maybeNotScalar | TypeFlags::rtype;
+        return FlagSet() | TypeFlags::maybeNotScalar | TypeFlags::maybeNa |
+               TypeFlags::rtype;
     }
 
     static constexpr FlagSet topRTypeFlags() {
         return FlagSet() | TypeFlags::lazy | TypeFlags::promiseWrapped |
                TypeFlags::maybeObject | TypeFlags::maybeAttrib |
-               TypeFlags::maybeNotScalar | TypeFlags::rtype;
+               TypeFlags::maybeNotScalar | TypeFlags::maybeNa |
+               TypeFlags::rtype;
     }
     static constexpr FlagSet optimisticRTypeFlags() {
         return FlagSet() | TypeFlags::rtype;
@@ -277,6 +280,11 @@ struct PirType {
         return flags_.includes(TypeFlags::promiseWrapped) ||
                flags_.includes(TypeFlags::lazy);
     }
+    RIR_INLINE constexpr bool maybeNa() const {
+        if (!isRType())
+            return false;
+        return flags_.includes(TypeFlags::maybeNa);
+    }
     RIR_INLINE constexpr bool isScalar() const {
         if (!isRType())
             return true;
@@ -354,6 +362,11 @@ struct PirType {
         return PirType(t_.r & ~RTypeSet(RType::missing), flags_);
     }
 
+    RIR_INLINE constexpr PirType notNa() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeNa));
+    }
+
     RIR_INLINE constexpr PirType scalar() const {
         assert(isRType());
         return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeNotScalar));
@@ -367,6 +380,11 @@ struct PirType {
     RIR_INLINE constexpr PirType orT(RType t) const {
         assert(isRType());
         return PirType(t_.r | t, flags_);
+    }
+
+    RIR_INLINE constexpr PirType orNa() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ | TypeFlags::maybeNa);
     }
 
     RIR_INLINE constexpr PirType orNotScalar() const {
@@ -489,6 +507,7 @@ struct PirType {
     RIR_INLINE void setNotMissing() { *this = notMissing(); }
     RIR_INLINE void setNotObject() { *this = notObject(); }
     RIR_INLINE void setNoAttribs() { *this = noAttribs(); }
+    RIR_INLINE void setNotNa() { *this = notNa(); }
     RIR_INLINE void setScalar() { *this = scalar(); }
 
     RIR_INLINE void setScalar(RType rtype) {
@@ -530,7 +549,7 @@ struct PirType {
             (!maybePromiseWrapped() && o.maybePromiseWrapped()) ||
             (!maybeObj() && o.maybeObj()) ||
             (!maybeHasAttrs() && o.maybeHasAttrs()) ||
-            (isScalar() && !o.isScalar())) {
+            (!maybeNa() && o.maybeNa()) || (isScalar() && !o.isScalar())) {
             return false;
         }
         return t_.r.includes(o.t_.r);
@@ -681,6 +700,8 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
 
     if (t.isScalar())
         out << "$";
+    if (!t.maybeNa())
+        out << "#";
     if (t.maybeLazy())
         out << "^";
     else if (t.maybePromiseWrapped())

--- a/rir/src/compiler/util/type_test.h
+++ b/rir/src/compiler/util/type_test.h
@@ -19,7 +19,7 @@ class TypeTest {
                        const PirType& suggested, const PirType& required,
                        const std::function<void(Info)>& action,
                        const std::function<void()>& failed) {
-        auto expected = i->type & feedback.type;
+        auto expected = i->type & feedback.type.orNa();
 
         if (i->type.isA(expected))
             return;


### PR DESCRIPTION
To implement this, I extended the type-system with a non-NA flag. I know it's a broad approach but I couldn't figure out any clean narrower alternative - I could add a property `bool isNa` to `pir::Value`, or make the native backend explicitly check if lhs and rhs are constants or colon cast instructions, but both approaches are hacky and probably would end up being more work.

I did explicitly prevent PIR from speculating on non-NA values though, because that was breaking `pir_check` regression tests. Maybe later we can re-enable the speculation and add more non-NA optimizations, e.g. I think you mentioned that subscripts have to be boxed in case of NA arguments.