### PR TITLE
Speed up dominators algorithm

### DIFF
--- a/rir/src/compiler/analysis/available_checkpoints.h
+++ b/rir/src/compiler/analysis/available_checkpoints.h
@@ -73,8 +73,7 @@ class AvailableCheckpoints {
     Checkpoint* next(Instruction* i, Instruction* dependency,
                      const DominanceGraph& dom) {
         Checkpoint* res = next(i);
-        if (res && (dependency->bb() == res->bb() ||
-                    dom.dominates(dependency->bb(), res->bb())))
+        if (res && dom.dominates(dependency->bb(), res->bb()))
             return res;
         return nullptr;
     }

--- a/rir/src/compiler/analysis/generic_static_analysis.h
+++ b/rir/src/compiler/analysis/generic_static_analysis.h
@@ -394,7 +394,7 @@ class StaticAnalysis {
                     }
 
                     if (Forward)
-                        for (auto suc : bb->succsessors())
+                        for (auto suc : bb->successors())
                             mergeBranch(bb, suc, state, changed);
                     else
                         for (auto suc : bb->predecessors())

--- a/rir/src/compiler/analysis/liveness.cpp
+++ b/rir/src/compiler/analysis/liveness.cpp
@@ -150,7 +150,7 @@ restart:
     }
 
     Visitor::run(code->entry, [&](BB* bb) {
-        for (auto n : bb->succsessors()) {
+        for (auto n : bb->successors()) {
             if (!liveAtEnd.count(n))
                 todo.insert(n);
         }

--- a/rir/src/compiler/analysis/loop_detection.cpp
+++ b/rir/src/compiler/analysis/loop_detection.cpp
@@ -12,7 +12,7 @@ LoopDetection::LoopDetection(Code* code, bool determineNesting) {
     // find back edges, i.e. edges tail->header where header dominates tail
     Visitor::run(code->entry, [&](BB* maybeHeader) {
         for (const auto& maybeTail : maybeHeader->predecessors()) {
-            if (dom.dominates(maybeHeader, maybeTail)) {
+            if (dom.strictlyDominates(maybeHeader, maybeTail)) {
                 if (tailNodes.count(maybeHeader)) {
                     tailNodes[maybeHeader].push_back(maybeTail);
                 } else {

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -92,7 +92,7 @@ class TheVerifier {
     }
 
     void verify(BB* bb, bool inPromise) {
-        for (auto suc : bb->succsessors()) {
+        for (auto suc : bb->successors()) {
             if (!suc->predecessors().count(bb)) {
                 std::cout << "BB" << bb->id << " points to BB" << suc->id
                           << " but that one is not pointing back\n";
@@ -101,9 +101,9 @@ class TheVerifier {
         }
         for (auto p : bb->predecessors()) {
             seenPreds.insert(p);
-            if (!p->succsessors().any([&](BB* suc) { return suc == bb; })) {
+            if (!p->successors().any([&](BB* suc) { return suc == bb; })) {
                 std::cout << "BB" << bb->id << " points back to BB" << p->id
-                          << " but that one does not have us as a succsessor\n";
+                          << " but that one does not have us as a successor\n";
                 ok = false;
             }
         }
@@ -163,23 +163,23 @@ class TheVerifier {
         } else {
             Instruction* last = bb->last();
             if (last->branches()) {
-                if (bb->succsessors().size() == 1) {
+                if (bb->successors().size() == 1) {
                     std::cerr << "split bb" << bb->id
                               << " must end in branch\n";
                     ok = false;
                 }
             } else if (last->exits()) {
-                if (bb->succsessors().size() > 0) {
+                if (bb->successors().size() > 0) {
                     std::cerr << "exit bb" << bb->id << " must end in return\n";
                     ok = false;
                 }
             } else {
-                if (bb->succsessors().size() > 1) {
+                if (bb->successors().size() > 1) {
                     std::cerr << "bb" << bb->id
                               << " has false branch but no branch instr\n";
                     ok = false;
                 }
-                if (bb->succsessors().size() == 0) {
+                if (bb->successors().size() == 0) {
                     std::cerr << "bb" << bb->id << " has no successor\n";
                     ok = false;
                 }

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -375,7 +375,7 @@ class TheVerifier {
                     if ((iv->bb() == i->bb() &&
                          bb->indexOf(iv) > bb->indexOf(i)) ||
                         (iv->bb() != i->bb() && slow &&
-                         !dom(bb->owner).dominates(iv->bb(), bb))) {
+                         !dom(bb->owner).strictlyDominates(iv->bb(), bb))) {
                         std::cerr << "Error at instruction '";
                         i->print(std::cerr);
                         std::cerr << "': input '";

--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -43,6 +43,11 @@ class TheVerifier {
             ok = false;
         }
 
+        if (f->entry->predecessors().size() > 0) {
+            std::cerr << "The entry bb has predecessors.\n";
+            ok = false;
+        }
+
         if (!ok) {
             std::cerr << "Verification of function " << *f << " failed\n";
             f->print(std::cerr, false);

--- a/rir/src/compiler/native/lower_llvm.cpp
+++ b/rir/src/compiler/native/lower_llvm.cpp
@@ -365,7 +365,7 @@ class LowerFunctionLLVM {
 
         if (auto phi = Phi::Cast(variable)) {
             bool isNext = false;
-            for (auto n : currentBB->succsessors())
+            for (auto n : currentBB->successors())
                 if (n == phi->bb())
                     isNext = true;
             if (!isNext) {
@@ -5098,7 +5098,7 @@ bool LowerFunctionLLVM::tryCompile() {
         if (bb->isJmp())
             builder.CreateBr(getBlock(bb->next()));
 
-        for (auto suc : bb->succsessors())
+        for (auto suc : bb->successors())
             blockInPushContext[suc] = inPushContext;
     });
 

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -246,7 +246,7 @@ class TheCleanup {
                 BB* d = bb->next();
                 while (!d->isEmpty())
                     d->moveToEnd(d->begin(), bb);
-                bb->overrideSuccessors(d->succsessors());
+                bb->overrideSuccessors(d->successors());
                 d->deleteSuccessors();
                 fixupPhiInput(d, bb);
                 toDel[d] = nullptr;
@@ -261,7 +261,7 @@ class TheCleanup {
                 while (!d->isEmpty()) {
                     d->moveToEnd(d->begin(), bb);
                 }
-                bb->overrideSuccessors(d->succsessors());
+                bb->overrideSuccessors(d->successors());
                 d->deleteSuccessors();
                 fixupPhiInput(d, bb);
                 toDel[d] = nullptr;
@@ -292,7 +292,7 @@ class TheCleanup {
             while (!d->isEmpty()) {
                 d->moveToEnd(d->begin(), bb);
             }
-            bb->overrideSuccessors(d->succsessors());
+            bb->overrideSuccessors(d->successors());
             d->deleteSuccessors();
             fixupPhiInput(d, bb);
             toDel[d] = nullptr;

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -229,11 +229,16 @@ class TheCleanup {
 
         std::unordered_map<BB*, BB*> toDel;
         Visitor::run(function->entry, [&](BB* bb) {
+            // Prevent this removal from merging the entry block with its
+            // successor. We always want an empty, separate entry block, so
+            // that it will never have predecessors.
+            if (function->entry == bb)
+                return;
             // If bb is a jump to non-merge block, we merge it with the next
             if (bb->isJmp() && bb->next()->hasSinglePred()) {
-                bool block = false;
                 // Prevent this removal from merging a phi input block with the
                 // block the phi resides in
+                bool block = false;
                 if (usedBB.count(bb))
                     for (auto phi : usedBB[bb]) {
                         phi->eachArg([&](BB* in, Value*) {
@@ -255,6 +260,11 @@ class TheCleanup {
 
         // Merge blocks
         Visitor::runPostChange(function->entry, [&](BB* bb) {
+            // Prevent this removal from merging the entry block with its
+            // successor. We always want an empty, separate entry block, so
+            // that it will never have predecessors.
+            if (function->entry == bb)
+                return;
             if (bb->isJmp() && bb->hasSinglePred() &&
                 bb->next()->hasSinglePred()) {
                 BB* d = bb->next();
@@ -285,18 +295,12 @@ class TheCleanup {
             }
         });
 
-        if (function->entry->isJmp() &&
-            function->entry->next()->hasSinglePred()) {
-            BB* bb = function->entry;
-            BB* d = bb->next();
-            while (!d->isEmpty()) {
-                d->moveToEnd(d->begin(), bb);
-            }
-            bb->overrideSuccessors(d->successors());
-            d->deleteSuccessors();
-            fixupPhiInput(d, bb);
-            toDel[d] = nullptr;
-        }
+        // There used to be code here to merge an entry block with its next
+        // block, if the entry had only one successor and the next block had
+        // only one predecessor. We want to avoid this kind of merge, because
+        // we want to ensure that there is always an empty, separate entry
+        // block with no predecessors.
+
         Visitor::run(function->entry, [&](BB* bb) {
             while (bb->isJmp() && toDel.count(bb->next()))
                 bb->overrideNext(toDel[bb->next()]);

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -149,10 +149,11 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
                             continue;
                         auto bb1 = (*a)->bb();
                         auto bb2 = (*b)->bb();
-                        if (dom.dominates(bb1, bb2)) {
-                            if (dom.dominates(bb1->trueBranch(), bb2)) {
+                        if (dom.strictlyDominates(bb1, bb2)) {
+                            if (dom.strictlyDominates(bb1->trueBranch(), bb2)) {
                                 (*b)->arg(0).val() = True::instance();
-                            } else if (dom.dominates(bb1->falseBranch(), bb2)) {
+                            } else if (dom.strictlyDominates(bb1->falseBranch(),
+                                                             bb2)) {
                                 (*b)->arg(0).val() = False::instance();
                             } else {
 
@@ -162,7 +163,7 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
                                 BB* target = bb2;
 
                                 while (next != bb1) {
-                                    if (dom.dominates(next, bb2))
+                                    if (dom.strictlyDominates(next, bb2))
                                         target = next;
 
                                     next = dom.immediateDominator(next);
@@ -170,11 +171,11 @@ void Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
 
                                 auto p = new Phi;
                                 for (auto pred : target->predecessors()) {
-                                    if (dom.dominates(bb1->trueBranch(),
-                                                      pred)) {
+                                    if (dom.strictlyDominates(bb1->trueBranch(),
+                                                              pred)) {
                                         p->addInput(pred, True::instance());
-                                    } else if (dom.dominates(bb1->falseBranch(),
-                                                             pred)) {
+                                    } else if (dom.strictlyDominates(
+                                                   bb1->falseBranch(), pred)) {
                                         p->addInput(pred, False::instance());
                                     } else {
                                         success = false;

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -59,7 +59,8 @@ void DelayInstr::apply(RirCompiler&, ClosureVersion* function,
                         auto& updateTargets =
                             udatePromiseTargets[updatePromise];
                         for (auto deoptTarget : deoptUses) {
-                            if (dom.dominates(updatePromise->bb(), deoptTarget))
+                            if (dom.strictlyDominates(updatePromise->bb(),
+                                                      deoptTarget))
                                 updateTargets.insert(deoptTarget);
                             else if (cfg.isPredecessor(updatePromise->bb(),
                                                        deoptTarget))

--- a/rir/src/compiler/opt/gvn.cpp
+++ b/rir/src/compiler/opt/gvn.cpp
@@ -194,7 +194,7 @@ void GVN::apply(RirCompiler&, ClosureVersion* cls, LogStream& log) const {
             for (auto can : g.second) {
                 if (auto cani = Instruction::Cast(can)) {
                     if (!firstInstr ||
-                        dom.dominates(cani->bb(), firstInstr->bb()))
+                        dom.strictlyDominates(cani->bb(), firstInstr->bb()))
                         firstInstr = cani;
                 }
             }

--- a/rir/src/compiler/opt/hoist_instruction.cpp
+++ b/rir/src/compiler/opt/hoist_instruction.cpp
@@ -107,10 +107,10 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                 else if (target->isBranch())
                     // both branches dominate bb, then we should move target
                     // forward until they join again
-                    while (*target->successors().begin() != bb &&
-                           dom.dominates(*target->successors().begin(), bb) &&
+                    while (dom.strictlyDominates(*target->successors().begin(),
+                                                 bb) &&
                            (!target->isBranch() ||
-                            dom.dominates(target->falseBranch(), bb)))
+                            dom.strictlyDominates(target->falseBranch(), bb)))
                         target = *target->successors().begin();
             }
 
@@ -128,8 +128,8 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                         // We can only hoist effects over branches if both
                         // branch targets will trigger the effect
                         if (x->last()->branches()) {
-                            if (!dom.dominates(x->trueBranch(), bb) ||
-                                !dom.dominates(x->falseBranch(), bb))
+                            if (!dom.strictlyDominates(x->trueBranch(), bb) ||
+                                !dom.strictlyDominates(x->falseBranch(), bb))
                                 return false;
                         }
                     }
@@ -165,8 +165,8 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                         // branches does not need the value, then this will
                         // waste computation
                         if (x->last()->branches()) {
-                            if (!dom.dominates(x->trueBranch(), bb) ||
-                                !dom.dominates(x->falseBranch(), bb)) {
+                            if (!dom.strictlyDominates(x->trueBranch(), bb) ||
+                                !dom.strictlyDominates(x->falseBranch(), bb)) {
                                 if (exceptions == 0)
                                     return false;
                                 exceptions--;

--- a/rir/src/compiler/opt/hoist_instruction.cpp
+++ b/rir/src/compiler/opt/hoist_instruction.cpp
@@ -107,11 +107,11 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                 else if (target->isBranch())
                     // both branches dominate bb, then we should move target
                     // forward until they join again
-                    while (*target->succsessors().begin() != bb &&
-                           dom.dominates(*target->succsessors().begin(), bb) &&
+                    while (*target->successors().begin() != bb &&
+                           dom.dominates(*target->successors().begin(), bb) &&
                            (!target->isBranch() ||
                             dom.dominates(target->falseBranch(), bb)))
-                        target = *target->succsessors().begin();
+                        target = *target->successors().begin();
             }
 
             if (!target) {
@@ -151,9 +151,9 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                             return false;
                         }
 
-                    return x->succsessors().all(compute);
+                    return x->successors().all(compute);
                 };
-                return x->succsessors().all(compute);
+                return x->successors().all(compute);
             };
 
             auto noUnneccessaryComputation = [&](BB* x, unsigned exceptions) {
@@ -173,9 +173,9 @@ void HoistInstruction::apply(RirCompiler& cmp, ClosureVersion* function,
                             }
                         }
                     }
-                    return x->succsessors().all(compute);
+                    return x->successors().all(compute);
                 };
-                return x->succsessors().all(compute);
+                return x->successors().all(compute);
             };
 
             bool success = true;

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -20,9 +20,11 @@ using namespace rir::pir;
 // reflective effects
 static bool noReflection(ClosureVersion* cls, Code* code, Value* callEnv,
                          ScopeAnalysis& analysis, ScopeAnalysisState& state) {
+    // Note that the entry block is empty and jumps to the next block; this is
+    // to ensure that it has no predecessors.
     auto entry = code->entry;
-    assert(!entry->isEmpty());
-    auto funEnv = LdFunctionEnv::Cast(*entry->begin());
+    assert(entry->isEmpty() && entry->isJmp() && !entry->next()->isEmpty());
+    auto funEnv = LdFunctionEnv::Cast(*entry->next()->begin());
 
     return Visitor::check(code->entry, [&](Instruction* i) {
         if (CallSafeBuiltin::Cast(i))

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -199,8 +199,8 @@ class BB {
 
         size_t size() const { return end() - begin(); }
     };
-    const Successors nonDeoptSuccsessors() {
-        auto res = succsessors();
+    const Successors nonDeoptSuccessors() {
+        auto res = successors();
         if (isCheckpoint())
             res.next[1] = nullptr;
         for (auto i = 0; i < 2; ++i)
@@ -211,7 +211,7 @@ class BB {
             return {res.next[1], nullptr};
         return res;
     }
-    const Successors succsessors() { return {next0, next1}; }
+    const Successors successors() { return {next0, next1}; }
 
     void setSuccessors(const Successors& succ) {
         assert(!next0 && !next1);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -576,7 +576,11 @@ void MkArg::printArgs(std::ostream& out, bool tty) const {
 
 bool MkArg::usesPromEnv() const {
     if (!isEager()) {
-        BB* bb = prom()->entry;
+        // Note that the entry block is empty and jumps to the next block; this
+        // is to ensure that it has no predecessors.
+        BB* entry = prom()->entry;
+        assert(entry->isEmpty() && entry->isJmp() && !entry->next()->isEmpty());
+        BB* bb = entry->next();
         if (bb->size() > 0 && LdFunctionEnv::Cast(*bb->begin())) {
             return true;
         }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -317,7 +317,7 @@ void Instruction::replaceDominatedUses(Instruction* replace,
 
     auto stop = replace->bb() != bb() ? bb() : nullptr;
     Visitor::run(replace->bb(), stop, [&](BB* bb) {
-        if (bb != replace->bb() && !dom.dominates(replace->bb(), bb))
+        if (!dom.dominates(replace->bb(), bb))
             return;
         for (auto& i : *bb) {
             // First we need to find the position of the replacee, only after

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -421,13 +421,32 @@ bool testCfg() {
 
         DominanceGraph dom(&MockBB::code);
 
+        assert(dom.dominates(&A, &A));
+        assert(dom.dominates(&B, &B));
+        assert(dom.dominates(&C, &C));
+        assert(dom.dominates(&D, &D));
+        assert(dom.dominates(&F, &F));
+
+        assert(!dom.strictlyDominates(&A, &A));
+        assert(!dom.strictlyDominates(&B, &B));
+        assert(!dom.strictlyDominates(&C, &C));
+        assert(!dom.strictlyDominates(&D, &D));
+        assert(!dom.strictlyDominates(&F, &F));
+
         assert(dom.dominates(&A, &B));
         assert(dom.dominates(&A, &C));
         assert(dom.dominates(&A, &D));
         assert(dom.dominates(&A, &F));
+        assert(dom.dominates(&C, &D));
         assert(!dom.dominates(&B, &F));
         assert(!dom.dominates(&C, &F));
-        assert(dom.dominates(&C, &D));
+
+        assert(dom.strictlyDominates(&A, &B));
+        assert(dom.strictlyDominates(&A, &C));
+        assert(dom.strictlyDominates(&A, &D));
+        assert(dom.strictlyDominates(&A, &F));
+        assert(dom.strictlyDominates(&C, &D));
+
         assert(dom.immediatelyDominates(&A, &B));
         assert(dom.immediatelyDominates(&A, &C));
         assert(!dom.immediatelyDominates(&A, &D));
@@ -457,10 +476,27 @@ bool testCfg() {
         assert(cfg.isPredecessor(&C, &D));
 
         DominanceGraph dom(&MockBB::code);
+        assert(dom.dominates(&A, &A));
+        assert(dom.dominates(&B, &B));
+        assert(dom.dominates(&C, &C));
+        assert(dom.dominates(&D, &D));
+        assert(dom.dominates(&E, &E));
+
+        assert(!dom.strictlyDominates(&A, &A));
+        assert(!dom.strictlyDominates(&B, &B));
+        assert(!dom.strictlyDominates(&C, &C));
+        assert(!dom.strictlyDominates(&D, &D));
+        assert(!dom.strictlyDominates(&E, &E));
+
         assert(dom.dominates(&A, &B));
         assert(dom.dominates(&A, &C));
         assert(dom.dominates(&A, &D));
         assert(dom.dominates(&A, &E));
+
+        assert(dom.strictlyDominates(&A, &B));
+        assert(dom.strictlyDominates(&A, &C));
+        assert(dom.strictlyDominates(&A, &D));
+        assert(dom.strictlyDominates(&A, &E));
 
         assert(dom.immediatelyDominates(&A, &B));
         assert(dom.immediatelyDominates(&A, &C));
@@ -508,6 +544,18 @@ bool testCfg() {
         assert(cfg.isPredecessor(&C, &A));
 
         DominanceGraph dom(&MockBB::code);
+        assert(dom.dominates(&S, &S));
+        assert(dom.dominates(&A, &A));
+        assert(dom.dominates(&B, &B));
+        assert(dom.dominates(&C, &C));
+        assert(dom.dominates(&D, &D));
+
+        assert(!dom.strictlyDominates(&S, &S));
+        assert(!dom.strictlyDominates(&A, &A));
+        assert(!dom.strictlyDominates(&B, &B));
+        assert(!dom.strictlyDominates(&C, &C));
+        assert(!dom.strictlyDominates(&D, &D));
+
         assert(dom.dominates(&S, &A));
         assert(dom.dominates(&A, &B));
         assert(dom.dominates(&A, &C));
@@ -518,13 +566,19 @@ bool testCfg() {
         assert(!dom.dominates(&D, &A));
         assert(!dom.dominates(&C, &D));
 
+        assert(dom.strictlyDominates(&S, &A));
+        assert(dom.strictlyDominates(&A, &B));
+        assert(dom.strictlyDominates(&A, &C));
+        assert(dom.strictlyDominates(&A, &D));
+        assert(dom.strictlyDominates(&B, &D));
+
         assert(dom.immediatelyDominates(&S, &A));
         assert(dom.immediatelyDominates(&A, &B));
         assert(dom.immediatelyDominates(&A, &C));
         assert(dom.immediatelyDominates(&B, &D));
         assert(!dom.immediatelyDominates(&A, &D));
 
-        assert(dom.dominators(&B) == DominanceGraph::BBSet({&S, &A}));
+        assert(dom.dominators(&B) == DominanceGraph::BBSet({&S, &A, &B}));
 
         DominanceFrontier f(&MockBB::code, dom);
         assert(f.at(&S).empty());

--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -29,7 +29,7 @@ BB* BBTransform::clone(BB* src, Code* target, ClosureVersion* targetClosure) {
     // Fixup CFG: next pointers of copied BB's need to be filled in.
     Visitor::run(src, [&](BB* bb) {
         bbs[bb->id]->setSuccessors(
-            bb->succsessors().map([&](BB* suc) { return bbs[suc->id]; }));
+            bb->successors().map([&](BB* suc) { return bbs[suc->id]; }));
     });
 
     std::unordered_map<Promise*, Promise*> promMap;
@@ -88,7 +88,7 @@ BB* BBTransform::split(size_t next_id, BB* src, BB::Instrs::iterator it,
     BB* split = new BB(target, next_id);
     while (it != src->end())
         it = src->moveToEnd(it, split);
-    split->setSuccessors(src->succsessors());
+    split->setSuccessors(src->successors());
     src->overrideSuccessors({split});
     Visitor::run(split, [&](Instruction* i) {
         if (auto phi = Phi::Cast(i)) {
@@ -328,7 +328,7 @@ void BBTransform::mergeRedundantBBs(Code* closure) {
         while (instr != next->end()) {
             instr = next->moveToEnd(instr, bb);
         }
-        bb->overrideSuccessors(next->succsessors());
+        bb->overrideSuccessors(next->successors());
         next->deleteSuccessors();
         delete next;
     }

--- a/rir/src/compiler/translations/pir_2_rir/allocators.h
+++ b/rir/src/compiler/translations/pir_2_rir/allocators.h
@@ -442,7 +442,7 @@ class SSAAllocator {
                 }
             }
 
-            auto succs = bb->succsessors();
+            auto succs = bb->successors();
             for (auto suc : succs) {
                 if (branchTaken.count({bb, suc}))
                     continue;

--- a/rir/src/compiler/util/builder.cpp
+++ b/rir/src/compiler/util/builder.cpp
@@ -88,6 +88,9 @@ Builder::Builder(ClosureVersion* version, Value* closureEnv)
     function->entry = bb;
     auto closure = version->owner();
 
+    // Create another BB to ensure that the entry BB has no predecessors.
+    createNextBB();
+
     auto& assumptions = version->assumptions();
     std::vector<Value*> args(closure->nargs());
     size_t nargs = closure->nargs() - assumptions.numMissing();
@@ -115,6 +118,10 @@ Builder::Builder(ClosureVersion* fun, Promise* prom)
     createNextBB();
     assert(!prom->entry);
     prom->entry = bb;
+
+    // Create another BB to ensure that the entry BB has no predecessors.
+    createNextBB();
+
     auto ldenv = new LdFunctionEnv();
     add(ldenv);
     this->env = ldenv;

--- a/rir/src/compiler/util/cfg.cpp
+++ b/rir/src/compiler/util/cfg.cpp
@@ -49,7 +49,6 @@ bool CFG::isPredecessor(BB* a, BB* b) const {
         std::bind(std::equal_to<BB*>(), std::placeholders::_1, a));
 }
 
-// TODO: fix bug, algorithm assumes start node has no predecessor...
 DominanceGraph::DominanceGraph(Code* start) : idom(start->nextBBId) {
     int size = start->nextBBId;
     int N = 0;

--- a/rir/src/compiler/util/cfg.cpp
+++ b/rir/src/compiler/util/cfg.cpp
@@ -20,7 +20,7 @@ CFG::CFG(Code* start)
                 transitivePredecessors[next->id].push_back(bb);
             }
         };
-        auto succs = bb->succsessors();
+        auto succs = bb->successors();
         for (auto suc : succs)
             apply(suc);
         if (succs.size() == 0)
@@ -90,7 +90,7 @@ DominanceGraph::DominanceGraph(Code* start) : dominating(start->nextBBId) {
             if (d.merge(curState))
                 todo.push(bb);
         };
-        for (auto suc : cur->succsessors())
+        for (auto suc : cur->successors())
             apply(suc);
     }
 }
@@ -147,7 +147,7 @@ DominanceGraph::BBSet DominanceGraph::dominatedSet(Code* start,
                 }
             }
         };
-        for (auto suc : cur->succsessors())
+        for (auto suc : cur->successors())
             apply(suc);
     }
 

--- a/rir/src/compiler/util/cfg.cpp
+++ b/rir/src/compiler/util/cfg.cpp
@@ -50,111 +50,301 @@ bool CFG::isPredecessor(BB* a, BB* b) const {
 }
 
 DominanceGraph::DominanceGraph(Code* start) : idom(start->nextBBId) {
+    // We use the Lengauer-Tarjan algorithm [LT79] for computing dominators.
+    // The algorithmic complexity is O(N log N), where N is the number of edges
+    // plus the number of nodes.
+    //
+    // A later paper [GTW06] studied various practical dominator algorithms,
+    // and suggested that the simple Lengauer-Tarjan algorithm was the most
+    // consistently fast algorithm in their experiments, and also less
+    // sensitive to pathological examples.
+    //
+    // This implementation is a fairly close translation of the pseudocode from
+    // [AP04]. The details of the algorithm are fairly technical, but can be
+    // found in the same place. (Note: [AP04] is clearer than [LT79] at
+    // explaining the algorithm.)
+    //
+    //
+    // The algorithm can be divided into four steps.
+    //
+    //   Step 1.
+    //     Perform a depth-first search of the graph, numbering vertices in
+    //     order of discovery. This number (dfnum) allows us to determine if a
+    //     node `a` is an ancestor (in the DFS tree) of `b`, assuming there is
+    //     a path from `a` to `b` in the CFG.
+    //
+    //     `a` is an ancestor of `b` if dfnum[a] < dfnum[b]. `a` is a proper
+    //     ancestor of `b` if `a` is an ancestor of `b` and `a` is not equal to
+    //     `b`.
+    //
+    //   Step 2.
+    //     Iterate over nodes in decreasing dfnum. Calculate semidominators
+    //     using the Semidominator Theorem. A node's semidominator is often
+    //     that node's immediate dominator. As each node is visited, we insert
+    //     it into the spanning forest.
+    //
+    //     If `s` is the semidominator of `n`, then it is the node with the
+    //     smallest dfnum with a path to `n` whose nodes (other than `s` and
+    //     `n`) are not ancestors of `n`. In other words, there is a path in
+    //     the CFG (but not the DFS tree) that departs from `s` and then
+    //     rejoins the tree at `n`.
+    //
+    //     Semidominator Theorem.
+    //       For all predecessors of `n`:
+    //        1. If `v` is a proper ancestor of `n` (i.e. dfnum[v] < dfnum[n]),
+    //           then `v` is a candidate for semi(n).
+    //        2. If `v` is a nonancestor of `n` (i.e. dfnum[v] > dfnum[n]),
+    //           then for each ancestor `u` of `v` (or u = v) that is not an
+    //           ancestor of `n`, semi(u) is a candidate for semi(n).
+    //       The candidate with smallest dfnum is the semidominator of `n`.
+    //
+    //   Step 3.
+    //     Implicitly define the immediate dominator by applying the first
+    //     clause of the Dominator Theorem.
+    //
+    //   Step 4.
+    //     Explicitly define the immediate dominator by applying the second
+    //     clause of the Dominator Theorem. Do this while iterating over nodes
+    //     in increasing dfnum.
+    //
+    //     Dominator Theorem.
+    //       On the DFS tree path below semi(n) and above or including `n`, let
+    //       `y` be the node the the smallest numbered semidominator, i.e. with
+    //       minimum dfnum[semi(y)]. Then:
+    //         1. idom(n) = semi(n)    if semi(y) == semi(n)
+    //         2. idom(n) = idom(y)    if semi(y) != semi(n)
+    //
+    //
+    // As the algorithm runs, it maintains a spanning forest of nodes -- at the
+    // end, the forest will be fully connected as a single spanning tree. The
+    // algorithm is designed so that when a node `n` is being processed, only
+    // nodes with a higher dfnum than `n`, i.e. nonancestors of `n`, will be in
+    // the forest.
+    //
+    // This spanning forest is represented by the `ancestor` array, updated by
+    // the `link` function, and queried by the `ancestorWithLowestSemi`
+    // function.
+    //
+    // Note that the naive implementation of `ancestorWithLowestSemi` is O(N),
+    // but this implementation performs "path compression," so its amortized
+    // complexity is O(log N). There is an even more sophisticated version with
+    // better algorithmic complexity [LT79], that performs "balanced path
+    // compression," but in practice, it is actually slower [GTW06].
+    //
+    // As `ancestorWithLowestSemi` searches the spanning forest, it updates
+    // the `ancestor` array to compress the path. However, as it does so, it
+    // must remember the best result in the path that was skipped, i.e. the
+    // node with semidominator with lowest dfnum.
+    //
+    //
+    // References:
+    //
+    // [AP04] Appel, A. and Palsberg, J. (2004). "Efficient Computation of the
+    // Dominator Tree." In "Modern Compiler Implementation in Java," 2nd ed.
+    //
+    // [GTW06] Georgiadis, L., Tarjan, R. E., and Werneck R. F. (2006).
+    // "Finding dominators in practice." J. Graph Algorithms Appl.
+    // http://doi.org/10.7155/jgaa.00119
+    //
+    // [LT79] Lengauer, T. and Tarjan, R. E. (1979). "A fast algorithm for
+    // finding dominators in a flowgraph." ACM Trans. Program. Lang. Syst.
+    // https://doi.org/10.1145/357062.357071
+
+    /***************************************************************************
+     * Declarations and initializations.
+     **************************************************************************/
+
+    // Note that this is an overapproximation of the actual number of BBs,
+    // because some BBs may have been deleted.
     int size = start->nextBBId;
+
+    // Counter for numbering BBs, by depth-first search order.
     int N = 0;
 
-    std::vector<SmallSet<BB*>> bucket(size);
-    std::vector<int> dfnum(size, -1);
-    BBList semi(size);
-    BBList ancestor(size);
-    BBList samedom(size);
+    // Indexed by BB id. `dfnum[n->id]` is the dfnum of node `n`.
+    std::vector<int> dfnum(size);
+
+    // Indexed by dfnum. `vertex[i]` is the node whose dfnum is `i`. Note that
+    // `vertex[dfnum[n->id]] == n`.
+    std::vector<BB*> vertex(size);
+
+    // Indexed by BB id. `parent[n->id]` is the node that is the parent of `n`
+    // in the DFS tree.
     BBList parent(size);
+
+    // Indexed by BB id. `semi[n->id]` is the semidominator of `n`.
+    BBList semi(size);
+
+    // Indexed by BB id. `n` has the same dominator as `samedom[n->id]`, i.e.,
+    // idom(n) == idom(samedom(n)). This is used for the deferred application
+    // of the Dominator Theorem, clause 2.
+    BBList samedom(size);
+
+    // Indexed by BB id. `bucket[s->id]` is the set of nodes that `s`
+    // semidominates. Used to defer the dominator calculation until after
+    // linking.
+    std::vector<SmallSet<BB*>> bucket(size);
+
+    // Indexed by BB id. Spanning forest for the CFG. `ancestor[n->id]` is an
+    // ancestor (not necessarily parent) of `n`, i.e., any node above `n` in
+    // the spanning forest. This is gradually built as the algorithm runs; at
+    // the end, it will be a spanning tree.
+    BBList ancestor(size);
+
+    // Indexed by BB id. While `ancestor[n->id]` points to some ancestor of
+    // `n`, it may skip over some nodes. We need to remember the node along
+    // that possibly skipped path (which includes `n` but not
+    // `ancestor[n->id]`) which has the semidominator with lowest dfnum; that
+    // node is `best[n->id]`.
     BBList best(size);
-    BBList vertex;
-    vertex.reserve(size); // can't assume BBs are contiguously numbered
 
-    std::function<void()> DFS = [&]() {
-        std::stack<BB*> nodes;
-        std::stack<BB*> parents;
-        nodes.push(start->entry);
-        parents.push(nullptr);
+    // Add the edge `n -> p` (where `p` is the parent of `n`) to the spanning
+    // forest, represented by `ancestor`.
+    std::function<void(BB*, BB*)> link = [&](BB* p, BB* n) {
+        // Initially `ancestor[n->id]` points to `n`'s parent.
+        ancestor[n->id] = p;
 
-        while (!nodes.empty()) {
-            BB* n = nodes.top();
-            BB* p = parents.top();
-            nodes.pop();
-            parents.pop();
-
-            if (dfnum[n->id] == -1) {
-                dfnum[n->id] = N;
-                vertex.push_back(n);
-                parent[n->id] = p;
-                N++;
-
-                for (const auto& w : n->successors()) {
-                    nodes.push(w);
-                    parents.push(n);
-                }
-            }
-        }
+        // Initially only `n` is in the path to its ancestor, so it is our
+        // current best.
+        best[n->id] = n;
     };
 
+    // Search upward in the spanning forest, represented by `ancestor`, for the
+    // nonroot ancestor of `v` whose semidominator has the smallest dfnum. Note
+    // that `ancestor` is built as the algorithm runs, so some nodes are (by
+    // design) missing from the forest.
     std::function<BB*(BB*)> ancestorWithLowestSemi = [&](BB* v) {
         BB* a = ancestor[v->id];
         if (ancestor[a->id] != nullptr) {
             BB* b = ancestorWithLowestSemi(a);
+
+            // Compress the path as we walk up the spanning forest. We want to
+            // skip `a`, which is currently `v`'s ancestor.
             ancestor[v->id] = ancestor[a->id];
-            if (dfnum[semi[b->id]->id] < dfnum[semi[best[v->id]->id]->id]) {
+
+            // However, `b` might be the new "best" node, i.e. the node whose
+            // semidominator has the lowest dfnum. We need to update
+            // `best[v->id]` if this is the case.
+            BB* curBest = best[v->id];
+            if (dfnum[semi[b->id]->id] < dfnum[semi[curBest->id]->id]) {
                 best[v->id] = b;
             }
         }
         return best[v->id];
     };
 
-    std::function<void(BB*, BB*)> link = [&](BB* p, BB* n) {
-        ancestor[n->id] = p;
-        best[n->id] = n;
-    };
+    /***************************************************************************
+     * Algorithm starts here.
+     **************************************************************************/
 
-    // Number nodes by depth-first number.
-    DFS();
+    // Step 1. Number nodes by depth-first number. We don't need a function
+    // because our DFS is iterative, with an explicit stack -- in fact, we use
+    // two stacks in parallel, for nodes and their parents.
+    std::stack<BB*> nodes;
+    std::stack<BB*> parents;
+    nodes.push(start->entry);
+    parents.push(nullptr);
 
-    // Iterate over nodes (skipping the root) in reverse DFS order.
+    while (!nodes.empty()) {
+        assert(nodes.size() == parents.size());
+        BB* n = nodes.top();
+        BB* p = parents.top();
+        nodes.pop();
+        parents.pop();
+
+        // We haven't visited or numbered `n` yet.
+        if (dfnum[n->id] == 0) {
+            dfnum[n->id] = N;
+            vertex[N] = n;
+            parent[n->id] = p;
+            N++;
+
+            for (const auto& w : n->successors()) {
+                nodes.push(w);
+                parents.push(n);
+            }
+        }
+    }
+
+    // Step 2. Iterate over nodes (skipping the root) in descending dfnum
+    // order.
     for (int i = N - 1; i >= 1; --i) {
         BB* n = vertex[i];
         BB* p = parent[n->id];
+
+        // Parent of `n` is a candidate semidominator (since it's a proper
+        // ancestor).
         BB* s = p;
 
-        // Calculate the semidominator of n, based on the Semidominator Theorem
+        // Calculate `s`, the semidominator of `n`, using the Semidominator
+        // Theorem. We need to consider all predecessors `v` of `n`.
         for (const auto& v : n->predecessors()) {
             BB* s1;
             if (dfnum[v->id] <= dfnum[n->id]) {
+                // Semidominator Theorem, clause 1: `v` is an ancestor of `n`,
+                // so it is a candidate semidominator.
                 s1 = v;
             } else {
-                s1 = semi[ancestorWithLowestSemi(v)->id];
+                // Semidominator Theorem, clause 2: `v` is a nonancestor of
+                // `n`. For each `u` that is an ancestor of `v` (or u = v) but
+                // not an ancestor of `n`, the semi(u) with the lowest dfnum is
+                // a candidate. Note that when `n` is processed, only nodes
+                // with a higher dfnum than `n` (i.e. nonancestors) will be in
+                // the forest.
+                BB* u = ancestorWithLowestSemi(v);
+                s1 = semi[u->id];
             }
             if (dfnum[s1->id] < dfnum[s->id]) {
+                // Take the one with the lowest dfnum as the new candidate
+                // semidominator. After this loop, we will have found the
+                // candidate with the lowest dfnum.
                 s = s1;
             }
         }
 
-        // Calculation of n's dominator is deferred until the path from s to n
-        // has been linked into the forest.
+        // Calculation of `n`'s dominator is deferred until the path from `s`
+        // to `n` has been linked into the forest. We don't yet know `y`, the
+        // lowest semidominator on the path from `s` to `n` is. Therefore, we
+        // put `n` into the bucket of all nodes that `s` semidominates, so we
+        // can process it after linking.
         semi[n->id] = s;
         bucket[s->id].insert(n);
         link(p, n);
 
-        // Now that the path from p to v has been linked into the spanning
-        // forest, calculate the dominator of v, based on the first clause of
-        // the Dominator Theorem, or else defer calculation until y's dominator
-        // is known.
+        // Step 3. Now that the path from `p` to `v` has been linked into the
+        // spanning forest, calculate the dominator of `v`, based on the first
+        // clause of the Dominator Theorem, or else defer calculation until
+        // y`'s dominator is known.
         for (const auto& v : bucket[p->id]) {
+            // Find `y`, the ancestor of `v` whose semidominator has the lowest
+            // dfnum. Note that the spanning forest only contains nodes with a
+            // higher dfnum than `n`.
             BB* y = ancestorWithLowestSemi(v);
             if (semi[y->id] == semi[v->id]) {
+                // Dominator Theorem, clause 1: semi(v) = p is the immediate
+                // dominator of `v`.
                 idom[v->id] = p;
             } else {
+                // Dominator Theorem, clause 2: idom(y) is the immediate
+                // dominator of `v`. But we don't yet know what idom(y) is, so
+                // defer this calculation.
                 samedom[v->id] = y;
             }
         }
         bucket[p->id].clear();
     }
 
+    // Step 4. Iterate over the nodes (skipping the root) in ascending dfnum
+    // order.
     for (int i = 1; i < N; ++i) {
         BB* n = vertex[i];
         // Perform the deferred dominator calculations, based on the second
-        // clause of the Dominator THeorem.
+        // clause of the Dominator Theorem.
         if (samedom[n->id] != nullptr) {
-            idom[n->id] = idom[samedom[n->id]->id];
+            // idom(n) = idom(y), and we had previously assigned `y` to
+            // samedom(n).
+            BB* y = samedom[n->id];
+            idom[n->id] = idom[y->id];
         }
     }
 }
@@ -219,6 +409,8 @@ DominanceGraph::BBSet DominanceGraph::dominatedSet(Code* start,
 }
 
 bool DominanceGraph::dominates(BB* a, BB* b) const {
+    // Start with node `b`, because `a` dominates `b` if `a` equals `b`. Then
+    // walk up the dominator tree, comparing each visited node to `a`.
     BB* dominator = b;
     while (dominator != nullptr) {
         if (dominator == a) {
@@ -247,8 +439,11 @@ BB* DominanceGraph::immediateDominator(BB* bb) const {
 }
 
 const DominanceGraph::BBSet DominanceGraph::dominators(BB* bb) const {
+    // A node bb dominates itself.
     BBSet result{bb};
 
+    // Walk the dominator tree and insert each immediate dominator into the
+    // result set.
     BB* dominator = idom[bb->id];
     while (dominator != nullptr) {
         result.insert(dominator);

--- a/rir/src/compiler/util/cfg.cpp
+++ b/rir/src/compiler/util/cfg.cpp
@@ -219,7 +219,7 @@ DominanceGraph::BBSet DominanceGraph::dominatedSet(Code* start,
 }
 
 bool DominanceGraph::dominates(BB* a, BB* b) const {
-    BB* dominator = idom[b->id];
+    BB* dominator = b;
     while (dominator != nullptr) {
         if (dominator == a) {
             return true;
@@ -227,6 +227,10 @@ bool DominanceGraph::dominates(BB* a, BB* b) const {
         dominator = idom[dominator->id];
     }
     return false;
+}
+
+bool DominanceGraph::strictlyDominates(BB* a, BB* b) const {
+    return a != b && dominates(a, b);
 }
 
 bool DominanceGraph::immediatelyDominates(BB* a, BB* b) const {
@@ -243,7 +247,7 @@ BB* DominanceGraph::immediateDominator(BB* bb) const {
 }
 
 const DominanceGraph::BBSet DominanceGraph::dominators(BB* bb) const {
-    BBSet result;
+    BBSet result{bb};
 
     BB* dominator = idom[bb->id];
     while (dominator != nullptr) {

--- a/rir/src/compiler/util/cfg.h
+++ b/rir/src/compiler/util/cfg.h
@@ -29,18 +29,34 @@ class DominanceGraph {
     typedef std::unordered_set<BB*> BBSet;
 
   private:
+    // This array, indexed by BB id, represents the dominator tree. It stores
+    // the immediate dominator of each node, i.e., for a node `v`,
+    // `idom[v->id]` is the immediate dominator of `v`. The dominators of `v`
+    // can be found by walking through this array. E.g., `idom[v->id]`
+    // dominates `v`, `idom[idom[v->id]->id]` dominates `v`, and so on.
     BBList idom;
 
   public:
-    size_t size() const { return idom.size(); }
     explicit DominanceGraph(Code*);
+
+    size_t size() const { return idom.size(); }
 
     // Given a Code and a set of BBs, return the set of BBs dominated by the
     // input set.
     static BBSet dominatedSet(Code* start, const BBSet& bbs);
 
+    // `a` dominates `b` if every path from the entry node to `b` contains `a`.
+    // Note that a node dominates itself. Nodes may dominate multiple nodes,
+    // and be dominated by multiple nodes.
     bool dominates(BB* a, BB* b) const;
+
+    // `a` strictly dominates `b` if `a` dominates `b` and `a` does not equal
+    // `b`.
     bool strictlyDominates(BB* a, BB* b) const;
+
+    // `a` immediately dominates `b` if `a` strictly dominates `b`, but does not
+    // strictly dominate any other node that strictly dominates `b`. Every node,
+    // except for the entry node, has exactly one immediate dominator.
     bool immediatelyDominates(BB* a, BB* b) const;
 
     bool hasImmediateDominator(BB* bb) const;
@@ -58,6 +74,11 @@ class DominanceFrontier {
 
   public:
     DominanceFrontier(Code* code, const DominanceGraph&);
+
+    // The dominance frontier at node `bb` is the set of all nodes `n` such
+    // that `bb` dominates an immediate predecessor of `n`, but does not
+    // dominate `n`. I.e., the dominance frontier of `bb` is where the
+    // dominance of `bb` "stops."
     const BBList& at(BB* bb) const;
 };
 

--- a/rir/src/compiler/util/cfg.h
+++ b/rir/src/compiler/util/cfg.h
@@ -40,6 +40,7 @@ class DominanceGraph {
     static BBSet dominatedSet(Code* start, const BBSet& bbs);
 
     bool dominates(BB* a, BB* b) const;
+    bool strictlyDominates(BB* a, BB* b) const;
     bool immediatelyDominates(BB* a, BB* b) const;
 
     bool hasImmediateDominator(BB* bb) const;

--- a/rir/src/compiler/util/cfg.h
+++ b/rir/src/compiler/util/cfg.h
@@ -29,17 +29,10 @@ class DominanceGraph {
     typedef std::unordered_set<BB*> BBSet;
 
   private:
-    class DomTree {
-      public:
-        std::vector<BB*> container;
-        bool seen = false;
-        bool merge(const DomTree& other);
-        void push_back(BB* bb) { container.push_back(bb); }
-    };
-    std::vector<DomTree> dominating;
+    BBList idom;
 
   public:
-    size_t size() const { return dominating.size(); }
+    size_t size() const { return idom.size(); }
     explicit DominanceGraph(Code*);
 
     // Given a Code and a set of BBs, return the set of BBs dominated by the
@@ -51,7 +44,7 @@ class DominanceGraph {
 
     bool hasImmediateDominator(BB* bb) const;
     BB* immediateDominator(BB*) const;
-    const BBList& dominators(BB*) const;
+    const BBSet dominators(BB*) const;
     void dominatorTreeNext(BB* bb, const std::function<void(BB*)>&) const;
 };
 

--- a/rir/src/compiler/util/phi_placement.cpp
+++ b/rir/src/compiler/util/phi_placement.cpp
@@ -67,7 +67,7 @@ PhiPlacement::PhiPlacement(ClosureVersion* cls,
                     pendingInput[next] = input;
             };
 
-            for (auto suc : cur->succsessors())
+            for (auto suc : cur->successors())
                 apply(suc);
         });
     }

--- a/rir/src/compiler/util/visitor.h
+++ b/rir/src/compiler/util/visitor.h
@@ -234,8 +234,8 @@ class VisitorImplementation {
         struct Scheduler {
             BB::Successors operator()(BB* cur) const {
                 if (!VISIT_DEOPT_BRANCH)
-                    return cur->nonDeoptSuccsessors();
-                return cur->succsessors();
+                    return cur->nonDeoptSuccessors();
+                return cur->successors();
             }
         };
         const Scheduler scheduler;


### PR DESCRIPTION
I rewrote the dominators computation to use the Lenguaer-Tarjan algorithm. There were a few drive-by commits I included:

- Typo in BB successors method.
- LT algorithm assumes the start node has no predecessors, so I made some changes to check/enforce that.
- Previously, the `dominates` method only checked for strict dominance, i.e. a node does not dominate itself. I made `dominates` check for non-strict dominance and added a `strictlyDominates` method. I also went and changed other places in the codebase to use `strictlyDominates` if it made sense. @skrynski reviewed that commit for me.

The implementation is thoroughly documented, but it is a fairly close translation of the pseudocode from [_Modern Compiler Implementation_](https://www.cs.princeton.edu/~appel/modern/).

If you have any branches that use dominance, please double-check after merging in this branch. Check whether you really want strict or non-strict dominanace.

### Performance numbers

On the flexclust benchmark, this speeds up the compiler overhead by about 2 seconds. I ran flexclust with our benchmark framework, but also inserted timing/counters into the dominators code. These timers/counters are across all runs of the benchmark.

**Before this PR**
```
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 16346475us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 14905355us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 21660213us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 21436819us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 14856454us
flexclust_no_s4: iterations=5; average: 17841063 us; total: 89205316us
=== DominanceGraph perf:
                DomGraph ctor    4988 ms (called     61940 times)
               DomGraph merge    4434 ms (called   1732656 times)
          DomGraph dominates?      42 ms (called    911066 times)
         DomGraph idominates?     186 ms (called   7798074 times)
```

We can see that there is some overhead on the first run, and significant overhead on the third and fourth runs. The time for `DomGraph merge` is included inside `DomGraph ctor`. Note that while we spend 5 seconds inside `DomGraph ctor`, that time is mainly split over the third and fourth runs, i.e. we spend 2.5 seconds constructing the dominance graph.

**With this PR**
```
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 15604257us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 14444395us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 18667478us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 18996542us
Flexclust::kcca  5  352.0658   74
flexclust_no_s4: iterations=1 runtime: 14712814us
flexclust_no_s4: iterations=5; average: 16485097 us; total: 82425486us
=== DominanceGraph perf:
                DomGraph ctor      90 ms (called     61950 times)
          DomGraph dominates?     169 ms (called    928404 times)
         DomGraph idominates?     153 ms (called   8083418 times)
```

There is a similar pattern for when we see the overheads. However, the time for the slow runs (numbers three and four) is less, about 2 seconds faster than before. We also see that we spend significantly less time inside `DomGraph ctor`.

`DomGraph dominates` got a bit slower -- before, it was looking up a value in an array. But now, we need to walk up the dominator tree. We could precompute this, but I don't think it's worth the trouble.