### PR TITLE
Clear the guess argument of a LdFun if they are both marked as dead b…

### DIFF
--- a/rir/src/compiler/transform/bb.cpp
+++ b/rir/src/compiler/transform/bb.cpp
@@ -385,6 +385,13 @@ void BBTransform::removeDeadInstrs(Code* fun, uint8_t maxBurstSize) {
                         uses.insert(i);
                     }
                 });
+                if (auto ldf = LdFun::Cast(i)) {
+                    if (auto guess = ldf->guessedBinding()) {
+                        auto gi = Instruction::Cast(guess);
+                        if (!gi->hasObservableEffects() && dead.isDead(gi))
+                            ldf->clearGuessedBinding();
+                    }
+                }
             }
             ip = next;
         }


### PR DESCRIPTION
…ut the load ends up not being deleted (because of its effects)