### PR TITLE
Check if inputs are Numbers for logical operators

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3248,6 +3248,10 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(aslogical_) {
             SEXP val = ostack_top(ctx);
+            if (!Rf_isNumber(val)) {
+              SEXP call = getSrcAt(c, pc - 1, ctx);
+              errorcall(call, "argument has the wrong type for && or ||");
+            }
             int x1 = Rf_asLogical(val);
             assert(x1 == 1 || x1 == 0 || x1 == NA_LOGICAL);
             res = Rf_ScalarLogical(x1);

--- a/rir/tests/rir_lgl.R
+++ b/rir/tests/rir_lgl.R
@@ -43,6 +43,21 @@ f <- rir.compile(function() {
     stopifnot(is.na(a21))
     a22 <- !((1:5 %% 2) == 0)
     stopifnot(a22 == c(TRUE, FALSE, TRUE, FALSE, TRUE))
+
+    fail <- function(expr) {
+      msg <- "argument has the wrong type for && or ||"
+      tryCatch(expr, error=function(e) { stopifnot(e[1] == msg) })
+    }
+    fail("foo" || -42)
+    fail(c("one", "two") || 1)
+    fail(42 && "")
+    fail(TRUE && "bad")
+
+    # short circuit could prevent error from occurring
+    a23 <- TRUE || "bad"
+    stopifnot(a23 == TRUE)
+    a24 <- FALSE && c("one", "two")
+    stopifnot(a24 == FALSE)
 })
 
 f()


### PR DESCRIPTION
In the R implementations of `||` and `&&`, the arguments are checked by `isNumber` before being applied to `asLogical`.
To enable a similar checking behavior in rir, we add in the check during interpretation of `aslogical_` instruction, since it's only used in compiling `||` and `&&`.

The added integration test cases demonstrate the expected behavior, which is currently missing.