### PR TITLE
cleanup and fixes to context dispatching

### DIFF
--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -384,9 +384,8 @@ bool Constantfold::apply(RirCompiler& cmp, ClosureVersion* function,
                             return !PushContext::Cast(i);
                         });
                     if (notInlined) {
-                        auto nargsC = new LdConst(ScalarInteger(
-                            function->nargs() -
-                            function->assumptions().numMissing()));
+                        auto nargsC = new LdConst(
+                            ScalarInteger(function->effectiveNArgs()));
                         anyChange = true;
                         i->replaceUsesAndSwapWith(nargsC, ip);
                     }

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -183,6 +183,8 @@ bool EagerCalls::apply(RirCompiler& cmp, ClosureVersion* closure,
                 }
 
                 auto availableAssumptions = call->inferAvailableAssumptions();
+                assert(version->assumptions().numMissing() <=
+                       availableAssumptions.numMissing());
                 cls->rirFunction()->clearDisabledAssumptions(
                     availableAssumptions);
 

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -65,9 +65,7 @@ class TheInliner {
                     inlinee = call->tryDispatch(inlineeCls);
                     if (!inlinee)
                         continue;
-                    if (inlinee->nargs() -
-                            inlinee->assumptions().numMissing() !=
-                        call->nCallArgs())
+                    if (inlinee->effectiveNArgs() != call->nCallArgs())
                         continue;
                     bool hasDotArgs = false;
                     call->eachCallArg([&](Value* v) {
@@ -86,9 +84,7 @@ class TheInliner {
                     inlinee = call->tryDispatch();
                     if (!inlinee)
                         continue;
-                    if (inlinee->nargs() -
-                            inlinee->assumptions().numMissing() !=
-                        call->nCallArgs())
+                    if (inlinee->effectiveNArgs() != call->nCallArgs())
                         continue;
                     // if we don't know the closure of the inlinee, we can't
                     // inline.

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -969,6 +969,12 @@ ClosureVersion* CallInstruction::tryDispatch(Closure* cls) const {
         std::cout << inferAvailableAssumptions() << "\n";
     }
 #endif
+    if (res) {
+        if (res->assumptions().includes(Assumption::NoExplicitlyMissingArgs))
+            assert(res->effectiveNArgs() == nCallArgs());
+        else
+            assert(res->effectiveNArgs() >= nCallArgs());
+    }
     return res;
 }
 
@@ -1041,11 +1047,11 @@ Assumptions CallInstruction::inferAvailableAssumptions() const {
             auto missing = cls->nargs() - nCallArgs();
             given.numMissing(missing);
         }
-    }
 
-    // Make some optimistic assumptions, they might be reset below...
-    given.add(Assumption::NoExplicitlyMissingArgs);
-    given.add(Assumption::NoReflectiveArgument);
+        // Make some optimistic assumptions, they might be reset below...
+        given.add(Assumption::NoExplicitlyMissingArgs);
+        given.add(Assumption::NoReflectiveArgument);
+    }
 
     bool hasDotsArg = false;
     size_t i = 0;

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -67,12 +67,12 @@ ClosuresByName compileRir2Pir(SEXP env, pir::Module* m) {
         auto fun = *f;
         if (TYPEOF(fun) == CLOSXP) {
             assert(isValidClosureSEXP(fun));
-            cmp.compileClosure(
-                fun, "test_function",
-                [&](pir::ClosureVersion* cls) {
-                    results[CHAR(PRINTNAME(f.tag()))] = cls;
-                },
-                []() { assert(false); });
+            cmp.compileClosure(fun, "test_function",
+                               pir::Rir2PirCompiler::defaultAssumptions,
+                               [&](pir::ClosureVersion* cls) {
+                                   results[CHAR(PRINTNAME(f.tag()))] = cls;
+                               },
+                               []() { assert(false); });
         }
     }
 

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir.h
@@ -5,12 +5,14 @@
 #include "../pir_translator.h"
 #include "rir_2_pir_compiler.h"
 
+#include <unordered_map>
 #include <unordered_set>
 
 namespace rir {
 namespace pir {
 
 struct RirStack;
+class MkFunCls;
 
 class Rir2Pir {
   public:
@@ -20,21 +22,21 @@ class Rir2Pir {
 
     bool tryCompile(Builder& insert) __attribute__((warn_unused_result));
 
-    Value* tryCreateArg(rir::Code* prom, Builder& insert, bool eager) const
+    Value* tryCreateArg(rir::Code* prom, Builder& insert, bool eager)
         __attribute__((warn_unused_result));
 
   private:
-    Value* tryTranslatePromise(rir::Code* srcCode, Builder& insert) const
+    Value* tryTranslatePromise(rir::Code* srcCode, Builder& insert)
         __attribute__((warn_unused_result));
 
     // Tries to compile the srcCode. Return value indicates failure. Builder
     // has to be discarded, if compilation fails!
     bool tryCompile(rir::Code* srcCode, Builder& insert)
         __attribute__((warn_unused_result));
-    bool tryCompilePromise(rir::Code* prom, Builder& insert) const
+    bool tryCompilePromise(rir::Code* prom, Builder& insert)
         __attribute__((warn_unused_result));
 
-    Value* tryTranslate(rir::Code* srcCode, Builder& insert) const
+    Value* tryTranslate(rir::Code* srcCode, Builder& insert)
         __attribute__((warn_unused_result));
 
     void finalize(Value*, Builder& insert);
@@ -46,13 +48,23 @@ class Rir2Pir {
     ClosureStreamLogger& log;
     std::string name;
 
+    struct DelayedCompilation {
+        DispatchTable* dt;
+        std::string name;
+        SEXP formals;
+        SEXP srcRef;
+        bool seen;
+        Assumptions assumptions;
+    };
+    std::unordered_map<MkFunCls*, DelayedCompilation> delayedCompilation;
+
     typedef std::unordered_map<
         Value*, std::tuple<Checkpoint*, ObservedCallees, Opcode*>>
         CallTargetFeedback;
 
     bool compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                    rir::Code* srcCode, RirStack&, Builder&,
-                   CallTargetFeedback&) const;
+                   CallTargetFeedback&);
     virtual bool inPromise() const { return inPromise_; }
 
     Checkpoint* addCheckpoint(rir::Code* srcCode, Opcode* pos,

--- a/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
+++ b/rir/src/compiler/translations/rir_2_pir/rir_2_pir_compiler.h
@@ -22,18 +22,8 @@ class Rir2PirCompiler : public RirCompiler {
     Rir2PirCompiler(Module* module, StreamLogger& logger)
         : RirCompiler(module), logger(logger){};
 
-    void compileClosure(SEXP cls, const std::string& name, MaybeCls success,
-                        Maybe fail) {
-        compileClosure(cls, name, defaultAssumptions, success, fail);
-    }
     void compileClosure(SEXP, const std::string& name, const Assumptions& ctx,
                         MaybeCls success, Maybe fail);
-    void compileFunction(rir::DispatchTable* f, const std::string& name,
-                         SEXP formals, SEXP srcRef, MaybeCls success,
-                         Maybe fail) {
-        compileFunction(f, name, formals, srcRef, defaultAssumptions, success,
-                        fail);
-    }
     void compileFunction(rir::DispatchTable*, const std::string& name,
                          SEXP formals, SEXP srcRef, const Assumptions& ctx,
                          MaybeCls success, Maybe fail);


### PR DESCRIPTION
Any broken things around context dispatching.

* Fix calling of functions which expect more arguments (by padding
them with missing).
* Delay compilation of inner functions so we can first collect
assumptions.