### PR TITLE
Improved recording of types

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -112,8 +112,9 @@ completely disables the PIR optimizer. As follows are the different Options avai
 * `^` : May be lazy (and wrapped in a promise)
 * `~` : May be wrapped in a promise (but evaluated)
 * `?` : May be missing
-* `'` : Not an object but may have attributes
-* `"` : Not an object and has no attributes
+* `⁺` : Not an object but may have attributes
+* `ⁿ` : Can only have dimension attributes (not an object)
+* `⁻` : No attributes at all
 
 #### Effects
 

--- a/rir/src/compiler/analysis/abstract_value.cpp
+++ b/rir/src/compiler/analysis/abstract_value.cpp
@@ -193,12 +193,12 @@ AbstractLoad AbstractREnvironmentHierarchy::getFun(Value* env, SEXP e) const {
             const AbstractPirValue& res = envIt->second.get(e);
 
             // If it is a closure, we know we are good
-            if (res.type.isA(RType::closure))
+            if (res.type.isA(PirType::closure()))
                 return AbstractLoad(env, res);
 
             // If it might be a closure, we can neither be sure, nor exclude
             // this binding...
-            if (res.type.maybe(RType::closure))
+            if (res.type.maybe(PirType::closure()))
                 return AbstractLoad(env, AbstractPirValue::tainted());
 
             if (res.maybeUnboundValue())

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -4342,7 +4342,7 @@ void LowerFunctionLLVM::compile() {
                 auto vector = loadSxp(extract->vec());
 
                 bool fastcase = !extract->vec()->type.maybe(RType::vec) &&
-                                !extract->vec()->type.maybeHasAttrs() &&
+                                !extract->vec()->type.maybeObj() &&
                                 vectorTypeSupport(extract->vec()) &&
                                 extract->idx()->type.isA(
                                     PirType::intReal().notObject().scalar());

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -3939,7 +3939,9 @@ void LowerFunctionLLVM::compile() {
                     }
                     if (arg->type.maybeHasAttrs() &&
                         !t->typeTest.maybeHasAttrs()) {
-                        res = builder.CreateAnd(res, fastVeceltOkNative(a));
+                        res = builder.CreateAnd(
+                            res, builder.CreateICmpEQ(
+                                     attr(a), constant(R_NilValue, t::SEXP)));
                     }
                     if (arg->type.maybeObj() && !t->typeTest.maybeObj()) {
                         res =

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -674,10 +674,10 @@ llvm::Value* LowerFunctionLLVM::dataPtr(llvm::Value* v, bool enableAsserts) {
 
 bool LowerFunctionLLVM::vectorTypeSupport(Value* vector) {
     auto type = vector->type;
-    return type.isA(PirType(RType::vec).notObject()) ||
-           type.isA(PirType(RType::integer).notObject()) ||
-           type.isA(PirType(RType::logical).notObject()) ||
-           type.isA(PirType(RType::real).notObject());
+    return type.isA(PirType(RType::vec).orAttribsOrObj().fastVecelt()) ||
+           type.isA(PirType(RType::integer).orAttribsOrObj().fastVecelt()) ||
+           type.isA(PirType(RType::logical).orAttribsOrObj().fastVecelt()) ||
+           type.isA(PirType(RType::real).orAttribsOrObj().fastVecelt());
 }
 
 llvm::Value* LowerFunctionLLVM::vectorPositionPtr(llvm::Value* vector,
@@ -685,12 +685,12 @@ llvm::Value* LowerFunctionLLVM::vectorPositionPtr(llvm::Value* vector,
                                                   PirType type) {
     assert(vector->getType() == t::SEXP);
     PointerType* nativeType;
-    if (type.isA(PirType(RType::integer).notObject()) ||
-        type.isA(PirType(RType::logical).notObject())) {
+    if (type.isA(PirType(RType::integer).orAttribsOrObj().fastVecelt()) ||
+        type.isA(PirType(RType::logical).orAttribsOrObj().fastVecelt())) {
         nativeType = t::IntPtr;
-    } else if (type.isA(PirType(RType::real).notObject())) {
+    } else if (type.isA(PirType(RType::real).orAttribsOrObj().fastVecelt())) {
         nativeType = t::DoublePtr;
-    } else if (type.isA(PirType(RType::vec).notObject())) {
+    } else if (type.isA(PirType(RType::vec).orAttribsOrObj().fastVecelt())) {
         nativeType = t::SEXP_ptr;
     } else {
         nativeType = t::SEXP_ptr;
@@ -4360,7 +4360,7 @@ void LowerFunctionLLVM::compile() {
                                              branchMostlyFalse);
                         builder.SetInsertPoint(hit2);
 
-                        if (extract->vec()->type.maybeHasAttrs()) {
+                        if (extract->vec()->type.maybeNotFastVecelt()) {
                             auto hit3 = BasicBlock::Create(
                                 PirJitLLVM::getContext(), "", fun);
                             builder.CreateCondBr(fastVeceltOkNative(vector),
@@ -4430,7 +4430,7 @@ void LowerFunctionLLVM::compile() {
                                              branchMostlyFalse);
                         builder.SetInsertPoint(hit2);
 
-                        if (extract->vec()->type.maybeHasAttrs()) {
+                        if (extract->vec()->type.maybeNotFastVecelt()) {
                             auto hit3 = BasicBlock::Create(
                                 PirJitLLVM::getContext(), "", fun);
                             builder.CreateCondBr(fastVeceltOkNative(vector),
@@ -4873,7 +4873,7 @@ void LowerFunctionLLVM::compile() {
                                              branchMostlyFalse);
                         builder.SetInsertPoint(hit1);
 
-                        if (vecType.maybeHasAttrs()) {
+                        if (vecType.maybeNotFastVecelt()) {
                             auto hit2 = BasicBlock::Create(
                                 PirJitLLVM::getContext(), "", fun);
                             builder.CreateCondBr(fastVeceltOkNative(vector),

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -4342,8 +4342,8 @@ void LowerFunctionLLVM::compile() {
                 auto vector = loadSxp(extract->vec());
 
                 bool fastcase = !extract->vec()->type.maybe(RType::vec) &&
-                                !extract->vec()->type.maybeObj() &&
                                 vectorTypeSupport(extract->vec()) &&
+                                extract->type.unboxable() &&
                                 extract->idx()->type.isA(
                                     PirType::intReal().notObject().scalar());
                 BasicBlock* done;
@@ -4409,7 +4409,7 @@ void LowerFunctionLLVM::compile() {
                 auto extract = Extract1_2D::Cast(i);
 
                 bool fastcase = !extract->vec()->type.maybe(RType::vec) &&
-                                !extract->vec()->type.maybeObj() &&
+                                extract->type.unboxable() &&
                                 vectorTypeSupport(extract->vec()) &&
                                 extract->idx1()->type.isA(
                                     PirType::intReal().notObject().scalar()) &&

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -674,10 +674,10 @@ llvm::Value* LowerFunctionLLVM::dataPtr(llvm::Value* v, bool enableAsserts) {
 
 bool LowerFunctionLLVM::vectorTypeSupport(Value* vector) {
     auto type = vector->type;
-    return type.isA(PirType(RType::vec).orAttribsOrObj().fastVecelt()) ||
-           type.isA(PirType(RType::integer).orAttribsOrObj().fastVecelt()) ||
-           type.isA(PirType(RType::logical).orAttribsOrObj().fastVecelt()) ||
-           type.isA(PirType(RType::real).orAttribsOrObj().fastVecelt());
+    return type.isA(PirType(RType::vec).orFastVecelt()) ||
+           type.isA(PirType(RType::integer).orFastVecelt()) ||
+           type.isA(PirType(RType::logical).orFastVecelt()) ||
+           type.isA(PirType(RType::real).orFastVecelt());
 }
 
 llvm::Value* LowerFunctionLLVM::vectorPositionPtr(llvm::Value* vector,
@@ -4738,9 +4738,11 @@ void LowerFunctionLLVM::compile() {
                     idx1Type.isA(PirType::intReal().notObject().scalar()) &&
                     idx2Type.isA(PirType::intReal().notObject().scalar()) &&
                     valType.isScalar() && !vecType.maybeObj() &&
-                    ((vecType.isA(RType::integer) &&
+                    ((vecType.isA(PirType(RType::integer).orFastVecelt()) &&
                       valType.isA(RType::integer)) ||
-                     (vecType.isA(RType::real) && valType.isA(RType::real)));
+                     (vecType.isA(PirType(RType::real).orFastVecelt()) &&
+                      valType.isA(RType::real)));
+
                 // Conversion from scalar to vector. eg. `a = 1; a[10] = 2`
                 if (Representation::Of(subAssign->vec()) != t::SEXP &&
                     Representation::Of(i) == t::SEXP)
@@ -4854,10 +4856,11 @@ void LowerFunctionLLVM::compile() {
                 bool fastcase =
                     idxType.isA(PirType::intReal().notObject().scalar()) &&
                     valType.isScalar() && !vecType.maybeObj() &&
-                    (vecType.isA(RType::vec) ||
-                     (vecType.isA(RType::integer) &&
+                    (vecType.isA(PirType(RType::vec).orFastVecelt()) ||
+                     (vecType.isA(PirType(RType::integer).orFastVecelt()) &&
                       valType.isA(RType::integer)) ||
-                     (vecType.isA(RType::real) && valType.isA(RType::real)));
+                     (vecType.isA(PirType(RType::real).orFastVecelt()) &&
+                      valType.isA(RType::real)));
                 // Conversion from scalar to vector. eg. `a = 1; a[10] = 2`
                 if (Representation::Of(subAssign->vec()) != t::SEXP &&
                     Representation::Of(i) == t::SEXP)
@@ -4940,9 +4943,10 @@ void LowerFunctionLLVM::compile() {
                 bool fastcase =
                     idxType.isA(PirType::intRealLgl().notObject().scalar()) &&
                     valType.isScalar() && !vecType.maybeObj() &&
-                    ((vecType.isA(RType::integer) &&
+                    ((vecType.isA(PirType(RType::integer).orFastVecelt()) &&
                       valType.isA(RType::integer)) ||
-                     (vecType.isA(RType::real) && valType.isA(RType::real)));
+                     (vecType.isA(PirType(RType::real).orFastVecelt()) &&
+                      valType.isA(RType::real)));
                 // Conversion from scalar to vector. eg. `a = 1; a[10] = 2`
                 if (Representation::Of(subAssign->vec()) != t::SEXP &&
                     Representation::Of(i) == t::SEXP)

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -70,7 +70,7 @@ bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code,
                     }
                 } else if (auto chkcls = ChkClosure::Cast(i)) {
                     Value* arg = chkcls->arg<0>().val();
-                    if (arg->type.isA(RType::closure)) {
+                    if (arg->type.isA(PirType::closure())) {
                         removed = true;
                         chkcls->replaceUsesWith(arg);
                         next = bb->remove(ip);

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -747,7 +747,7 @@ bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         }
                     } else if (builtinId == blt("is.integer") && nargs == 1) {
                         auto t = i->arg(0).val()->type;
-                        if (t.isA(PirType(RType::integer).noAttribs())) {
+                        if (t.isA(PirType(RType::integer))) {
                             iterAnyChange = true;
                             i->replaceUsesWith(True::instance());
                             next = bb->remove(ip);
@@ -814,7 +814,7 @@ bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         static PirType typeThatDoesntError =
                             (PirType::num() | RType::chr | RType::str |
                              RType::vec)
-                                .orAttribs();
+                                .orAttribsOrObj();
                         if (typeThatDoesntError.isA(t) && !t.maybeNAOrNaN()) {
                             iterAnyChange = true;
                             i->replaceUsesWith(False::instance());

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -703,11 +703,11 @@ bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         }
                     } else if (builtinId == blt("is.function") && nargs == 1) {
                         auto t = i->arg(0).val()->type;
-                        if (t.isA(RType::closure)) {
+                        if (t.isA(PirType::closure())) {
                             iterAnyChange = true;
                             i->replaceUsesWith(True::instance());
                             next = bb->remove(ip);
-                        } else if (!t.maybe(RType::closure)) {
+                        } else if (!t.maybe(PirType::closure())) {
                             iterAnyChange = true;
                             i->replaceUsesWith(False::instance());
                             next = bb->remove(ip);
@@ -835,7 +835,7 @@ bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                             if (auto cast = CastType::Cast(i->arg(0).val())) {
                                 if (cast != in &&
                                     cast->kind == CastType::Downcast &&
-                                    cast->type.isA(RType::closure)) {
+                                    cast->type.isA(PirType::closure())) {
                                     if (auto cast2 = CastType::Cast(
                                             cast->arg(0).val())) {
                                         if (cast2 != in &&

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -116,6 +116,7 @@ bool DelayInstr::apply(Compiler&, ClosureVersion* cls, Code* code,
                     instruction->replaceUsesIn(newInstr, targetBB);
                     replacements[instruction].insert({targetBB, newInstr});
                 }
+                next = bb->remove(ip);
             }
             ip = next;
         }

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -79,7 +79,7 @@ bool ElideEnvSpec::apply(Compiler&, ClosureVersion* cls, Code* code,
                         // opts if we show that the vector has no attribs
                         if (auto e = Extract1_1D::Cast(i))
                             if (arg == e->vec())
-                                suggested = required.noAttribs();
+                                suggested = required.noAttribsOrObject();
 
                         TypeTest::Create(
                             arg, seen, suggested, required,

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -62,7 +62,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                 i->replaceUsesWith(
                     mk->eagerArg(),
                     [&](Instruction* j, size_t a) {
-                        if (!j->arg(a).type().maybeLazy())
+                        if (j->arg(a).type().isA(RType::prom))
                             j->arg(a).type() = mk->eagerArg()->type;
                     },
                     [&](Instruction* j) { return j->tag != Tag::CastType; });

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -61,7 +61,8 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
             if (mk->isEager() && mk->prom()->trivial()) {
                 i->replaceUsesWith(mk->eagerArg(),
                                    [&](Instruction* j, size_t a) {
-                                       if (j->arg(a).type().isA(RType::prom))
+                                       if (j->arg(a).type().isA(PirType() |
+                                                                RType::prom))
                                            j->arg(a).type() =
                                                mk->eagerArg()->type;
                                    },
@@ -401,7 +402,6 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                         if (inlinedPromise.count(otherForce)) {
                             f->replaceUsesWith(inlinedPromise.at(otherForce));
                         } else {
-                            dom->second->type = dom->second->type & f->type;
                             f->replaceUsesWith(dom->second);
                         }
                         next = bb->remove(ip);

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -59,17 +59,13 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
         }
         if (auto mk = MkArg::Cast(i)) {
             if (mk->isEager() && mk->prom()->trivial()) {
-                i->replaceUsesWith(mk->eagerArg(),
-                                   [&](Instruction* j, size_t a) {
-                                       if (j->arg(a).type().isA(PirType() |
-                                                                RType::prom))
-                                           j->arg(a).type() =
-                                               mk->eagerArg()->type;
-                                   },
-                                   [&](Instruction* j) {
-                                       return !CallInstruction::CastCall(j) &&
-                                              j->tag != Tag::CastType;
-                                   });
+                i->replaceUsesWith(
+                    mk->eagerArg(),
+                    [&](Instruction* j, size_t a) {
+                        if (!j->arg(a).type().maybeLazy())
+                            j->arg(a).type() = mk->eagerArg()->type;
+                    },
+                    [&](Instruction* j) { return j->tag != Tag::CastType; });
                 anyChange = true;
             }
         }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -101,7 +101,7 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
                             }
                             auto e = new CallSafeBuiltin(
                                 b, {call->runtimeClosure()}, 0);
-                            e->type = RType::env;
+                            e->type = PirType::env();
                             e->effects.reset();
                             it = bb->insert(it, e);
                             it++;

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -31,6 +31,7 @@ PassScheduler::PassScheduler() {
 
         add<OptimizeContexts>();
 
+        add<DelayInstr>();
         add<ForceDominance>();
         add<ScopeResolution>();
         add<LoadElision>();
@@ -47,7 +48,6 @@ PassScheduler::PassScheduler() {
 
         add<ElideEnv>();
         add<DelayEnv>();
-        add<DelayInstr>();
         add<Cleanup>();
 
         add<OptimizeVisibility>();

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -60,6 +60,7 @@ PassScheduler::PassScheduler() {
     auto addDefaultPostPhaseOpt = [&]() {
         add<HoistInstruction>();
         add<LoopInvariant>();
+        add<DelayInstr>();
     };
 
     nextPhase("Initial", 60);

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -48,6 +48,7 @@ PassScheduler::PassScheduler() {
 
         add<ElideEnv>();
         add<DelayEnv>();
+        add<DelayInstr>();
         add<Cleanup>();
 
         add<OptimizeVisibility>();
@@ -60,7 +61,6 @@ PassScheduler::PassScheduler() {
     auto addDefaultPostPhaseOpt = [&]() {
         add<HoistInstruction>();
         add<LoopInvariant>();
-        add<DelayInstr>();
     };
 
     nextPhase("Initial", 60);

--- a/rir/src/compiler/opt/type_test.h
+++ b/rir/src/compiler/opt/type_test.h
@@ -34,9 +34,9 @@ class TypeTest {
         assert(feedback.origin);
         // First try to refine the type
         if (!expected.maybeObj() && // TODO: Is this right?
-            (expected.noAttribs().isA(RType::integer) ||
-             expected.noAttribs().isA(RType::real) ||
-             expected.noAttribs().isA(RType::logical))) {
+            (expected.noAttribsOrObject().isA(RType::integer) ||
+             expected.noAttribsOrObject().isA(RType::real) ||
+             expected.noAttribsOrObject().isA(RType::logical))) {
             return action({expected, new IsType(expected, i), true,
                            feedback.srcCode, feedback.origin});
         }
@@ -48,7 +48,7 @@ class TypeTest {
         if (i->type.isA(suggested))
             return;
 
-        auto checkFor = i->type.notLazy().noAttribs();
+        auto checkFor = i->type.notLazy().noAttribsOrObject();
         if (expected.isA(checkFor)) {
             assert(!expected.maybeObj());
             assert(!expected.maybeHasAttrs());

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -74,7 +74,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                                 m = m.mergeWithConversion(
                                     getType(c->callArg(i).val()));
                             if (!m.maybeObj()) {
-                                inferred = m & PirType::num();
+                                inferred = m & PirType::num().orAttribsOrObj();
 
                                 if (inferred.maybe(RType::logical))
                                     inferred = inferred.orT(RType::integer)
@@ -102,7 +102,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                                 m = m.mergeWithConversion(
                                     getType(c->callArg(i).val()));
                             if (!m.maybeObj()) {
-                                inferred = m & PirType::num();
+                                inferred = m & PirType::num().orAttribsOrObj();
                                 inferred = inferred.orT(RType::real)
                                                .notT(RType::integer);
                                 break;
@@ -207,7 +207,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                     }
 
                     if ("strsplit" == name) {
-                        inferred = RType::vec;
+                        inferred = PirType(RType::vec).orAttribsOrObj();
                         break;
                     }
 

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -131,6 +131,12 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                     if (vecTests.count(name)) {
                         if (!getType(c->callArg(0).val()).maybeObj()) {
                             inferred = PirType(RType::logical);
+                            if (getType(c->callArg(0).val()).maybeHasAttrs())
+                                inferred =
+                                    inferred.orAttribsOrObj().notObject();
+                            if (!getType(c->callArg(0).val())
+                                     .maybeNotFastVecelt())
+                                inferred = inferred.fastVecelt();
                             if (getType(c->callArg(0).val()).isSimpleScalar())
                                 inferred = inferred.simpleScalar();
                         } else {

--- a/rir/src/compiler/pir/env.h
+++ b/rir/src/compiler/pir/env.h
@@ -19,7 +19,7 @@ class Instruction;
  */
 class Env : public Value {
     Env(SEXP rho, Env* parent)
-        : Value(RType::env, Tag::Env), rho(rho), parent(parent) {}
+        : Value(PirType::env(), Tag::Env), rho(rho), parent(parent) {}
     friend class Module;
 
   public:

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -741,7 +741,7 @@ void PirCopy::print(std::ostream& out, bool tty) const {
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
                                  unsigned srcIdx)
-    : VarLenInstruction(PirType::val().notObject().notMissing(), srcIdx),
+    : VarLenInstruction(PirType::val().notMissing(), srcIdx),
       builtinSexp(builtin), builtin(getBuiltin(builtin)),
       builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)
@@ -914,7 +914,7 @@ void ScheduledDeopt::printArgs(std::ostream& out, bool tty) const {
 
 MkFunCls::MkFunCls(Closure* cls, SEXP formals, SEXP srcRef,
                    DispatchTable* originalBody, Value* lexicalEnv)
-    : FixedLenInstructionWithEnvSlot(RType::closure, lexicalEnv), cls(cls),
+    : FixedLenInstructionWithEnvSlot(PirType::closure(), lexicalEnv), cls(cls),
       originalBody(originalBody), formals(formals), srcRef(srcRef) {}
 
 void MkFunCls::printArgs(std::ostream& out, bool tty) const {
@@ -1082,7 +1082,7 @@ Call::Call(Value* callerEnv, Value* fun, const std::vector<Value*>& args,
     : VarLenInstructionWithEnvSlot(PirType::val(), callerEnv, srcIdx) {
     assert(fs);
     pushArg(fs, NativeType::frameState);
-    pushArg(fun, RType::closure);
+    pushArg(fun, PirType::closure());
 
     // Calling builtins with names or ... is not supported by callBuiltin,
     // that's why those calls go through the normal call BC.
@@ -1104,7 +1104,7 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     assert(names_.size() == args.size());
     assert(fs);
     pushArg(fs, NativeType::frameState);
-    pushArg(fun, RType::closure);
+    pushArg(fun, PirType::closure());
 
     // Calling builtins with names or ... is not supported by callBuiltin,
     // that's why those calls go through the normal call BC.
@@ -1130,7 +1130,7 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     assert(names_.size() == args.size());
     assert(fs);
     pushArg(fs, NativeType::frameState);
-    pushArg(fun, RType::closure);
+    pushArg(fun, PirType::closure());
 
     // Calling builtins with names or ... is not supported by callBuiltin,
     // that's why those calls go through the normal call BC.
@@ -1157,7 +1157,7 @@ StaticCall::StaticCall(Value* callerEnv, Closure* cls, Context givenContext,
     assert(cls->nargs() >= args.size());
     assert(fs);
     pushArg(fs, NativeType::frameState);
-    pushArg(runtimeClosure, RType::closure);
+    pushArg(runtimeClosure, PirType::closure());
     for (unsigned i = 0; i < args.size(); ++i) {
         assert(!ExpandDots::Cast(args[i]) &&
                "Static Call cannot accept dynamic number of arguments");

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -63,7 +63,7 @@ std::string Instruction::getRef() const {
 }
 
 void Instruction::printRef(std::ostream& out) const {
-    if (type == RType::env)
+    if (type == PirType::env())
         out << "e" << id();
     else
         out << "%" << id();

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -741,7 +741,7 @@ void PirCopy::print(std::ostream& out, bool tty) const {
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
                                  unsigned srcIdx)
-    : VarLenInstruction(PirType::val().notMissing(), srcIdx),
+    : VarLenInstruction(PirType::val().notObject().notMissing(), srcIdx),
       builtinSexp(builtin), builtin(getBuiltin(builtin)),
       builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -741,7 +741,10 @@ void PirCopy::print(std::ostream& out, bool tty) const {
 
 CallSafeBuiltin::CallSafeBuiltin(SEXP builtin, const std::vector<Value*>& args,
                                  unsigned srcIdx)
-    : VarLenInstruction(PirType::val().notObject().notMissing(), srcIdx),
+    : VarLenInstruction(SafeBuiltinsList::returnsObj(getBuiltinNr(builtin))
+                            ? PirType::val().notMissing()
+                            : PirType::val().notMissing().notObject(),
+                        srcIdx),
       builtinSexp(builtin), builtin(getBuiltin(builtin)),
       builtinId(getBuiltinNr(builtin)) {
     for (unsigned i = 0; i < args.size(); ++i)

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1407,11 +1407,13 @@ class FLIE(Subassign1_1D, 4, Effects::Any()) {
     Value* idx() const { return arg(2).val(); }
 
     PirType inferType(const GetType& getType) const override final {
-        return ifNonObjectArgs(getType,
-                               type & (getType(vec())
-                                           .mergeWithConversion(getType(val()))
-                                           .orNotScalar()),
-                               type);
+        bool maybeStringIdx = getType(idx()).maybe(PirType() | RType::str);
+        auto restricted =
+            type &
+            (getType(vec()).mergeWithConversion(getType(val())).orNotScalar());
+        if (maybeStringIdx)
+            restricted = restricted.orNameAttrs();
+        return ifNonObjectArgs(getType, restricted, type);
     }
     Effects inferEffects(const GetType& getType) const override final {
         return ifNonObjectArgs(getType, effects & errorWarnVisible, effects);
@@ -1431,11 +1433,13 @@ class FLIE(Subassign2_1D, 4, Effects::Any()) {
     Value* idx() const { return arg(2).val(); }
 
     PirType inferType(const GetType& getType) const override final {
-        return ifNonObjectArgs(
-            getType,
-            type & (getType(vec()).mergeWithConversion(getType(val())))
-                       .orNotScalar(),
-            type);
+        bool maybeStringIdx = getType(idx()).maybe(PirType() | RType::str);
+        auto restricted =
+            type &
+            (getType(vec()).mergeWithConversion(getType(val())).orNotScalar());
+        if (maybeStringIdx)
+            restricted = restricted.orNameAttrs();
+        return ifNonObjectArgs(getType, restricted, type);
     }
     Effects inferEffects(const GetType& getType) const override final {
         return ifNonObjectArgs(getType, effects & errorWarnVisible, effects);
@@ -1457,11 +1461,14 @@ class FLIE(Subassign1_2D, 5, Effects::Any()) {
     Value* idx2() const { return arg(3).val(); }
 
     PirType inferType(const GetType& getType) const override final {
-        return ifNonObjectArgs(getType,
-                               type & (getType(vec())
-                                           .mergeWithConversion(getType(val()))
-                                           .orNotScalar()),
-                               type);
+        bool maybeStringIdx = getType(idx1()).maybe(PirType() | RType::str) ||
+                              getType(idx2()).maybe(PirType() | RType::str);
+        auto restricted =
+            type &
+            (getType(vec()).mergeWithConversion(getType(val())).orNotScalar());
+        if (maybeStringIdx)
+            restricted = restricted.orNameAttrs();
+        return ifNonObjectArgs(getType, restricted, type);
     }
     Effects inferEffects(const GetType& getType) const override final {
         return ifNonObjectArgs(getType, effects & errorWarnVisible, effects);
@@ -1483,11 +1490,14 @@ class FLIE(Subassign2_2D, 5, Effects::Any()) {
     Value* idx2() const { return arg(3).val(); }
 
     PirType inferType(const GetType& getType) const override final {
-        return ifNonObjectArgs(getType,
-                               type & (getType(vec())
-                                           .mergeWithConversion(getType(val()))
-                                           .orNotScalar()),
-                               type);
+        bool maybeStringIdx = getType(idx1()).maybe(PirType() | RType::str) ||
+                              getType(idx2()).maybe(PirType() | RType::str);
+        auto restricted =
+            type &
+            (getType(vec()).mergeWithConversion(getType(val())).orNotScalar());
+        if (maybeStringIdx)
+            restricted = restricted.orNameAttrs();
+        return ifNonObjectArgs(getType, restricted, type);
     }
     Effects inferEffects(const GetType& getType) const override final {
         return ifNonObjectArgs(getType, effects & errorWarnVisible, effects);
@@ -1510,11 +1520,15 @@ class FLIE(Subassign1_3D, 6, Effects::Any()) {
     Value* idx3() const { return arg(4).val(); }
 
     PirType inferType(const GetType& getType) const override final {
-        return ifNonObjectArgs(getType,
-                               type & (getType(vec())
-                                           .mergeWithConversion(getType(val()))
-                                           .orNotScalar()),
-                               type);
+        bool maybeStringIdx = getType(idx1()).maybe(PirType() | RType::str) ||
+                              getType(idx2()).maybe(PirType() | RType::str) ||
+                              getType(idx3()).maybe(PirType() | RType::str);
+        auto restricted =
+            type &
+            (getType(vec()).mergeWithConversion(getType(val())).orNotScalar());
+        if (maybeStringIdx)
+            restricted = restricted.orNameAttrs();
+        return ifNonObjectArgs(getType, restricted, type);
     }
     Effects inferEffects(const GetType& getType) const override final {
         return ifNonObjectArgs(getType, effects & errorWarnVisible, effects);

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -399,7 +399,7 @@ class Instruction : public Value {
             if (t.isSimpleScalar())
                 res = res.simpleScalar();
             if (!t.maybeNAOrNaN())
-                t = res.notNAOrNaN();
+                res = res.notNAOrNaN();
             return type & res;
         }
         return type;

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -124,7 +124,7 @@ class Tombstone : public Value {
             assert(false);
     }
     static Tombstone* closure() {
-        static Tombstone cls(RType::closure);
+        static Tombstone cls(PirType::closure());
         return &cls;
     }
     static Tombstone* framestate() {

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -172,7 +172,8 @@ void PirType::merge(const ObservedValues& other) {
         flags_.set(TypeFlags::maybeAttrib);
     if (!other.scalar)
         flags_.set(TypeFlags::maybeNotScalar);
-    flags_.set(TypeFlags::maybeNAOrNaN);
+    if (other.numTypes)
+        flags_.set(TypeFlags::maybeNAOrNaN);
     for (size_t i = 0; i < other.numTypes; ++i)
         merge(other.seen[i]);
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -172,8 +172,8 @@ void PirType::merge(const ObservedValues& other) {
         flags_.set(TypeFlags::maybeAttrib);
     if (!other.scalar)
         flags_.set(TypeFlags::maybeNotScalar);
-    if (other.numTypes)
-        flags_.set(TypeFlags::maybeNAOrNaN);
+
+    flags_.set(TypeFlags::maybeNAOrNaN);
     for (size_t i = 0; i < other.numTypes; ++i)
         merge(other.seen[i]);
 

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -157,13 +157,11 @@ PirType::PirType(SEXP e) : flags_(topRTypeFlags()), t_(RTypeSet()) {
         assert(!Rf_isObject(e));
         flags_.reset(TypeFlags::maybeAttrib);
     }
+    if (Rf_xlength(e) == 1)
+        flags_.reset(TypeFlags::maybeNotScalar);
 
-    if (PirType::vecs().isSuper(*this)) {
-        if (Rf_length(e) == 1)
-            flags_.reset(TypeFlags::maybeNotScalar);
-        if (!maybeContainsNAOrNaN(e))
-            flags_.reset(TypeFlags::maybeNAOrNaN);
-    }
+    if (!maybeContainsNAOrNaN(e))
+        flags_.reset(TypeFlags::maybeNAOrNaN);
 }
 
 PirType::PirType(uint64_t i) : PirType() {

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -170,7 +170,7 @@ void PirType::merge(const ObservedValues& other) {
         flags_.set(TypeFlags::maybeObject);
     if (other.attribs)
         flags_.set(TypeFlags::maybeAttrib);
-    if (!other.scalar)
+    if (other.notScalar)
         flags_.set(TypeFlags::maybeNotScalar);
 
     flags_.set(TypeFlags::maybeNAOrNaN);

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -152,9 +152,8 @@ PirType::PirType(SEXP e) : flags_(topRTypeFlags()), t_(RTypeSet()) {
         flags_.reset(TypeFlags::maybeObject);
     if (fastVeceltOk(e))
         flags_.reset(TypeFlags::maybeNotFastVecelt);
-    if (ATTRIB(e) == R_NilValue) {
+    if (ATTRIB(e) == R_NilValue && !Rf_isObject(e)) {
         assert(fastVeceltOk(e));
-        assert(!Rf_isObject(e));
         flags_.reset(TypeFlags::maybeAttrib);
     }
     if (Rf_xlength(e) == 1)

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -215,6 +215,11 @@ struct PirType {
         return res;
     }
 
+    constexpr PirType orSexpTypes(const PirType& other) const {
+        assert(isRType() && other.isRType());
+        return PirType(t_.r | other.t_.r, flags_);
+    }
+
     void merge(const ObservedValues& other);
     void merge(SEXPTYPE t);
 
@@ -235,6 +240,7 @@ struct PirType {
                        RType::closure | RType::prom | RType::code | RType::env |
                        RType::missing | RType::unbound | RType::ast |
                        RType::dots | RType::other)
+            .orNAOrNaN()
             .orObject()
             .orAttribs();
     }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -489,6 +489,11 @@ struct PirType {
                                  TypeFlags::maybeObject);
     }
 
+    RIR_INLINE constexpr PirType orFastVecelt() const {
+        assert(isRType());
+        return orAttribsOrObj().orAttribsOrObj().fastVecelt();
+    }
+
     RIR_INLINE constexpr PirType fastVecelt() const {
         assert(isRType());
         return PirType(t_.r, flags_ & ~(FlagSet() | TypeFlags::maybeObject |

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -489,6 +489,12 @@ struct PirType {
                                  TypeFlags::maybeObject);
     }
 
+    RIR_INLINE constexpr PirType orNameAttrs() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ | TypeFlags::maybeAttrib |
+                                 TypeFlags::maybeNotFastVecelt);
+    }
+
     RIR_INLINE constexpr PirType orFastVecelt() const {
         assert(isRType());
         return orAttribsOrObj().orAttribsOrObj().fastVecelt();

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -485,6 +485,12 @@ struct PirType {
                                  TypeFlags::maybeObject);
     }
 
+    RIR_INLINE constexpr PirType fastVecelt() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ & ~(FlagSet() | TypeFlags::maybeObject |
+                                        TypeFlags::maybeNotFastVecelt));
+    }
+
     PirType constexpr notPromiseWrapped() const {
         return PirType(t_.r, flags_ & ~(FlagSet() | TypeFlags::lazy |
                                         TypeFlags::promiseWrapped));
@@ -774,13 +780,15 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
         out << "^";
     else if (t.maybePromiseWrapped())
         out << "~";
-    if (t.maybeHasAttrs()) {
-        if (!t.maybeNotFastVecelt())
+    if (!t.maybeHasAttrs()) {
+        out << "⁻";
+    } else {
+        if (!t.maybeNotFastVecelt()) {
+            assert(!t.maybeObj());
             out << "ⁿ";
-        else if (!t.maybeObj())
-            out << "−";
-        else
-            out << "ₐ";
+        }
+        if (t.maybeObj())
+            out << "⁰";
     }
 
     return out;

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -92,9 +92,12 @@ enum class TypeFlags : uint8_t {
 
     lazy,
     promiseWrapped,
+
     maybeNotScalar,
     maybeObject,
+    maybeNotFastVecelt,
     maybeAttrib,
+
     maybeNAOrNaN,
     rtype,
 
@@ -139,9 +142,9 @@ struct PirType {
 
     static constexpr FlagSet topRTypeFlags() {
         return FlagSet() | TypeFlags::lazy | TypeFlags::promiseWrapped |
-               TypeFlags::maybeObject | TypeFlags::maybeAttrib |
-               TypeFlags::maybeNotScalar | TypeFlags::maybeNAOrNaN |
-               TypeFlags::rtype;
+               TypeFlags::maybeObject | TypeFlags::maybeNotFastVecelt |
+               TypeFlags::maybeAttrib | TypeFlags::maybeNotScalar |
+               TypeFlags::maybeNAOrNaN | TypeFlags::rtype;
     }
     static constexpr FlagSet optimisticRTypeFlags() {
         return FlagSet() | TypeFlags::rtype;
@@ -241,8 +244,7 @@ struct PirType {
                        RType::missing | RType::unbound | RType::ast |
                        RType::dots | RType::other)
             .orNAOrNaN()
-            .orObject()
-            .orAttribs();
+            .orAttribsOrObj();
     }
     static constexpr PirType vecs() {
         return num() | RType::str | RType::raw | RType::vec |
@@ -318,8 +320,9 @@ struct PirType {
         return flags_.includes(TypeFlags::maybeNAOrNaN);
     }
     RIR_INLINE constexpr bool isSimpleScalar() const {
-        return isScalar() && !maybeHasAttrs() && !maybeObj();
+        return isScalar() && !maybeHasAttrs();
     }
+
     RIR_INLINE constexpr bool isScalar() const {
         if (!isRType())
             return true;
@@ -342,13 +345,26 @@ struct PirType {
         if (!isRType())
             return false;
         auto res = flags_.includes(TypeFlags::maybeObject);
-        assert(!res || maybeHasAttrs());
+        assert(!res || (flags_.includes(TypeFlags::maybeAttrib) &&
+                        flags_.includes(TypeFlags::maybeNotFastVecelt)));
         return res;
     }
+
+    RIR_INLINE constexpr bool maybeNotFastVecelt() const {
+        if (!isRType())
+            return false;
+        auto res = flags_.includes(TypeFlags::maybeNotFastVecelt);
+        assert(!res || flags_.includes(TypeFlags::maybeAttrib));
+        return res;
+    }
+
     RIR_INLINE constexpr bool maybeHasAttrs() const {
         if (!isRType())
             return false;
-        return flags_.includes(TypeFlags::maybeAttrib);
+        auto res = flags_.includes(TypeFlags::maybeAttrib);
+        assert(res || (!flags_.includes(TypeFlags::maybeNotFastVecelt) &&
+                       !flags_.includes(TypeFlags::maybeObject)));
+        return res;
     }
 
     RIR_INLINE constexpr PirType operator|(const PirType& o) const {
@@ -389,10 +405,12 @@ struct PirType {
         return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::maybeObject));
     }
 
-    PirType constexpr noAttribs() const {
+    PirType constexpr noAttribsOrObject() const {
         assert(isRType());
-        return PirType(t_.r, flags_ & ~(FlagSet() | TypeFlags::maybeAttrib |
-                                        TypeFlags::maybeObject));
+        return PirType(t_.r,
+                       flags_ & ~(FlagSet() | TypeFlags::maybeNotFastVecelt |
+                                  TypeFlags::maybeAttrib))
+            .notObject();
     }
 
     PirType constexpr notMissing() const {
@@ -411,7 +429,7 @@ struct PirType {
     }
 
     RIR_INLINE constexpr PirType simpleScalar() const {
-        return scalar().noAttribs().notObject();
+        return scalar().noAttribsOrObject();
     }
 
     RIR_INLINE constexpr PirType notT(RType t) const {
@@ -448,12 +466,21 @@ struct PirType {
     RIR_INLINE constexpr PirType orObject() const {
         assert(isRType());
         return PirType(t_.r, flags_ | TypeFlags::maybeObject |
+                                 TypeFlags::maybeAttrib |
+                                 TypeFlags::maybeNotFastVecelt);
+    }
+
+    RIR_INLINE constexpr PirType orNotFastVecelt() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ | TypeFlags::maybeNotFastVecelt |
                                  TypeFlags::maybeAttrib);
     }
 
-    RIR_INLINE constexpr PirType orAttribs() const {
+    RIR_INLINE constexpr PirType orAttribsOrObj() const {
         assert(isRType());
-        return PirType(t_.r, flags_ | TypeFlags::maybeAttrib);
+        return PirType(t_.r, flags_ | TypeFlags::maybeAttrib |
+                                 TypeFlags::maybeNotFastVecelt |
+                                 TypeFlags::maybeObject);
     }
 
     PirType constexpr notPromiseWrapped() const {
@@ -484,47 +511,49 @@ struct PirType {
     // Type of <this>[<idx>] or <this>[<idx>, <idx>]
     PirType subsetType(PirType idx) const {
         assert(isRType());
-        if (isA(PirType(RType::nil).orAttribs())) {
+        if (isA(PirType(RType::nil).orAttribsOrObj())) {
             // NULL
             return RType::nil;
         }
-        if (isA((num() | RType::str | RType::list | RType::code).orAttribs())) {
+        if (isA((num() | RType::str | RType::list | RType::code)
+                    .orAttribsOrObj())) {
             // If the index is out of bounds, NA is returned (even if both args
             // are non-NA) so we must add orNAOrNaN()
             if (idx.isA(PirType(RType::str).scalar()))
-                return scalar().orAttribs().orNAOrNaN();
+                return scalar().orAttribsOrObj().orNAOrNaN();
             // e.g. c(1,2,3)[-1] returns c(2,3)
             return orNotScalar().orNAOrNaN();
         } else if (isA(RType::vec)) {
             return PirType(RType::vec);
-        } else if (isA(PirType(RType::vec).orAttribs())) {
-            return PirType(RType::vec).orAttribs();
-        } else if (!maybeHasAttrs() && !PirType(RType::prom).isA(*this)) {
+        } else if (isA(PirType(RType::vec).orAttribsOrObj())) {
+            return PirType(RType::vec).orAttribsOrObj();
+        } else if (!maybeNotFastVecelt() && !PirType(RType::prom).isA(*this)) {
             // Something else
             return val().notMissing();
         } else {
             // Possible object
-            return valOrLazy();
+            return val();
         }
     }
 
     // Type of <this>[[<idx>]] or <this>[[<idx>, <idx>]]
     PirType extractType(PirType idx) const {
         assert(isRType());
-        if (isA(PirType(RType::nil).orAttribs())) {
+        if (isA(PirType(RType::nil).orAttribsOrObj())) {
             // NULL
             return RType::nil;
         }
-        if (isA((num() | RType::str | RType::list | RType::code).orAttribs())) {
-            return scalar();
-        } else if (isA(PirType(RType::vec).orAttribs())) {
+        if (isA((num() | RType::str | RType::list | RType::code)
+                    .orAttribsOrObj())) {
+            return simpleScalar();
+        } else if (isA(PirType(RType::vec))) {
             return val().notMissing();
-        } else if (!maybeObj() && !PirType(RType::prom).isA(*this)) {
+        } else if (!maybeNotFastVecelt() && !PirType(RType::prom).isA(*this)) {
             // Something else
             return val().notMissing();
         } else {
             // Possible object
-            return valOrLazy();
+            return val();
         }
     }
 
@@ -548,19 +577,6 @@ struct PirType {
         } else {
             return forced().notObject().orNotScalar().orNAOrNaN() | RType::vec;
         }
-    }
-
-    RIR_INLINE void setNotScalar() { *this = orNotScalar(); }
-    RIR_INLINE void setNotMissing() { *this = notMissing(); }
-    RIR_INLINE void setNotObject() { *this = notObject(); }
-    RIR_INLINE void setNoAttribs() { *this = noAttribs(); }
-    RIR_INLINE void setNotNAOrNaN() { *this = notNAOrNaN(); }
-    RIR_INLINE void setMaybeNAOrNaN() { *this = orNAOrNaN(); }
-    RIR_INLINE void setScalar() { *this = scalar(); }
-
-    RIR_INLINE void setScalar(RType rtype) {
-        setScalar();
-        t_.r = RTypeSet(rtype);
     }
 
     constexpr bool isVoid() const {
@@ -596,6 +612,7 @@ struct PirType {
         if ((!maybeLazy() && o.maybeLazy()) ||
             (!maybePromiseWrapped() && o.maybePromiseWrapped()) ||
             (!maybeObj() && o.maybeObj()) ||
+            (!maybeNotFastVecelt() && o.maybeNotFastVecelt()) ||
             (!maybeHasAttrs() && o.maybeHasAttrs()) ||
             (!maybeNAOrNaN() && o.maybeNAOrNaN()) ||
             (isScalar() && !o.isScalar())) {
@@ -755,10 +772,14 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
         out << "^";
     else if (t.maybePromiseWrapped())
         out << "~";
-    if (!t.maybeHasAttrs())
-        out << "\"";
-    else if (!t.maybeObj())
-        out << "'";
+    if (t.maybeHasAttrs()) {
+        if (!t.maybeNotFastVecelt())
+            out << "ⁿ";
+        else if (!t.maybeObj())
+            out << "−";
+        else
+            out << "ₐ";
+    }
 
     return out;
 }

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -254,6 +254,10 @@ struct PirType {
         return PirType(RType::closure).orAttribsOrObj();
     }
 
+    static constexpr PirType env() {
+        return PirType(RType::env).orAttribsOrObj();
+    }
+
     static constexpr PirType dotsArg() {
         return (PirType() | RType::missing | RType::dots).notPromiseWrapped();
     }
@@ -786,9 +790,9 @@ inline std::ostream& operator<<(std::ostream& out, PirType t) {
         if (!t.maybeNotFastVecelt()) {
             assert(!t.maybeObj());
             out << "ⁿ";
+        } else if (!t.maybeObj()) {
+            out << "⁺";
         }
-        if (t.maybeObj())
-            out << "⁰";
     }
 
     return out;

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -250,7 +250,9 @@ struct PirType {
         return num() | RType::str | RType::raw | RType::vec |
                RType::expressions;
     }
-    static constexpr PirType closure() { return RType::closure; }
+    static constexpr PirType closure() {
+        return PirType(RType::closure).orAttribsOrObj();
+    }
 
     static constexpr PirType dotsArg() {
         return (PirType() | RType::missing | RType::dots).notPromiseWrapped();

--- a/rir/src/compiler/rir2pir/insert_cast.cpp
+++ b/rir/src/compiler/rir2pir/insert_cast.cpp
@@ -9,7 +9,7 @@ pir::Instruction* InsertCast::cast(pir::Value* v, PirType t, Value* env) {
     if (v->type.maybePromiseWrapped() && !t.maybePromiseWrapped()) {
         return new pir::Force(v, env, Tombstone::framestate());
     }
-    if (!v->type.isA(RType::closure) && t == RType::closure) {
+    if (!v->type.isA(PirType::closure()) && t == PirType::closure()) {
         return new pir::ChkClosure(v);
     }
 

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -274,7 +274,7 @@ static Value* insertLdFunGuard(const TargetInfo& trg, Value* callee,
         // It is therefore safe (ie. conservative with respect to the
         // guard) to avoid forcing the result by casting it to a value.
         auto casted = new CastType(calleeForGuard, CastType::Downcast,
-                                   PirType::any(), RType::closure);
+                                   PirType::any(), PirType::closure());
         pos = bb->insert(pos, casted);
         pos++;
 

--- a/rir/src/compiler/test/PirTests.cpp
+++ b/rir/src/compiler/test/PirTests.cpp
@@ -849,12 +849,14 @@ bool testTypeRules() {
     assert(r.subsetType(PirType::any()).isA(RType::vec));
     assert(!r.subsetType(PirType::any()).maybeObj());
     assert(!r.orObject().subsetType(PirType::bottom()).isA(RType::vec));
-    assert(!r.orObject().subsetType(PirType::bottom()).isA(PirType::val()));
+    assert(!r.orObject()
+                .subsetType(PirType::bottom())
+                .isA(PirType::val().noAttribsOrObject()));
     assert(r.extractType(PirType::any()).isA(PirType::val()));
     assert(!r.extractType(PirType::bottom()).isScalar());
     assert(!r.extractType(PirType::bottom()).maybeMissing());
     assert(!r.extractType(PirType::bottom()).isA(RType::vec));
-    assert(r.orObject().extractType(PirType::bottom()).maybeMissing());
+    assert(r.orObject().extractType(PirType::simpleScalarInt()).maybeMissing());
     assert(r2.subsetType(RType::real).isA(RType::logical));
     assert(!r2.subsetType(RType::integer).isScalar());
     assert(!r2.scalar().subsetType(RType::integer).isScalar());
@@ -869,11 +871,11 @@ bool testTypeRules() {
     auto a = (PirType() | RType::real | RType::integer)
                  .notPromiseWrapped()
                  .notObject()
-                 .noAttribs();
+                 .noAttribsOrObject();
     auto b = (PirType() | RType::integer)
                  .notPromiseWrapped()
                  .notObject()
-                 .noAttribs();
+                 .noAttribsOrObject();
     assert(a.mergeWithConversion(b) == a);
     assert(b.mergeWithConversion(a) == a);
     t = PirType::bottom();
@@ -884,7 +886,7 @@ bool testTypeRules() {
     assert(t == a);
     t = PirType::any() & t;
     assert(t == a);
-    auto real = PirType(RType::real).orAttribs().notObject();
+    auto real = PirType(RType::real).orAttribsOrObj().notObject();
     auto realScalar = PirType::simpleScalarReal();
     assert(real.maybeHasAttrs());
     assert(!realScalar.maybeHasAttrs());

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -77,6 +77,7 @@ bool SafeBuiltinsList::always(int builtin) {
 
         blt("which"),
 
+        blt("cat"),
         blt("stdout"),
         blt("stderr"),
         blt("("),
@@ -312,7 +313,6 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         blt("cumsum"),
         blt("colSums"),
 
-        blt("cat"),
         blt("paste"),
         blt("nchar"),
         blt("pmatch"),

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -97,6 +97,18 @@ bool SafeBuiltinsList::always(SEXP builtin) {
     return always(getBuiltinNr(builtin));
 }
 
+bool SafeBuiltinsList::returnsObj(int builtin) {
+    static int safeBuiltins[] = {
+        blt("stdout"),
+        blt("stderr"),
+    };
+
+    for (auto i : safeBuiltins)
+        if (i == builtin)
+            return true;
+    return false;
+}
+
 bool SafeBuiltinsList::nonObject(int builtin) {
     if (always(builtin))
         return true;

--- a/rir/src/compiler/util/safe_builtins_list.h
+++ b/rir/src/compiler/util/safe_builtins_list.h
@@ -13,6 +13,7 @@ class SafeBuiltinsList {
     static bool nonObject(SEXP builtin);
     static bool nonObjectIdempotent(SEXP builtin);
     static bool always(int builtin);
+    static bool returnsObj(int builtin);
     static bool idempotent(int builtin);
     static bool nonObject(int builtin);
     static bool nonObjectIdempotent(int builtin);

--- a/rir/src/interpreter/builtins.cpp
+++ b/rir/src/interpreter/builtins.cpp
@@ -157,8 +157,6 @@ SEXP tryFastSpecialCall(const CallContext& call, InterpreterInstance* ctx) {
                     evaluatePromise(p);
                 else if (p == R_MissingArg)
                     errorcall(innerCall.ast, ("argument %d is empty"), i);
-                else
-                    Rf_error("something weird happened");
             }
         } else if (TYPEOF(fun) != SPECIALSXP) {
             Rf_error("attempt to apply non-function");

--- a/rir/src/ir/BC.cpp
+++ b/rir/src/ir/BC.cpp
@@ -336,32 +336,6 @@ void BC::print(std::ostream& out) const {
         bc != Opcode::record_test_)
         printOpcode(out);
 
-    auto printTypeFeedback = [&](const ObservedValues& prof) {
-        if (prof.numTypes) {
-            for (size_t i = 0; i < prof.numTypes; ++i) {
-                auto t = prof.seen[i];
-                out << Rf_type2char(t.sexptype) << "(" << (t.object ? "o" : "")
-                    << (t.attribs ? "a" : "") << (t.scalar ? "s" : "") << ")";
-                if (i != (unsigned)prof.numTypes - 1)
-                    out << ", ";
-            }
-            if (prof.stateBeforeLastForce !=
-                ObservedValues::StateBeforeLastForce::unknown) {
-                out << " | "
-                    << ((prof.stateBeforeLastForce ==
-                         ObservedValues::StateBeforeLastForce::value)
-                            ? "value"
-                            : (prof.stateBeforeLastForce ==
-                               ObservedValues::StateBeforeLastForce::
-                                   evaluatedPromise)
-                                  ? "evaluatedPromise"
-                                  : "promise");
-            }
-        } else {
-            out << "<?>";
-        }
-    };
-
     switch (bc) {
     case Opcode::invalid_:
     case Opcode::num_of:
@@ -468,7 +442,7 @@ void BC::print(std::ostream& out) const {
 
     case Opcode::record_type_: {
         out << "[ ";
-        printTypeFeedback(immediate.typeFeedback);
+        immediate.typeFeedback.print(out);
         out << " ]";
         break;
     }

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -91,7 +91,7 @@ struct ObservedValues {
 
     ObservedValues()
         : numTypes(0), stateBeforeLastForce(StateBeforeLastForce::unknown),
-          unused(0) {}
+          scalar(1), object(0), attribs(0), unused(0) {}
 
     void reset() { *this = ObservedValues(); }
 

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -124,7 +124,7 @@ struct ObservedValues {
     RIR_INLINE void record(SEXP e) {
         scalar = scalar && IS_SIMPLE_SCALAR(e, TYPEOF(e));
         object = object || isObject(e);
-        attribs = attribs || !fastVeceltOk(e);
+        attribs = attribs || ATTRIB(e) != R_NilValue;
 
         uint8_t type = TYPEOF(e);
         if (numTypes < MaxTypes) {

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -11,10 +11,6 @@ namespace rir {
 
 struct Code;
 
-// For non-scalars, it takes too long to determine whether they
-// contain NaN for the benefit, so we simple assume they do
-static const R_xlen_t MAX_SIZE_OF_VECTOR_FOR_NAN_CHECK = 1;
-
 #pragma pack(push)
 #pragma pack(1)
 
@@ -37,44 +33,14 @@ struct ObservedCallees {
 
     std::array<unsigned, MaxTargets> targets;
 };
+static_assert(sizeof(ObservedCallees) == 4 * sizeof(uint32_t),
+              "Size needs to fit inside a record_ bc immediate args");
 
 inline bool fastVeceltOk(SEXP vec) {
     return !isObject(vec) &&
            (ATTRIB(vec) == R_NilValue || (TAG(ATTRIB(vec)) == R_DimSymbol &&
                                           CDR(ATTRIB(vec)) == R_NilValue));
 }
-
-struct ObservedType {
-    uint8_t sexptype : 5;
-    uint8_t scalar : 1;
-    uint8_t object : 1;
-    uint8_t attribs : 1;
-
-    ObservedType() {}
-    explicit ObservedType(SEXP s)
-        : sexptype((uint8_t)TYPEOF(s)), scalar(IS_SIMPLE_SCALAR(s, TYPEOF(s))),
-          object(isObject(s)), attribs(object || !fastVeceltOk(s)) {
-        assert(!object || attribs);
-    }
-
-    bool operator==(const ObservedType& other) {
-        return memcmp(this, &other, sizeof(ObservedType)) == 0;
-    }
-
-    ObservedType operator|(const ObservedType& other) {
-        assert(sexptype == other.sexptype);
-        ObservedType t;
-        t.sexptype = sexptype;
-        t.scalar = scalar && other.scalar;
-        t.object = object || other.object;
-        t.attribs = attribs || other.attribs;
-        return t;
-    }
-
-    bool isObj() const { return object; }
-};
-static_assert(sizeof(ObservedCallees) == 4 * sizeof(uint32_t),
-              "Size needs to fit inside a record_ bc immediate args");
 
 struct ObservedTest {
     enum { None, OnlyTrue, OnlyFalse, Both };
@@ -116,9 +82,12 @@ struct ObservedValues {
     static constexpr unsigned MaxTypes = 3;
     uint8_t numTypes : 2;
     uint8_t stateBeforeLastForce : 2;
-    uint8_t unused : 4;
+    uint8_t scalar : 1;
+    uint8_t object : 1;
+    uint8_t attribs : 1;
+    uint8_t unused : 1;
 
-    std::array<ObservedType, MaxTypes> seen;
+    std::array<uint8_t, MaxTypes> seen;
 
     ObservedValues()
         : numTypes(0), stateBeforeLastForce(StateBeforeLastForce::unknown),
@@ -129,12 +98,12 @@ struct ObservedValues {
     void print(std::ostream& out) const {
         if (numTypes) {
             for (size_t i = 0; i < numTypes; ++i) {
-                auto t = seen[i];
-                out << Rf_type2char(t.sexptype) << "(" << (t.object ? "o" : "")
-                    << (t.attribs ? "a" : "") << (t.scalar ? "s" : "") << ")";
+                out << Rf_type2char(seen[i]);
                 if (i != (unsigned)numTypes - 1)
                     out << ", ";
             }
+            out << " (" << (object ? "o" : "") << (attribs ? "a" : "")
+                << (scalar ? "s" : "") << ")";
             if (stateBeforeLastForce !=
                 ObservedValues::StateBeforeLastForce::unknown) {
                 out << " | "
@@ -153,16 +122,16 @@ struct ObservedValues {
     };
 
     RIR_INLINE void record(SEXP e) {
-        ObservedType type(e);
+        scalar = scalar && IS_SIMPLE_SCALAR(e, TYPEOF(e));
+        object = object || isObject(e);
+        attribs = attribs || !fastVeceltOk(e);
+
+        uint8_t type = TYPEOF(e);
         if (numTypes < MaxTypes) {
             int i = 0;
             for (; i < numTypes; ++i) {
                 if (seen[i] == type)
                     break;
-                if (seen[i].sexptype == type.sexptype) {
-                    seen[i] = seen[i] | type;
-                    return;
-                }
             }
             if (i == numTypes)
                 seen[numTypes++] = type;

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -83,9 +83,9 @@ struct ObservedValues {
     uint8_t numTypes : 2;
     uint8_t stateBeforeLastForce : 2;
     uint8_t notScalar : 1;
-    uint8_t object : 1;
     uint8_t attribs : 1;
-    uint8_t unused : 1;
+    uint8_t object : 1;
+    uint8_t notFastVecelt : 1;
 
     std::array<uint8_t, MaxTypes> seen;
 
@@ -104,7 +104,7 @@ struct ObservedValues {
                     out << ", ";
             }
             out << " (" << (object ? "o" : "") << (attribs ? "a" : "")
-                << (!notScalar ? "s" : "") << ")";
+                << (notFastVecelt ? "v" : "") << (!notScalar ? "s" : "") << ")";
             if (stateBeforeLastForce !=
                 ObservedValues::StateBeforeLastForce::unknown) {
                 out << " | "
@@ -123,9 +123,10 @@ struct ObservedValues {
     };
 
     RIR_INLINE void record(SEXP e) {
-        notScalar = notScalar || !IS_SIMPLE_SCALAR(e, TYPEOF(e));
+        notScalar = notScalar || XLENGTH(e) != 1;
         object = object || isObject(e);
         attribs = attribs || ATTRIB(e) != R_NilValue;
+        notFastVecelt = notFastVecelt || !fastVeceltOk(e);
 
         uint8_t type = TYPEOF(e);
         if (numTypes < MaxTypes) {


### PR DESCRIPTION
Previously our type feedback mechanism would record
(attribute,object,scalar) flags for each type individually. When the
number of types overflows this leaves no other option than to assume
these are tainted. To improve precision we move the flags out of the
individual types, such that even if the SEXPTYPES overflow, we still
keep track precisely of the attributes.

pair-programmed with @skrynski