### PR TITLE
Support gdb debugging of pir

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -159,3 +159,125 @@ debugging:
   containing its ast maps and code objects
 * `.printInvocation`: prints invocation during evaluation
 * `.int3`: breakpoint during evaluation
+
+## PIR & GDB (experimental!)
+
+There is *WIP* support for debugging LLVM jitted PIR code. It is enabled by `#define PIR_GDB_SUPPORT` in `compiler/native/pir_debug_info.h`, currently set for debug builds.
+
+Run your program, ideally with `rr`:
+```
+***@***:~/rir/build/debug$ bin/R -e "f <- function(x) { Sys.sleep(0.01); x + 123L }; f(4L); f(4L); f(4L); f(4L)" -d rr
+rr: Saving execution to trace directory `/home/***/.local/share/rr/R-402'.
+
+R version 3.6.2 (2019-12-12) -- "Dark and Stormy Night"
+[...]
+```
+
+This will produce PIR listing files for each PIR module compiled, named like `f.01`:
+```
+***@***:~/rir/build/debug$ cat f.01
+rsh_f[0x56500a98aa80].1
+BB0
+  int$~"          %0.0  = LdArg                    0
+  val?^           %0.1  = LdVar              eR    Sys.sleep, GlobalEnv
+  cls"            %0.2  = LdConst                  function (time)
+  lgl$#"          %0.3  = Identical                %0.1, %0.2
+  void                    Branch                   %0.3 -> BB4 (if true) | BB5 (if false)
+BB4   <- [0]
+  real$#"         %4.0  = LdConst                  0.01
+  prom"           %4.1  = MkArg                    %4.0, Prom(0) (!refl),
+  code"           %4.2  = LdConst                  Sys.sleep(0.01)
+  env"            e4.3  = (MkEnv)            l     x=%0.0, parent=GlobalEnv, context 1
+  ct              %4.4  = PushContext        lCL   %4.1, %4.2, %0.2, e4.3
+  env"            e4.5  = MKEnv              l     time=%4.0, parent=BaseNamespace, context 1
+  val?            %4.6  = CallBuiltin        !v    Sys.sleep(%4.0) e4.5
+  val?            %4.7  = PopContext         C     %4.6, %4.4
+  int$"<>         %4.8  = Force!<lazy>       d     %0.0,
+  int$#"          %4.9  = LdConst                  123
+  int$"<>         %4.10 = Add                vd    %4.8, %4.9, elided
+  void                    Return                   %4.10
+BB5   <- [0]
+  void                    RecordDeoptReason  m     %0.1
+  env"            e5.1  = MKEnv              l     x=%0.0, parent=GlobalEnv, context 1
+  void                    ScheduledDeopt           0x5650095589a0+0: [], env=e5.1
+
+rsh_f[0x56500a98aa80]_Prom(0).1
+BB0
+  real$#"         %0.0  = LdConst                  0.01
+  void                    Visible            v
+  void                    Return                   %0.0
+```
+
+Now, you can run the debugger and set a breakpoint in those files:
+```
+***@***:~/rir/build/debug$ rr replay
+GNU gdb (Ubuntu 8.1.1-0ubuntu1) 8.1.1
+...
+0x00007f0bdeeef090 in _start () from /lib64/ld-linux-x86-64.so.2
+(rr) b f.01:3
+No source file named f.01.
+Make breakpoint pending on future shared library load? (y or [n]) y
+Breakpoint 1 (f.01:3) pending.
+(rr) c
+Continuing.
+
+R version 3.6.2 (2019-12-12) -- "Dark and Stormy Night"
+[...]
+
+Breakpoint 1, rsh_f[0x56500a98aa80].1 () at f.01:3
+3         int$~"          %0.0  = LdArg                    0
+(rr) n
+4         val?^           %0.1  = LdVar              eR    Sys.sleep, GlobalEnv
+(rr) n
+6         lgl$#"          %0.3  = Identical                %0.1, %0.2
+(rr) n
+10        prom"           %4.1  = MkArg                    %4.0, Prom(0) (!refl),
+(rr) n
+12        env"            e4.3  = (MkEnv)            l     x=%0.0, parent=GlobalEnv, context 1
+(rr) bt
+#0  rsh_f[0x56500a98aa80].1 () at f.01:12
+#1  0x00007f0bd9a5a223 in rir::evalRirCode (c=0x56500aa2fcd8, ctx=0x5650097ce110,
+    env=0x5650097d59a8, callCtxt=0x7fff4d1290d0, initialPC=0x0, cache=0x0)
+    at ../../rir/src/interpreter/interp.cpp:1918
+#2  0x00007f0bd9a6b0ee in rir::evalRirCode (c=0x56500aa2fcd8, ctx=0x5650097ce110,
+    env=0x5650097d59a8, callCtxt=0x7fff4d1290d0)
+    at ../../rir/src/interpreter/interp.cpp:3783
+#3  0x00007f0bd9a5676e in rir::rirCallTrampoline_ (cntxt=..., call=...,
+    code=0x56500aa2fcd8, env=0x5650097d59a8, ctx=0x5650097ce110)
+    at ../../rir/src/interpreter/interp.cpp:501
+#4  0x00007f0bd9a568f9 in rir::rirCallTrampoline (call=..., fun=0x56500aa2ff98,
+    env=0x5650097d59a8, arglist=0x56500b32ffc0, ctx=0x5650097ce110)
+    at ../../rir/src/interpreter/interp.cpp:529
+#5  0x00007f0bd9a6ce41 in rir::rirCallTrampoline (call=..., fun=0x56500aa2ff98,
+    arglist=0x56500b32ffc0, ctx=0x5650097ce110)
+    at ../../rir/src/interpreter/interp.cpp:545
+#6  0x00007f0bd9a6d34a in rir::rirCall (call=..., ctx=0x5650097ce110)
+    at ../../rir/src/interpreter/interp.cpp:1054
+#7  0x00007f0bd9a6b56e in rir::rirApplyClosure (ast=0x56500b330068,
+    op=0x56500b328cb8, arglist=0x56500b32ffc0, rho=0x56500945e800,
+    suppliedvars=0x56500942c190) at ../../rir/src/interpreter/interp.cpp:3827
+#8  0x00005650070d9352 in Rf_applyClosure (call=call@entry=0x56500b330068,
+    op=op@entry=0x56500b328cb8, arglist=0x56500b32ffc0,
+    rho=rho@entry=0x56500945e800, suppliedvars=<optimized out>) at eval.c:1704
+#9  0x00005650070d6c15 in Rf_eval (e=e@entry=0x56500b330068,
+    rho=rho@entry=0x56500945e800) at eval.c:775
+#10 0x0000565007105dbd in Rf_ReplIteration (rho=0x56500945e800, savestack=0,
+    browselevel=0, state=0x7fff4d129400) at main.c:260
+#11 0x0000565007106181 in R_ReplConsole (rho=0x56500945e800, savestack=0,
+    browselevel=0) at main.c:310
+#12 0x0000565007106232 in run_Rmainloop () at main.c:1086
+#13 0x0000565007106282 in Rf_mainloop () at main.c:1093
+#14 0x000056500700cc98 in main (ac=ac@entry=3, av=av@entry=0x7fff4d12a548)
+    at Rmain.c:29
+#15 0x00007f0bdd1ebbf7 in __libc_start_main (main=0x56500700cc80 <main>, argc=3,
+    argv=0x7fff4d12a548, init=<optimized out>, fini=<optimized out>,
+    rtld_fini=<optimized out>, stack_end=0x7fff4d12a538)
+    at ../csu/libc-start.c:310
+#16 0x000056500700ccca in _start ()
+(rr)
+```
+
+Current limitations:
+* `continue` after setting a breakpoint breaks something in `rr` and kills the session
+* no variable information (can't do `p %0.1`)
+* sort of stepping into functions but not tested much

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -166,16 +166,16 @@ There is *WIP* support for debugging LLVM jitted PIR code. It is enabled by `#de
 
 Run your program, ideally with `rr`:
 ```
-***@***:~/rir/build/debug$ bin/R -e "f <- function(x) { Sys.sleep(0.01); x + 123L }; f(4L); f(4L); f(4L); f(4L)" -d rr
+***@***:~/rir/build/debug$ PIR_GDB_FOLDER=pirgdb bin/R -e "f <- function(x) { Sys.sleep(0.01); x + 123L }; f(4L); f(4L); f(4L); f(4L)" -d rr
 rr: Saving execution to trace directory `/home/***/.local/share/rr/R-402'.
 
 R version 3.6.2 (2019-12-12) -- "Dark and Stormy Night"
 [...]
 ```
 
-This will produce PIR listing files for each PIR module compiled, named like `f.01`:
+This will produce PIR listing files for each PIR module compiled, named like `f.001` in the folder specified by `PIR_GDB_FOLDER` (defaults to `pirgdb`, this folder will be wiped if it already exists):
 ```
-***@***:~/rir/build/debug$ cat f.01
+***@***:~/rir/build/debug$ cat pirgdb/f.001
 rsh_f[0x56500a98aa80].1
 BB0
   int$~"          %0.0  = LdArg                    0
@@ -212,19 +212,19 @@ Now, you can run the debugger and set a breakpoint in those files:
 ```
 ***@***:~/rir/build/debug$ rr replay
 GNU gdb (Ubuntu 8.1.1-0ubuntu1) 8.1.1
-...
+[...]
 0x00007f0bdeeef090 in _start () from /lib64/ld-linux-x86-64.so.2
-(rr) b f.01:3
-No source file named f.01.
+(rr) b f.001:3
+No source file named f.001.
 Make breakpoint pending on future shared library load? (y or [n]) y
-Breakpoint 1 (f.01:3) pending.
+Breakpoint 1 (f.001:3) pending.
 (rr) c
 Continuing.
 
 R version 3.6.2 (2019-12-12) -- "Dark and Stormy Night"
 [...]
 
-Breakpoint 1, rsh_f[0x56500a98aa80].1 () at f.01:3
+Breakpoint 1, rsh_f[0x56500a98aa80].1 () at f.001:3
 3         int$~"          %0.0  = LdArg                    0
 (rr) n
 4         val?^           %0.1  = LdVar              eR    Sys.sleep, GlobalEnv
@@ -235,7 +235,7 @@ Breakpoint 1, rsh_f[0x56500a98aa80].1 () at f.01:3
 (rr) n
 12        env"            e4.3  = (MkEnv)            l     x=%0.0, parent=GlobalEnv, context 1
 (rr) bt
-#0  rsh_f[0x56500a98aa80].1 () at f.01:12
+#0  rsh_f[0x56500a98aa80].1 () at f.001:12
 #1  0x00007f0bd9a5a223 in rir::evalRirCode (c=0x56500aa2fcd8, ctx=0x5650097ce110,
     env=0x5650097d59a8, callCtxt=0x7fff4d1290d0, initialPC=0x0, cache=0x0)
     at ../../rir/src/interpreter/interp.cpp:1918

--- a/rir/src/R/r.h
+++ b/rir/src/R/r.h
@@ -18,11 +18,12 @@
 #undef eval
 #undef cons
 
-#undef isString
-inline bool isString(SEXP s) { return TYPEOF(s) == STRSXP; }
-
 #undef isNull
 inline bool isNull(SEXP s) { return TYPEOF(s) == NILSXP; }
+#undef isComplex
+inline bool isComplex(SEXP s) { return TYPEOF(s) == CPLXSXP; }
+#undef isString
+inline bool isString(SEXP s) { return TYPEOF(s) == STRSXP; }
 
 #undef isObject
 inline bool isObject(SEXP s) { return OBJECT(s) != 0; }

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -2,16 +2,13 @@
  * in low level.
  */
 
-#include <cassert>
-#include <cstdio>
-
 #include "api.h"
-
 #include "R/Funtab.h"
 #include "R/Serialize.h"
 #include "compiler/backend.h"
 #include "compiler/compiler.h"
 #include "compiler/log/debug.h"
+#include "compiler/native/pir_debug_info.h"
 #include "compiler/parameter.h"
 #include "compiler/test/PirCheck.h"
 #include "compiler/test/PirTests.h"
@@ -19,6 +16,8 @@
 #include "ir/BC.h"
 #include "ir/Compiler.h"
 
+#include <cassert>
+#include <cstdio>
 #include <list>
 #include <memory>
 #include <string>
@@ -291,7 +290,11 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
     pir::StreamLogger logger(debug);
     logger.title("Compiling " + name);
     pir::Compiler cmp(m, logger);
+#ifdef PIR_GDB_SUPPORT
+    pir::Backend backend(logger, name);
+#else
     pir::Backend backend(logger);
+#endif
     cmp.compileClosure(what, name, assumptions,
                        [&](pir::ClosureVersion* c) {
                            logger.flush();

--- a/rir/src/compiler/backend.h
+++ b/rir/src/compiler/backend.h
@@ -3,6 +3,7 @@
 #include "R/Preserve.h"
 #include "compiler/log/debug.h"
 #include "compiler/log/stream_logger.h"
+#include "compiler/native/pir_debug_info.h"
 #include "compiler/native/pir_jit_llvm.h"
 #include "compiler/pir/module.h"
 #include "compiler/pir/pir.h"
@@ -16,7 +17,12 @@ namespace pir {
 
 class Backend {
   public:
+#ifdef PIR_GDB_SUPPORT
+    Backend(StreamLogger& logger, const std::string& name)
+        : jit(name), logger(logger) {}
+#else
     explicit Backend(StreamLogger& logger) : logger(logger) {}
+#endif
     Backend(const Backend&) = delete;
     Backend& operator=(const Backend&) = delete;
 

--- a/rir/src/compiler/log/stream_logger.h
+++ b/rir/src/compiler/log/stream_logger.h
@@ -73,7 +73,14 @@ class FileLogStream : public LogStream {
 
   public:
     explicit FileLogStream(const std::string& fileName)
-        : LogStream(fstream), fstream(fileName) {}
+        : LogStream(fstream), fstream(fileName) {
+#ifdef ENABLE_SLOWASSERT
+        if (!fstream.good()) {
+            std::cerr << "Warning: FileLogStream(" << fileName
+                      << ") error: " << strerror(errno) << "\n";
+        }
+#endif
+    }
     ~FileLogStream() override;
 
     bool tty() override { return false; }

--- a/rir/src/compiler/native/pir_debug_info.h
+++ b/rir/src/compiler/native/pir_debug_info.h
@@ -1,0 +1,8 @@
+#ifndef PIR_DEBUG_INFO_H
+#define PIR_DEBUG_INFO_H
+
+#ifdef ENABLE_SLOWASSERT
+#define PIR_GDB_SUPPORT
+#endif
+
+#endif

--- a/rir/src/compiler/native/pir_jit_llvm.cpp
+++ b/rir/src/compiler/native/pir_jit_llvm.cpp
@@ -30,6 +30,117 @@ llvm::orc::ThreadSafeContext TSC;
 
 } // namespace
 
+#ifdef PIR_GDB_SUPPORT
+void PirJitLLVM::DebugInfo::addCode(Code* c) {
+    assert(!codeLoc.count(c));
+    codeLoc[c] = line++;
+    log << makeName(c) << "\n";
+    Visitor::run(c->entry, [&](BB* bb) {
+        assert(!BBLoc.count(bb));
+        BBLoc[bb] = line++;
+        bb->printPrologue(log.out, false);
+
+        for (auto i : *bb) {
+            assert(!instLoc.count(i));
+            instLoc[i] = line++;
+            log << "  ";
+            i->print(log.out, false);
+            log << "\n";
+        }
+
+        if (bb->printEpilogue(log.out, false))
+            line++;
+    });
+    line++;
+    log << "\n";
+    log.flush();
+}
+
+llvm::DIType* PirJitLLVM::DebugInfo::getVoidPtrType(llvm::DIBuilder* builder) {
+    if (!VoidPtrType) {
+        VoidPtrType = builder->createNullPtrType();
+    }
+    return VoidPtrType;
+}
+
+llvm::DIType* PirJitLLVM::DebugInfo::getSEXPRECType(llvm::DIBuilder* builder) {
+    if (!SEXPRECType) {
+        // TODO: recursive struct??
+        SEXPRECType = builder->createStructType(CU, "SEXPREC", CU->getFile(), 0,
+                                                0, 0, llvm::DINode::FlagZero,
+                                                nullptr, llvm::DINodeArray());
+    }
+    return SEXPRECType;
+}
+
+llvm::DIType* PirJitLLVM::DebugInfo::getSEXPType(llvm::DIBuilder* builder) {
+    if (!SEXPType) {
+        auto sexprec = getSEXPRECType(builder);
+        SEXPType = builder->createPointerType(sexprec, 64);
+    }
+    return SEXPType;
+}
+
+llvm::DISubroutineType*
+PirJitLLVM::DebugInfo::getNativeCodeType(llvm::DIBuilder* builder) {
+    if (!NativeCodeType) {
+        // NativeCode type is SEXP(Code*, void*, SEXP, SEXP)
+        llvm::SmallVector<llvm::Metadata*, 5> EltTys;
+        EltTys.push_back(getSEXPType(builder));
+        EltTys.push_back(getVoidPtrType(builder));
+        EltTys.push_back(getVoidPtrType(builder));
+        EltTys.push_back(getSEXPType(builder));
+        EltTys.push_back(getSEXPType(builder));
+
+        NativeCodeType = builder->createSubroutineType(
+            builder->getOrCreateTypeArray(EltTys));
+    }
+    return NativeCodeType;
+}
+
+llvm::DIType* PirJitLLVM::DebugInfo::getInstrType(llvm::DIBuilder* builder,
+                                                  PirType t) {
+    std::stringstream ss;
+    ss << t;
+    return builder->createUnspecifiedType(ss.str());
+}
+
+llvm::DIScope* PirJitLLVM::DebugInfo::getScope() {
+    return LexicalBlocks.empty() ? CU : LexicalBlocks.back();
+}
+
+void PirJitLLVM::DebugInfo::emitLocation(llvm::IRBuilder<>& builder,
+                                         size_t line) {
+    llvm::DIScope* Scope = getScope();
+    builder.SetCurrentDebugLocation(
+        llvm::DILocation::get(Scope->getContext(), line, 0, Scope));
+}
+#endif // PIR_GDB_SUPPORT
+
+#ifdef PIR_GDB_SUPPORT
+PirJitLLVM::PirJitLLVM(const std::string& name)
+    : DI(name)
+#else
+PirJitLLVM::PirJitLLVM()
+#endif
+{
+    if (!initialized)
+        initializeLLVM();
+}
+
+// We have to wait to query LLVM for native code addresses until all Code's
+// (including promises) are added to the Module. Hence, in the destructor,
+// we need to fixup all the native pointers.
+PirJitLLVM::~PirJitLLVM() {
+    if (M) {
+#ifdef PIR_GDB_SUPPORT
+        DIB->finalize(); // should this happen before addIRModule or after?
+#endif
+        finalizeAndFixup();
+        nModules++;
+    }
+}
+
 void PirJitLLVM::finalizeAndFixup() {
     // TODO: maybe later have TSM from the start and use locking
     //       to allow concurrent compilation?
@@ -50,12 +161,42 @@ void PirJitLLVM::compile(
 
     if (!M.get()) {
         M = std::make_unique<llvm::Module>("", *TSC.getContext());
+
+#ifdef PIR_GDB_SUPPORT
+        // Add the current debug info version into the module.
+        M->addModuleFlag(llvm::Module::Warning, "Debug Info Version",
+                         llvm::DEBUG_METADATA_VERSION);
+
+        // Darwin only supports dwarf2.
+        if (JIT->getTargetTriple().isOSDarwin())
+            M->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 2);
+
+        // Construct the DIBuilder, we do this here because we need the module.
+        DIB = std::make_unique<llvm::DIBuilder>(*M);
+
+        // Create the compile unit for the module.
+        DI.File = DIB->createFile(DI.FileName, ".");
+        DI.CU = DIB->createCompileUnit(llvm::dwarf::DW_LANG_C, DI.File,
+                                       "PIR Compiler", false, "", 0);
+#endif // PIR_GDB_SUPPORT
     }
+
+#ifdef PIR_GDB_SUPPORT
+    DI.addCode(code);
+#endif
 
     std::string mangledName = JIT->mangle(makeName(code));
 
     LowerFunctionLLVM funCompiler(
         mangledName, code, promMap, refcount, needsLdVarForUpdate,
+        // declare
+        [&](Code* c, const std::string& name, llvm::FunctionType* signature) {
+            assert(!funs.count(c));
+            auto f = llvm::Function::Create(
+                signature, llvm::Function::ExternalLinkage, name, *M);
+            funs[c] = f;
+            return f;
+        },
         // getModule
         [&]() -> llvm::Module& { return *M; },
         // getFunction
@@ -81,30 +222,51 @@ void PirJitLLVM::compile(
 
             builtins[b.name] = {f, b.fun};
             return f;
-        },
-        // declare
-        [&](Code* c, const std::string& name, llvm::FunctionType* signature) {
-            assert(!funs.count(c));
-            auto f = llvm::Function::Create(
-                signature, llvm::Function::ExternalLinkage, name, *M);
-            funs[c] = f;
-            return f;
-        });
+        }
+#ifdef PIR_GDB_SUPPORT
+        ,
+        &DI, DIB.get()
+#endif
+    );
+
+#ifdef PIR_GDB_SUPPORT
+    llvm::DIScope* FContext = DI.File;
+    unsigned ScopeLine = 0;
+    llvm::DISubprogram* SP = DIB->createFunction(
+        FContext, makeName(code), mangledName, DI.File, DI.getCodeLoc(code),
+        DI.getNativeCodeType(DIB.get()), ScopeLine,
+        llvm::DINode::FlagPrototyped,
+        llvm::DISubprogram::toSPFlags(true /* isLocalToUnit */,
+                                      true /* isDefinition */,
+                                      false /* isOptimized */));
+
+    funCompiler.fun->setSubprogram(SP);
+    DI.LexicalBlocks.push_back(SP);
+#endif // PIR_GDB_SUPPORT
+
     funCompiler.compile();
+
+    llvm::verifyFunction(*funCompiler.fun);
+    assert(jitFixup.count(code) == 0);
+
+#ifdef PIR_GDB_SUPPORT
+    DI.LexicalBlocks.pop_back();
+    DIB->finalizeSubprogram(SP);
+#endif
+
     if (funCompiler.pirTypeFeedback)
         target->pirTypeFeedback(funCompiler.pirTypeFeedback);
     if (funCompiler.hasArgReordering())
         target->arglistOrder(ArglistOrder::New(funCompiler.getArgReordering()));
-    llvm::verifyFunction(*funCompiler.fun);
-    assert(jitFixup.count(code) == 0);
+    // can we use llvm::StringRefs?
+    jitFixup.emplace(code,
+                     std::make_pair(target, funCompiler.fun->getName().str()));
+
     log.LLVMBitcode([&](std::ostream& out, bool tty) {
         auto f = funCompiler.fun;
         llvm::raw_os_ostream ro(out);
         f->print(ro, nullptr);
     });
-    // can we use llvm::StringRefs?
-    jitFixup.emplace(code,
-                     std::make_pair(target, funCompiler.fun->getName().str()));
 }
 
 llvm::LLVMContext& PirJitLLVM::getContext() { return *TSC.getContext(); }
@@ -133,8 +295,7 @@ void PirJitLLVM::initializeLLVM() {
     JIT = ExitOnErr(
         LLJITBuilder()
             .setJITTargetMachineBuilder(std::move(JTMB))
-    // TODO: look into gdb support...
-#ifdef PIR_LLVM_GDB
+#ifdef PIR_GDB_SUPPORT
             .setObjectLinkingLayerCreator(
                 [&](ExecutionSession& ES, const Triple& TT) {
                     auto GetMemMgr = []() {
@@ -153,7 +314,7 @@ void PirJitLLVM::initializeLLVM() {
 
                     return ObjLinkingLayer;
                 })
-#endif
+#endif // PIR_GDB_SUPPORT
             .create());
 
     // Create one global ThreadSafeContext

--- a/rir/src/compiler/native/pir_jit_llvm.h
+++ b/rir/src/compiler/native/pir_jit_llvm.h
@@ -102,19 +102,21 @@ class PirJitLLVM {
   public:
     static std::string makeDbgFileName(const std::string& base) {
         std::stringstream ss;
-        ss << base << "." << std::setfill('0') << std::setw(2) << nModules;
+        ss << base << "." << std::setfill('0') << std::setw(3) << nModules;
         return ss.str();
     }
     struct DebugInfo {
         DebugInfo(const DebugInfo&) = delete;
-        explicit DebugInfo(const std::string& name)
-            : CU(nullptr), File(nullptr), FileName(makeDbgFileName(name)),
-              VoidPtrType(nullptr), SEXPRECType(nullptr), SEXPType(nullptr),
-              NativeCodeType(nullptr), log(FileName), line(1) {}
+        DebugInfo(const std::string& folder, const std::string& name)
+            : CU(nullptr), File(nullptr), Folder(folder),
+              FileName(makeDbgFileName(name)), VoidPtrType(nullptr),
+              SEXPRECType(nullptr), SEXPType(nullptr), NativeCodeType(nullptr),
+              line(1) {}
 
         llvm::DICompileUnit* CU;
         llvm::DIFile* File;
 
+        std::string Folder;
         std::string FileName;
 
         std::vector<llvm::DIScope*> LexicalBlocks;
@@ -130,7 +132,7 @@ class PirJitLLVM {
         llvm::DISubroutineType* getNativeCodeType(llvm::DIBuilder*);
         llvm::DIType* getInstrType(llvm::DIBuilder*, PirType);
 
-        FileLogStream log;
+        std::unique_ptr<FileLogStream> log;
         size_t line;
         std::unordered_map<Code*, size_t> codeLoc;
         std::unordered_map<BB*, size_t> BBLoc;

--- a/rir/src/compiler/native/pir_jit_llvm.h
+++ b/rir/src/compiler/native/pir_jit_llvm.h
@@ -3,12 +3,22 @@
 
 #include "compiler/log/stream_logger.h"
 #include "compiler/native/builtins.h"
+#include "compiler/native/pir_debug_info.h"
+#include "compiler/pir/bb.h"
 #include "compiler/pir/closure_version.h"
+#include "compiler/pir/instruction.h"
 #include "compiler/pir/pir.h"
 #include "compiler/pir/promise.h"
+#include "compiler/util/visitor.h"
 
+#ifdef PIR_GDB_SUPPORT
+#include "llvm/IR/DIBuilder.h"
+#endif
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
 
+#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
@@ -31,20 +41,14 @@ using PromMap = std::unordered_map<Code*, std::pair<unsigned, MkArg*>>;
 // addresses for PIR builtins.
 class PirJitLLVM {
   public:
-    PirJitLLVM() {
-        if (!initialized)
-            initializeLLVM();
-    }
-
-    // We have to wait to query LLVM for native code addresses until all Code's
-    // (including promises) are added to the Module. Hence, in the destructor,
-    // we need to fixup all the native pointers.
-    ~PirJitLLVM() {
-        if (M) {
-            finalizeAndFixup();
-            nModules++;
-        }
-    }
+#ifdef PIR_GDB_SUPPORT
+    explicit PirJitLLVM(const std::string& name);
+#else
+    PirJitLLVM();
+#endif
+    PirJitLLVM(const PirJitLLVM&) = delete;
+    PirJitLLVM(PirJitLLVM&&) = delete;
+    ~PirJitLLVM();
 
     void compile(rir::Code* target, Code* code, const PromMap& m,
                  const NeedsRefcountAdjustment& refcount,
@@ -92,6 +96,54 @@ class PirJitLLVM {
     static size_t nModules;
     static void initializeLLVM();
     static bool initialized;
+
+#ifdef PIR_GDB_SUPPORT
+    // Support for debugging pir in gdb
+  public:
+    static std::string makeDbgFileName(const std::string& base) {
+        std::stringstream ss;
+        ss << base << "." << std::setfill('0') << std::setw(2) << nModules;
+        return ss.str();
+    }
+    struct DebugInfo {
+        DebugInfo(const DebugInfo&) = delete;
+        explicit DebugInfo(const std::string& name)
+            : CU(nullptr), File(nullptr), FileName(makeDbgFileName(name)),
+              VoidPtrType(nullptr), SEXPRECType(nullptr), SEXPType(nullptr),
+              NativeCodeType(nullptr), log(FileName), line(1) {}
+
+        llvm::DICompileUnit* CU;
+        llvm::DIFile* File;
+
+        std::string FileName;
+
+        std::vector<llvm::DIScope*> LexicalBlocks;
+        llvm::DIScope* getScope();
+
+        llvm::DIType* VoidPtrType;
+        llvm::DIType* getVoidPtrType(llvm::DIBuilder*);
+        llvm::DIType* SEXPRECType;
+        llvm::DIType* getSEXPRECType(llvm::DIBuilder*);
+        llvm::DIType* SEXPType;
+        llvm::DIType* getSEXPType(llvm::DIBuilder*);
+        llvm::DISubroutineType* NativeCodeType;
+        llvm::DISubroutineType* getNativeCodeType(llvm::DIBuilder*);
+        llvm::DIType* getInstrType(llvm::DIBuilder*, PirType);
+
+        FileLogStream log;
+        size_t line;
+        std::unordered_map<Code*, size_t> codeLoc;
+        std::unordered_map<BB*, size_t> BBLoc;
+        std::unordered_map<Instruction*, size_t> instLoc;
+        void addCode(Code* c);
+        size_t getCodeLoc(Code* c) const { return codeLoc.at(c); }
+        size_t getBBLoc(BB* bb) const { return BBLoc.at(bb); }
+        size_t getInstLoc(Instruction* i) const { return instLoc.at(i); }
+        void emitLocation(llvm::IRBuilder<>&, size_t);
+    };
+    DebugInfo DI;
+    std::unique_ptr<llvm::DIBuilder> DIB;
+#endif
 };
 
 } // namespace pir

--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -22,7 +22,7 @@ void BB::remove(Instruction* i) {
     assert(false);
 }
 
-void BB::print(std::ostream& out, bool tty) {
+void BB::printPrologue(std::ostream& out, bool tty) {
     out << "BB" << id;
     if (!predecessors().empty()) {
         out << "   <- [";
@@ -34,14 +34,24 @@ void BB::print(std::ostream& out, bool tty) {
         out << "]";
     }
     out << "\n";
+}
+
+bool BB::printEpilogue(std::ostream& out, bool tty) {
+    if (isJmp()) {
+        out << "  goto BB" << next0->id << "\n";
+        return true;
+    }
+    return false;
+}
+
+void BB::print(std::ostream& out, bool tty) {
+    printPrologue(out, tty);
     for (auto i : instrs) {
         out << "  ";
         i->print(out, tty);
         out << "\n";
     }
-    if (isJmp()) {
-        out << "  goto BB" << next0->id << "\n";
-    }
+    printEpilogue(out, tty);
 }
 
 void BB::printGraph(std::ostream& out, bool omitDeoptBranches) {

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -5,8 +5,8 @@
 #include "pir.h"
 
 #include "utils/Set.h"
-#include <unordered_set>
 #include <iostream>
+#include <unordered_set>
 
 #include <array>
 
@@ -76,6 +76,9 @@ class BB {
 
     bool before(Instruction*, Instruction*) const;
 
+    void printPrologue(std::ostream&, bool tty);
+    // Returns true if it printed anything (for debugging src location purposes)
+    bool printEpilogue(std::ostream&, bool tty);
     void print(std::ostream&, bool tty);
     void printGraph(std::ostream&, bool omitDeoptBranches);
     void printBBGraph(std::ostream&, bool omitDeoptBranches);


### PR DESCRIPTION
This is still incomplete and broken.

Idea: when compiling, dump pir into a file and remember lines of each instruction, then set these as debugging metadata that llvm converts into dwarf.

to be done: info about variables, function calls, fix some weird errors after breaking and continuing, and probably more...