### PR TITLE
Fix force dominance

### DIFF
--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -476,9 +476,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                                      result.promToValueCast[mkarg]) {
                                     auto fixedCast = new CastType(
                                         fixedMkArg, CastType::Upcast,
-                                        RType::prom,
-                                        eagerVal->type.forced()
-                                            .orPromiseWrapped());
+                                        RType::prom, cast->type);
                                     next = bb->insert(next, fixedCast);
                                     cast->replaceDominatedUses(fixedCast);
                                 }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1256,6 +1256,9 @@ class FLI(CastType, 1, Effects::None()) {
         }
         return type;
     }
+    bool promToValue() const {
+        return kind == Kind::Upcast && MkArg::Cast(arg(0).val());
+    }
     void printArgs(std::ostream& out, bool tty) const override;
 };
 


### PR DESCRIPTION
Simply removing an UpdatePromise would lose information about the argument being forced, which could lead to inlining it multiple times. This commit instead replaced the UpdatePromise with a fresh eager MkArg.