### PR TITLE
add support to call internal builtins with ... or names

### DIFF
--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -1044,9 +1044,16 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     : VarLenInstructionWithEnvSlot(PirType::valOrLazy(), callerEnv, srcIdx) {
     assert(names_.size() == args.size());
     pushArg(fun, RType::closure);
+
+    // Calling builtins with names or ... is not supported by callBuiltin,
+    // that's why those calls go through the normall call BC.
+    auto argtype = PirType(RType::prom) | RType::missing | RType::expandedDots;
+    if (auto con = LdConst::Cast(fun))
+        if (TYPEOF(con->c()) == BUILTINSXP)
+            argtype = argtype | PirType::val();
+
     for (unsigned i = 0; i < args.size(); ++i) {
-        pushArg(args[i],
-                PirType(RType::prom) | RType::missing | RType::expandedDots);
+        pushArg(args[i], argtype);
         auto name = names_[i];
         assert(TYPEOF(name) == SYMSXP || name == R_NilValue);
         names.push_back(name);
@@ -1059,9 +1066,16 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     : VarLenInstructionWithEnvSlot(PirType::valOrLazy(), callerEnv, srcIdx) {
     assert(names_.size() == args.size());
     pushArg(fun, RType::closure);
+
+    // Calling builtins with names or ... is not supported by callBuiltin,
+    // that's why those calls go through the normall call BC.
+    auto argtype = PirType(RType::prom) | RType::missing | RType::expandedDots;
+    if (auto con = LdConst::Cast(fun))
+        if (TYPEOF(con->c()) == BUILTINSXP)
+            argtype = argtype | PirType::val();
+
     for (unsigned i = 0; i < args.size(); ++i) {
-        pushArg(args[i],
-                PirType(RType::prom) | RType::missing | RType::expandedDots);
+        pushArg(args[i], argtype);
         auto name = Pool::get(names_[i]);
         assert(TYPEOF(name) == SYMSXP || name == R_NilValue);
         names.push_back(name);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1929,9 +1929,17 @@ class VLIE(Call, Effects::Any()), public CallInstruction {
         assert(fs);
         pushArg(fs, NativeType::frameState);
         pushArg(fun, RType::closure);
+
+        // Calling builtins with names or ... is not supported by callBuiltin,
+        // that's why those calls go through the normall call BC.
+        auto argtype =
+            PirType(RType::prom) | RType::missing | RType::expandedDots;
+        if (auto con = LdConst::Cast(fun))
+            if (TYPEOF(con->c()) == BUILTINSXP)
+                argtype = argtype | PirType::val();
+
         for (unsigned i = 0; i < args.size(); ++i)
-            pushArg(args[i], PirType(RType::prom) | RType::missing |
-                                 RType::expandedDots);
+            pushArg(args[i], argtype);
     }
 
     Closure* tryGetCls() const override final {

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.cpp
@@ -486,6 +486,12 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             }
         }
 
+        bool staticCallee = false;
+        if (auto con = LdConst::Cast(callee)) {
+            monomorphic = con->c();
+            staticCallee = true;
+        }
+
         bool monomorphicClosure =
             monomorphic && isValidClosureSEXP(monomorphic);
         bool monomorphicBuiltin = monomorphic &&
@@ -540,8 +546,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         Assume* assumption = nullptr;
         Value* guardedCallee = callee;
         // Insert a guard if we want to speculate
-        if (monomorphicBuiltin || monomorphicClosure ||
-            monomorphicInnerFunction) {
+        if (!staticCallee && (monomorphicBuiltin || monomorphicClosure ||
+                              monomorphicInnerFunction)) {
             // We use ldvar instead of ldfun for the guard. The reason is that
             // ldfun can force promises, which is a pain for our optimizer to
             // deal with. If we use a ldvar here, the actual ldfun will be


### PR DESCRIPTION
for example `.Internal(pmin(a, ...))` caused us to not eagerly evaluate
arguments passed to the builtin...