### PR TITLE
force dominance eager mkarg replacement fix

### DIFF
--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -586,19 +586,6 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                         f->replaceUsesWith(eager);
                         next = bb->remove(ip);
                     }
-                } else if (auto phi = Phi::Cast(f->followCastsAndForce())) {
-                    phi->eachArg([&](BB* bb, InstrArg& v) {
-                        if (auto mk = MkArg::Cast(v.val()->followCasts())) {
-                            if (mk->isEager()) {
-                                anyChange = true;
-                                auto eager = Instruction::Cast(mk->eagerArg());
-                                assert(eager);
-                                v.val() = eager;
-                                v.type() = eager->type;
-                            }
-                        }
-                    });
-                    phi->updateTypeAndEffects();
                 }
             }
             ip = next;


### PR DESCRIPTION
can only use the known eager value of a mkarg to replace a force (instead of the casttype, which could lead to the eager value escaping where the promise was expected, eg. into substitute)