### PR TITLE
fix updatePromise

### DIFF
--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -300,6 +300,8 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
     AbstractResult apply(ForcedBy& state, Instruction* i) const override {
         AbstractResult res;
         auto apply = [&](Instruction* i) {
+            if (!i->effects.includes(Effect::LeakArg))
+                return;
             auto pc = PushContext::Cast(i);
             i->eachArg([&](Value* v_) {
                 auto v = v_->followCasts();
@@ -380,6 +382,33 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
 namespace rir {
 namespace pir {
 
+/*
+ *  In General this is the strategy here:
+ *
+ *    a  = MkArg(exp)
+ *    e  = MkEnv(x=a)   // leak a
+ *    a2 = Cast(a)
+ *    f  = Force(a2)    // force a
+ *    PushContext(a)    // use a for promargs
+ *    use(a)            // use a
+ *    use(f)
+ *
+ *  === Inline Promise ==>
+ *
+ *    a   = MkArg(exp)
+ *    a'  = MkArg(exp)
+ *    e   = MkEnv(x=a)      // leak a
+ *    f'  = eval(exp)       // inlinee
+ *    a'' = MkArg(exp, a)   // synthesized updated promise
+ *    UpdatePromise(a, f')  // update to ensure leaked a is correct
+ *    PushContext(a')       // push context needs unmodified a
+ *    use(a'')              // normal uses get the synthesized version
+ *    use(f')               // uses of the value get the result
+ *
+ *  updatePromise and the duplication of mkarg only happens if needed.
+ *
+ */
+
 bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                            LogStream& log) const {
     SmallSet<Force*> toInline;
@@ -413,7 +442,8 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                         if (auto mk = MkArg::Cast(f->followCastsAndForce())) {
                             if (!mk->isEager()) {
                                 if (!isHuge || mk->prom()->size() < 10) {
-                                    auto inl = a.isSafeToInline(mk, f);
+                                    auto b = analysis.before(i);
+                                    auto inl = b.isSafeToInline(mk, f);
                                     if (inl != ForcedBy::NotSafeToInline) {
                                         toInline.insert(f);
                                         if (inl ==
@@ -433,7 +463,6 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                             next = bb->remove(ip);
                     }
                 }
-
                 ip = next;
             }
         });
@@ -442,6 +471,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
     std::unordered_map<Force*, Value*> inlinedPromise;
     std::unordered_map<Instruction*, MkArg*> forcedMkArg;
     std::unordered_set<BB*> dead;
+    std::unordered_set<MkArg*> updated;
 
     // 1. Inline dominating promises
     Visitor::runPostChange(code->entry, [&](BB* bb) {
@@ -581,9 +611,11 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                         forcedMkArg[mkarg] = fixedMkArg;
 
                         inlinedPromise[f] = promRes;
-                        if (needsUpdate.count(f))
+                        if (needsUpdate.count(f)) {
                             next = split->insert(
                                 next, new UpdatePromise(mkarg, promRes));
+                            updated.insert(mkarg);
+                        }
 
                         if (promRet.second->isNonLocalReturn())
                             dead.insert(split);
@@ -612,9 +644,8 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
     Visitor::run(code->entry, [&](BB* bb) {
         auto ip = bb->begin();
         while (ip != bb->end()) {
-            auto f = Force::Cast(*ip);
             auto next = ip + 1;
-            if (f) {
+            if (auto f = Force::Cast(*ip)) {
                 // If this force instruction is dominated by another force
                 // we can replace it with the dominating instruction
                 auto dom = dominatedBy.find(f);
@@ -628,6 +659,19 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                     }
                     next = bb->remove(ip);
                 }
+            } else if (auto p = PushContext::Cast(*ip)) {
+                // Promargs need unchanged argument promise. If we updated a
+                // promise we need to duplicate it.
+                p->eachArg([&](InstrArg& arg) {
+                    if (auto a = MkArg::Cast(arg.val())) {
+                        if (updated.count(a)) {
+                            auto n = a->clone();
+                            ip = bb->insert(ip, n) + 1;
+                            arg.val() = n;
+                            next = ip + 1;
+                        }
+                    }
+                });
             }
             ip = next;
         }
@@ -635,7 +679,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
 
     // 3. replace remaining uses of the mkarg itself
     for (auto m : forcedMkArg) {
-        m.first->replaceDominatedUses(m.second);
+        m.first->replaceDominatedUses(m.second, {Tag::PushContext});
     }
 
     // 4. remove BB's that became dead due to non local return

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -149,6 +149,7 @@ void Instruction::printEffects(std::ostream& out, bool tty) const {
             CASE(ExecuteCode, "X")
             CASE(DependsOnAssume, "d")
             CASE(MutatesArgument, "M")
+            CASE(UpdatesMetadata, "m")
 #undef CASE
         }
     }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -108,6 +108,8 @@ enum class Effect : uint8_t {
     // Instruction might execute more R code
     ExecuteCode,
 
+    UpdatesMetadata,
+
     // If we speculatively optimize an instruction then we must set this flag
     // to avoid it getting hoisted over its assumption. Take care when removing
     // or masking this flag. Most of the time it is not correct to remove it,
@@ -195,6 +197,7 @@ class Instruction : public Value {
         // Yes visibility is a global effect. We try to preserve it. But geting
         // it wrong is not a strong correctness issue.
         e.reset(Effect::Visibility);
+        e.reset(Effect::UpdatesMetadata);
         return e;
     }
 
@@ -835,7 +838,7 @@ struct RirStack {
     Stack::iterator end() { return stack.end(); }
 };
 
-class FLI(RecordDeoptReason, 1, Effects::Any()) {
+class FLI(RecordDeoptReason, 1, Effect(Effect::UpdatesMetadata)) {
   public:
     DeoptReason reason;
     RecordDeoptReason(const DeoptReason& r, Value* value)
@@ -847,7 +850,8 @@ class FLI(RecordDeoptReason, 1, Effects::Any()) {
  *  Collects metadata about the current state of variables
  *  eventually needed for deoptimization purposes
  */
-class VLIE(FrameState, Effects(Effect::LeaksEnv) | Effect::ReadsEnv) {
+class VLIE(FrameState,
+           Effects(Effect::LeaksEnv) | Effect::ReadsEnv | Effect::LeakArg) {
   public:
     bool inlined = false;
     Opcode* pc;
@@ -1013,7 +1017,8 @@ class FLI(ChkClosure, 1, Effect::Error) {
     size_t gvnBase() const override { return tagHash(); }
 };
 
-class FLIE(StVarSuper, 2, Effects() | Effect::ReadsEnv | Effect::WritesEnv) {
+class FLIE(StVarSuper, 2,
+           Effects() | Effect::ReadsEnv | Effect::WritesEnv | Effect::LeakArg) {
   public:
     StVarSuper(SEXP name, Value* val, Value* env)
         : FixedLenInstructionWithEnvSlot(PirType::voyd(), {{PirType::val()}},
@@ -1048,7 +1053,7 @@ class FLIE(LdVarSuper, 1, Effects() | Effect::Error | Effect::ReadsEnv) {
     int minReferenceCount() const override { return 1; }
 };
 
-class FLIE(StVar, 2, Effect::WritesEnv) {
+class FLIE(StVar, 2, Effects(Effect::WritesEnv) | Effect::LeakArg) {
   public:
     bool isStArg = false;
 
@@ -1142,11 +1147,13 @@ class FLIE(MkArg, 2, Effects::None()) {
     bool usesPromEnv() const;
 };
 
-class FLI(UpdatePromise, 2, Effect::MutatesArgument) {
+class FLI(UpdatePromise, 2,
+          Effects(Effect::MutatesArgument) | Effect::LeakArg) {
   public:
     UpdatePromise(MkArg* prom, Value* v)
         : FixedLenInstruction(PirType::voyd(), {{RType::prom, PirType::val()}},
                               {{prom, v}}) {}
+    MkArg* mkarg() const { return MkArg::Cast(arg(0).val()); }
 };
 
 class FLIE(MkCls, 4, Effects::None()) {
@@ -2257,7 +2264,7 @@ class BuiltinCallFactory {
                             const std::vector<Value*>& args, unsigned srcIdx);
 };
 
-class VLIE(MkEnv, Effects::None()) {
+class VLIE(MkEnv, Effect::LeakArg) {
   public:
     std::vector<SEXP> varName;
     std::vector<bool> missing;
@@ -2356,7 +2363,8 @@ class FLIE(IsEnvStub, 1, Effect::ReadsEnv) {
         : FixedLenInstructionWithEnvSlot(NativeType::test, e) {}
 };
 
-class VLIE(PushContext, Effect::ChangesContexts) {
+class VLIE(PushContext, Effects(Effect::ChangesContexts) | Effect::LeakArg |
+                            Effect::LeaksEnv) {
   public:
     PushContext(Value* ast, Value* op, CallInstruction* call, Value* sysparent)
         : VarLenInstructionWithEnvSlot(NativeType::context, sysparent) {
@@ -2404,7 +2412,7 @@ class FLI(ExpandDots, 1, Effects::None()) {
                               {{dots}}) {}
 };
 
-class VLI(DotsList, Effects::None()) {
+class VLI(DotsList, Effect::LeakArg) {
   public:
     std::vector<SEXP> names;
     DotsList() : VarLenInstruction(RType::dots) {}


### PR DESCRIPTION
Update promise is only responsible for updating escaped promises.
We must not update non-escaped promises.

Additionally keep track of updated promises in scope analysis.

I believe this is the actual issue that was being worked around in #934