### PR TITLE
only count non-deopt instructions, without closures, for inlining

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,8 +239,8 @@ test_big_inline:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
     GIT_STRATEGY: none
-    PIR_MAX_INPUT_SIZE: 10000
-    PIR_INLINER_MAX_SIZE: 10000
+    PIR_MAX_INPUT_SIZE: 5000
+    PIR_INLINER_MAX_SIZE: 5000
     PIR_LLVM_OPT_LEVEL: 0
   stage: Run tests
   needs:

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -349,7 +349,7 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
             if (depth == MAX_DEPTH)
                 return;
 
-            if (version->size() > MAX_SIZE)
+            if (version->numNonDeoptInstrs() > MAX_SIZE)
                 return;
 
             std::vector<Value*> args;

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -109,7 +109,7 @@ class ScopeAnalysis
     const std::vector<Value*> args;
 
     static constexpr size_t MAX_DEPTH = 2;
-    static constexpr size_t MAX_SIZE = 200;
+    static constexpr size_t MAX_SIZE = 140;
     static constexpr size_t MAX_RESULTS = 800;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -109,8 +109,8 @@ class ScopeAnalysis
     const std::vector<Value*> args;
 
     static constexpr size_t MAX_DEPTH = 2;
-    static constexpr size_t MAX_SIZE = 250;
-    static constexpr size_t MAX_RESULTS = 1000;
+    static constexpr size_t MAX_SIZE = 200;
+    static constexpr size_t MAX_RESULTS = 800;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();
     bool inPromise = false;

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -74,7 +74,8 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
     std::unordered_map<Force*, ForcedBy::PromiseInlineable> toInline;
     SmallMap<Force*, Instruction*> dominatedBy;
 
-    bool isHuge = code->size() > Parameter::PROMISE_INLINER_MAX_SIZE;
+    bool isHuge =
+        cls->numNonDeoptInstrs() > Parameter::PROMISE_INLINER_MAX_SIZE;
     {
         ForceDominanceAnalysis analysis(cls, code, log);
 
@@ -131,7 +132,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                         f->strict = true;
                         if (auto mk = MkArg::Cast(f->followCastsAndForce())) {
                             if (!mk->isEager()) {
-                                if (!isHuge || mk->prom()->size() < 10) {
+                                if (!isHuge || mk->prom()->numInstrs() < 10) {
                                     // We need to know if the promise escaped
                                     // before the force. After the force the
                                     // analysis deletes escape information.
@@ -441,6 +442,6 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
 size_t Parameter::PROMISE_INLINER_MAX_SIZE =
     getenv("PIR_PROMISE_INLINER_MAX_SIZE")
         ? atoi(getenv("PIR_PROMISE_INLINER_MAX_SIZE"))
-        : 3000;
+        : 1800;
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -472,11 +472,11 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
     size_t Parameter::INLINER_MAX_INLINEE_SIZE =
         getenv("PIR_INLINER_MAX_INLINEE_SIZE")
             ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-            : 100;
+            : 90;
     size_t Parameter::INLINER_INITIAL_FUEL =
         getenv("PIR_INLINER_INITIAL_FUEL")
             ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
-            : 10;
+            : 15;
     size_t Parameter::INLINER_INLINE_UNLIKELY =
         getenv("PIR_INLINER_INLINE_UNLIKELY")
             ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -207,7 +207,9 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
                     continue;
                 } else if (weight > Parameter::INLINER_MAX_INLINEE_SIZE) {
                     if (!inlineeCls->rirFunction()->flags.contains(
-                            rir::Function::ForceInline))
+                            rir::Function::ForceInline) &&
+                        inlinee->numNonDeoptInstrs() >
+                            Parameter::INLINER_MAX_INLINEE_SIZE * 4)
                         inlineeCls->rirFunction()->flags.set(
                             rir::Function::NotInlineable);
                     continue;
@@ -470,11 +472,11 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
     size_t Parameter::INLINER_MAX_INLINEE_SIZE =
         getenv("PIR_INLINER_MAX_INLINEE_SIZE")
             ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-            : 80;
+            : 100;
     size_t Parameter::INLINER_INITIAL_FUEL =
         getenv("PIR_INLINER_INITIAL_FUEL")
             ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
-            : 15;
+            : 10;
     size_t Parameter::INLINER_INLINE_UNLIKELY =
         getenv("PIR_INLINER_INLINE_UNLIKELY")
             ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -23,7 +23,7 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
     bool anyChange = false;
     size_t fuel = Parameter::INLINER_INITIAL_FUEL;
 
-    if (cls->size() > Parameter::INLINER_MAX_SIZE)
+    if (cls->numNonDeoptInstrs() > Parameter::INLINER_MAX_SIZE)
         return false;
 
     auto dontInline = [](Closure* cls) {
@@ -159,7 +159,7 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
                     });
                 };
 
-                size_t weight = inlinee->size();
+                size_t weight = inlinee->numNonDeoptInstrs();
                 // The taken information of the call instruction tells us how
                 // many times a call was executed relative to function
                 // invocation. 0 means never, 1 means on every call, above 1
@@ -171,14 +171,14 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
                         // stays unchanged. Below it's increased and above it
                         // is decreased, but not more than 4x
                         double adjust = 1.25 * c->taken;
-                        if (adjust > 3)
-                            adjust = 3;
-                        if (adjust < 0.25)
-                            adjust = 0.25;
+                        if (adjust > 4)
+                            adjust = 4;
+                        if (adjust < 0.2)
+                            adjust = 0.2;
                         weight = (double)weight / adjust;
                         // Inline only small methods if we are getting close to
                         // the limit.
-                        auto limit = (double)inlinee->size() /
+                        auto limit = (double)inlinee->numNonDeoptInstrs() /
                                      (double)Parameter::INLINER_MAX_SIZE;
                         limit = (limit * 4) + 1;
                         weight *= limit;
@@ -464,21 +464,21 @@ bool Inline::apply(Compiler&, ClosureVersion* cls, Code* code,
 
 // TODO: maybe implement something more resonable to pass in those constants.
 // For now it seems a simple env variable is just fine.
-size_t Parameter::INLINER_MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
-                                         ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
-                                         : 4000;
-size_t Parameter::INLINER_MAX_INLINEE_SIZE =
-    getenv("PIR_INLINER_MAX_INLINEE_SIZE")
-        ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-        : 200;
-size_t Parameter::INLINER_INITIAL_FUEL =
-    getenv("PIR_INLINER_INITIAL_FUEL")
-        ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
-        : 15;
-size_t Parameter::INLINER_INLINE_UNLIKELY =
-    getenv("PIR_INLINER_INLINE_UNLIKELY")
-        ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))
-        : 0;
+    size_t Parameter::INLINER_MAX_SIZE =
+        getenv("PIR_INLINER_MAX_SIZE") ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
+                                       : 2500;
+    size_t Parameter::INLINER_MAX_INLINEE_SIZE =
+        getenv("PIR_INLINER_MAX_INLINEE_SIZE")
+            ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
+            : 80;
+    size_t Parameter::INLINER_INITIAL_FUEL =
+        getenv("PIR_INLINER_INITIAL_FUEL")
+            ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
+            : 15;
+    size_t Parameter::INLINER_INLINE_UNLIKELY =
+        getenv("PIR_INLINER_INLINE_UNLIKELY")
+            ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))
+            : 0;
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/pir/closure_version.cpp
+++ b/rir/src/compiler/pir/closure_version.cpp
@@ -106,10 +106,10 @@ void ClosureVersion::erasePromise(unsigned id) {
     promises_[id] = nullptr;
 }
 
-size_t ClosureVersion::size() const {
+size_t ClosureVersion::numNonDeoptInstrs() const {
     size_t s = 0;
-    eachPromise([&s](Promise* p) { s += p->size(); });
-    return s + Code::size();
+    VisitorNoDeoptBranch::run(entry, [&](BB* bb) { s += bb->size(); });
+    return s;
 }
 
 size_t ClosureVersion::nargs() const { return owner_->nargs(); }

--- a/rir/src/compiler/pir/closure_version.h
+++ b/rir/src/compiler/pir/closure_version.h
@@ -92,7 +92,7 @@ class ClosureVersion
                 it(p);
     }
 
-    size_t size() const override final;
+    size_t numNonDeoptInstrs() const;
 
     rir::Code* rirSrc() const override final;
 

--- a/rir/src/compiler/pir/code.cpp
+++ b/rir/src/compiler/pir/code.cpp
@@ -46,7 +46,7 @@ Code::~Code() {
     }
 }
 
-size_t Code::size() const {
+size_t Code::numInstrs() const {
     size_t s = 0;
     Visitor::run(entry, [&](BB* bb) { s += bb->size(); });
     return s;

--- a/rir/src/compiler/pir/code.h
+++ b/rir/src/compiler/pir/code.h
@@ -37,7 +37,7 @@ class Code {
     void printBBGraphCode(std::ostream&, bool omitDeoptBranches) const;
     virtual ~Code();
 
-    virtual size_t size() const;
+    size_t numInstrs() const;
 
     virtual rir::Code* rirSrc() const = 0;
 };


### PR DESCRIPTION
heuristics