### PR TITLE
Check if inputs are Numbers for logical operators

### DIFF
--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -1004,7 +1004,12 @@ NativeBuiltin NativeBuiltins::asTest = {
     (void*)&astestImpl,
 };
 
-int asLogicalImpl(SEXP a) { return Rf_asLogical(a); }
+int asLogicalImpl(SEXP a) {
+    if (!Rf_isNumber(a)) {
+      Rf_errorcall(R_NilValue, "argument has the wrong type for && or ||");
+    }
+    return Rf_asLogical(a);
+}
 
 NativeBuiltin NativeBuiltins::asLogicalBlt = {"aslogical",
                                               (void*)&asLogicalImpl};

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3248,6 +3248,10 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(aslogical_) {
             SEXP val = ostack_top(ctx);
+            if (!Rf_isNumber(val)) {
+              SEXP call = getSrcAt(c, pc - 1, ctx);
+              errorcall(call, "argument has the wrong type for && or ||");
+            }
             int x1 = Rf_asLogical(val);
             assert(x1 == 1 || x1 == 0 || x1 == NA_LOGICAL);
             res = Rf_ScalarLogical(x1);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3249,8 +3249,8 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
         INSTRUCTION(aslogical_) {
             SEXP val = ostack_top(ctx);
             if (!Rf_isNumber(val)) {
-              SEXP call = getSrcAt(c, pc - 1, ctx);
-              errorcall(call, "argument has the wrong type for && or ||");
+                SEXP call = getSrcAt(c, pc - 1, ctx);
+                Rf_errorcall(call, "argument has the wrong type for && or ||");
             }
             int x1 = Rf_asLogical(val);
             assert(x1 == 1 || x1 == 0 || x1 == NA_LOGICAL);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3248,6 +3248,13 @@ SEXP evalRirCode(Code* c, InterpreterInstance* ctx, SEXP env,
 
         INSTRUCTION(aslogical_) {
             SEXP val = ostack_top(ctx);
+            // TODO
+            // 1. currently aslogical_ is used for &&, || only, and this checking
+            //    is to mimic the behavior of builtin &&, ||. Technically asLogical
+            //    is less strict than this.
+            // 2. the error message also doesn't suggest which argument is wrong, or
+            //    which boolean operation it was. To achieve the exact behavior, one
+            //    could potentially compile this check in `ir/Compiler.cpp`
             if (!Rf_isNumber(val)) {
                 SEXP call = getSrcAt(c, pc - 1, ctx);
                 Rf_errorcall(call, "argument has the wrong type for && or ||");

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -525,14 +525,14 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
         compileExpr(ctx, args[0]);
 
         cs << BC::asLogical();
-        cs.addSrc(args[0]);
+        cs.addSrc(ast);
         cs << BC::dup()
            << BC::brtrue(nextBranch);
 
         compileExpr(ctx, args[1]);
 
         cs << BC::asLogical();
-        cs.addSrc(args[1]);
+        cs.addSrc(ast);
         cs << BC::lglOr();
 
         cs << nextBranch;

--- a/rir/tests/rir_lgl.R
+++ b/rir/tests/rir_lgl.R
@@ -43,6 +43,21 @@ f <- rir.compile(function() {
     stopifnot(is.na(a21))
     a22 <- !((1:5 %% 2) == 0)
     stopifnot(a22 == c(TRUE, FALSE, TRUE, FALSE, TRUE))
+
+    fail <- function(expr) {
+      msg <- "argument has the wrong type for && or ||"
+      tryCatch(expr, error=function(e) { stopifnot(e[1] == msg) })
+    }
+    fail("foo" || -42)
+    fail(c("one", "two") || 1)
+    fail(42 && "")
+    fail(TRUE && "bad")
+
+    # short circuit could prevent error from occurring
+    a23 <- TRUE || "bad"
+    stopifnot(a23 == TRUE)
+    a24 <- FALSE && c("one", "two")
+    stopifnot(a24 == FALSE)
 })
 
 f()


### PR DESCRIPTION
In the R implementations of `||` and `&&`, the arguments are checked by `isNumber` before being applied to `asLogical`.
To enable a similar checking behavior in rir, we add in the check during interpretation of `aslogical_` instruction, since it's only used in compiling `||` and `&&`.

The added integration test cases demonstrate the expected behavior, which is currently missing.