### PR TITLE
nargs() constant fold fix

### DIFF
--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -513,7 +513,7 @@ bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         Visitor::check(code->entry, [](Instruction* i) {
                             return !PushContext::Cast(i);
                         });
-                    if (notInlined) {
+                    if (notInlined && !cls->owner()->formals().hasDots()) {
                         auto nargsC =
                             new LdConst(ScalarInteger(cls->effectiveNArgs()));
                         anyChange = true;

--- a/rir/tests/pir_nargs.r
+++ b/rir/tests/pir_nargs.r
@@ -1,0 +1,4 @@
+f <- function(...) nargs()
+g <- function() f(1, 2, 3)
+for (i in 1:10)
+    stopifnot(g() == 3)


### PR DESCRIPTION
nargs() would ignore the dots and report them as one argument when it should report the actual length of the dotslist