### PR TITLE
set Argmatch flag even in interpreted calls

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -882,11 +882,11 @@ void inferCurrentContext(CallContext& call, size_t formalNargs,
         }
     };
 
+    bool tryArgmatch = !given.includes(Assumption::StaticallyArgmatched);
     given.add(Assumption::CorrectOrderOfArguments);
-
     auto sig =
         DispatchTable::unpack(BODY(call.callee))->baseline()->signature();
-    if (given.includes(Assumption::NotTooManyArguments) &&
+    if (tryArgmatch && given.includes(Assumption::NotTooManyArguments) &&
         given.numMissing() == 0 && !sig.hasDotsFormals)
         given.add(Assumption::StaticallyArgmatched);
 
@@ -896,8 +896,9 @@ void inferCurrentContext(CallContext& call, size_t formalNargs,
         if (call.hasNames()) {
             auto name = call.name(i, ctx);
             if (name != R_NilValue && name != TAG(formals)) {
+                if (tryArgmatch)
+                    given.remove(Assumption::StaticallyArgmatched);
                 given.remove(Assumption::CorrectOrderOfArguments);
-                given.remove(Assumption::StaticallyArgmatched);
             }
             formals = CDR(formals);
         }

--- a/rir/src/runtime/FunctionSignature.h
+++ b/rir/src/runtime/FunctionSignature.h
@@ -27,6 +27,7 @@ struct FunctionSignature {
         unsigned numArgs = InInteger(inp);
         FunctionSignature sig(envc, opt);
         sig.numArguments = numArgs;
+        sig.dotsPosition = InInteger(inp);
         return sig;
     }
 
@@ -34,13 +35,16 @@ struct FunctionSignature {
         OutInteger(out, (int)envCreation);
         OutInteger(out, (int)optimization);
         OutInteger(out, numArguments);
+        OutInteger(out, dotsPosition);
     }
 
     void pushFormal(SEXP arg, SEXP name) {
         if (arg != R_MissingArg)
             hasDefaultArgs = true;
-        if (name != R_NilValue)
+        if (name == R_DotsSymbol) {
             hasDotsFormals = true;
+            dotsPosition = numArguments;
+        }
         numArguments++;
     }
 
@@ -63,6 +67,7 @@ struct FunctionSignature {
     unsigned numArguments = 0;
     bool hasDotsFormals = false;
     bool hasDefaultArgs = false;
+    size_t dotsPosition = -1;
 };
 
 } // namespace rir


### PR DESCRIPTION
set the Argmatch flag if the caller happens to conform to its
requirements. (ie. all args are passed, in the correct order and dots
are resolved)