### PR TITLE
dynamically checking order of named calls

### DIFF
--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -83,7 +83,7 @@ struct DispatchTable
         }
         assert(!contains(fun->signature().assumptions));
         if (size() == capacity()) {
-#ifdef ENABLE_SLOWASSERT
+#ifdef DEBUG_DISPATCH
             std::cout << "Tried to insert into a full Dispatch table. Have: \n";
             for (size_t i = 0; i < size(); ++i) {
                 auto e = getEntry(i);

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -54,7 +54,7 @@ function build_r {
     # other than just patching it.
     cd src/library/Recommended
     tar xzf Matrix_1.2-18.tar.gz
-    sed -i -e 's/^stopifnot((st <- system.time(show(M)))\[1\] < 1.0)/((st <- system.time(show(M)))[1] < 1.0);((st <- system.time(show(M)))[1] < 1.0);((st <- system.time(show(M)))[1] < 1.0);stopifnot((st <-  system.time(show(M)))[1] < 1.0)/' Matrix/man/printSpMatrix.Rd
+    sed -i -e 's/^stopifnot((st <- system.time(show(M)))\[1\] < 1.0)/((st <- system.time(show(M)))[1] < 1.0)/' Matrix/man/printSpMatrix.Rd
     rm Matrix_1.2-18.tar.gz
     tar czf Matrix_1.2-18.tar.gz Matrix
     rm -rf Matrix


### PR DESCRIPTION
add support to dynamically check if named arguments happen to be
in the correct order. this allows us to call a lot more into
optimized code through named calls.

seeing how this goes in that PR. this will increase dispatch overhead, maybe we need some caching?