### PR TITLE
Make measuring timers independent

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -51,14 +51,14 @@ completely disables the PIR optimizer. As follows are the different Options avai
         GraphViz   print pir in GraphViz, displaying all instructions within BBs
         GraphVizBB print pir in GraphViz, displaying only BB names and connections
 
-    PIR_MEASURING=
-        1          enable event and time measuring
-
     PIR_MEASURING_LOGFILE=
         filename   write the output to filename instead of std::cerr
 
     PIR_MEASURE_COMPILER=
-        1          print overal time spend in different passes on shutdown
+        1          print overall time spend in different passes on shutdown
+
+    PIR_MEASURE_COMPILER_BACKEND=
+        1          print overall time spend in different phases in the backend
 
     RIR_CHECK_PIR_TYPES=
         0        Disable

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -278,7 +278,6 @@ static void toCSSA(Code* code) {
     });
 }
 
-// Don't forget to pass PIR_MEASURING=1 too
 bool MEASURE_COMPILER_BACKEND_PERF =
     getenv("PIR_MEASURE_COMPILER_BACKEND") ? true : false;
 
@@ -289,7 +288,7 @@ rir::Function* Backend::doCompile(ClosureVersion* cls,
     // + how to deal with inlined stuff?
 
     if (MEASURE_COMPILER_BACKEND_PERF)
-        Measuring::startTimer();
+        Measuring::startTimer("backend.cpp: lowering");
 
     FunctionWriter function;
 
@@ -337,8 +336,8 @@ rir::Function* Backend::doCompile(ClosureVersion* cls,
     lowerAndScanForPromises(cls);
 
     if (MEASURE_COMPILER_BACKEND_PERF) {
-        Measuring::countTimer("lowering");
-        Measuring::startTimer();
+        Measuring::countTimer("backend.cpp: lowering");
+        Measuring::startTimer("backend.cpp: pir2llvm");
     }
 
     std::unordered_map<Code*, rir::Code*> done;
@@ -369,8 +368,8 @@ rir::Function* Backend::doCompile(ClosureVersion* cls,
     auto body = compile(cls);
 
     if (MEASURE_COMPILER_BACKEND_PERF) {
-        Measuring::countTimer("pir2llvm");
-        Measuring::startTimer();
+        Measuring::countTimer("backend.cpp: pir2llvm");
+        Measuring::startTimer("backend.cpp: llvm");
     }
 
     log.finalPIR(cls);
@@ -382,7 +381,7 @@ rir::Function* Backend::doCompile(ClosureVersion* cls,
 
 Backend::LastDestructor::~LastDestructor() {
     if (MEASURE_COMPILER_BACKEND_PERF) {
-        Measuring::countTimer("llvm");
+        Measuring::countTimer("backend.cpp: llvm");
     }
 }
 

--- a/rir/src/compiler/compiler.cpp
+++ b/rir/src/compiler/compiler.cpp
@@ -206,7 +206,6 @@ void Compiler::compileClosure(Closure* closure, rir::Function* optFunction,
     return fail();
 }
 
-// Don't forget to pass PIR_MEASURING=1 too
 bool MEASURE_COMPILER_PERF = getenv("PIR_MEASURE_COMPILER") ? true : false;
 
 static void findUnreachable(Module* m) {
@@ -280,10 +279,10 @@ void Compiler::optimizeModule() {
         bool changed = false;
         if (translation->isSlow()) {
             if (MEASURE_COMPILER_PERF)
-                Measuring::startTimer();
+                Measuring::startTimer("compiler.cpp: module cleanup");
             findUnreachable(module);
             if (MEASURE_COMPILER_PERF)
-                Measuring::countTimer("module cleanup");
+                Measuring::countTimer("compiler.cpp: module cleanup");
         }
         module->eachPirClosure([&](Closure* c) {
             c->eachVersion([&](ClosureVersion* v) {
@@ -291,12 +290,14 @@ void Compiler::optimizeModule() {
                 log.pirOptimizationsHeader(translation);
 
                 if (MEASURE_COMPILER_PERF)
-                    Measuring::startTimer();
+                    Measuring::startTimer("compiler.cpp: " +
+                                          translation->getName());
 
                 if (translation->apply(*this, v, log.out()))
                     changed = true;
                 if (MEASURE_COMPILER_PERF)
-                    Measuring::countTimer(translation->getName());
+                    Measuring::countTimer("compiler.cpp: " +
+                                          translation->getName());
 
                 log.pirOptimizations(translation);
                 log.flush();
@@ -315,7 +316,7 @@ void Compiler::optimizeModule() {
         return changed;
     });
     if (MEASURE_COMPILER_PERF)
-        Measuring::startTimer();
+        Measuring::startTimer("compiler.cpp: verification");
 
     module->eachPirClosure([&](Closure* c) {
         c->eachVersion([&](ClosureVersion* v) {
@@ -331,7 +332,7 @@ void Compiler::optimizeModule() {
     });
 
     if (MEASURE_COMPILER_PERF)
-        Measuring::countTimer("Verification");
+        Measuring::countTimer("compiler.cpp: verification");
 
     logger.flush();
 }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1079,11 +1079,8 @@ class SlowcaseCounter {
   public:
     static void count(const std::string& kind, CallContext& call,
                       InterpreterInstance* ctx) {
-        static bool init = false;
-        if (!init) {
-            Measuring::setEventThreshold(100);
-            init = true;
-        }
+        // setting every time not needed but simple
+        Measuring::setEventThreshold(100);
         std::stringstream message;
         message << "Fast case " << kind << " failed for "
                 << getBuiltinName(getBuiltinNr(call.callee)) << " ("

--- a/rir/src/utils/measuring.cpp
+++ b/rir/src/utils/measuring.cpp
@@ -4,9 +4,9 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <sstream>
 #include <string>
 #include <unordered_map>
-#include <sstream>
 
 #include "measuring.h"
 
@@ -15,23 +15,24 @@ namespace rir {
 namespace {
 
 struct MeasuringImpl {
-    size_t EVENT_THRESHOLD = 0;
-    std::unordered_map<std::string, double> timers;
-    std::pair<size_t, size_t> timerMismatches;
+    struct Timer {
+        double timer = 0;
+        bool timerActive = false;
+        std::chrono::time_point<std::chrono::high_resolution_clock> start;
+        size_t alreadyRunning = 0;
+        size_t notStarted = 0;
+    };
+    std::unordered_map<std::string, Timer> timers;
     std::unordered_map<std::string, size_t> events;
     std::chrono::time_point<std::chrono::high_resolution_clock> start;
+    std::chrono::time_point<std::chrono::high_resolution_clock> end;
+    size_t threshold = 0;
     const unsigned width = 40;
 
     MeasuringImpl() : start(std::chrono::high_resolution_clock::now()) {}
 
-    void addTime(const std::string& name, double time) { timers[name] += time; }
-
-    void timerAlreadyRunning() { timerMismatches.first++; }
-    void timerNotStarted() { timerMismatches.second++; }
-
-    void countEvent(const std::string& name, size_t n) { events[name] += n; }
-
     ~MeasuringImpl() {
+        end = std::chrono::high_resolution_clock::now();
         auto logfile = getenv("PIR_MEASURING_LOGFILE");
         if (logfile) {
             std::ofstream fs(logfile);
@@ -48,60 +49,64 @@ struct MeasuringImpl {
     }
 
     void dump(std::ostream& out) {
-        std::chrono::time_point<std::chrono::high_resolution_clock> end =
-            std::chrono::high_resolution_clock::now();
-
         std::chrono::duration<double> duration = end - start;
-        out << "=== Measurments breakdown (total lifetime: "
-            << format(duration.count()) << ") ===\n";
+        out << "\n---== Measuring breakdown ===---\n\n";
+        out << "  Total lifetime: " << format(duration.count()) << "\n\n";
 
         {
-            std::map<double, std::string> orderedTimers;
-            double totalTimer = 0;
+            std::map<double, std::tuple<std::string, size_t, size_t, double>>
+                orderedTimers;
             for (auto& t : timers) {
-                while (orderedTimers.count(t.second))
-                    t.second += 1e-20;
-                orderedTimers.emplace(t.second, t.first);
-                totalTimer += t.second;
+                auto& key = t.second.timer;
+                while (orderedTimers.count(key))
+                    key += 1e-20;
+                double notStopped = 0;
+                if (t.second.timerActive) {
+                    duration = end - t.second.start;
+                    notStopped = duration.count();
+                }
+                orderedTimers.emplace(
+                    key, std::make_tuple(t.first, t.second.alreadyRunning,
+                                         t.second.notStarted, notStopped));
             }
             if (!orderedTimers.empty()) {
-                out << "= Timers   (total: " << format(totalTimer) << " ~ "
-                    << (totalTimer / duration.count()) * 100 << "%)\n"
-                    << "           (rest:  "
-                    << format(duration.count() - totalTimer) << " ~ "
-                    << ((1. - (totalTimer / duration.count())) * 100) << "%)\n";
-                for (auto& t : orderedTimers)
-                    out << "" << std::setw(width) << t.second << "\t"
-                        << format(t.first) << "\n";
+                out << "  Timers:\n";
+                for (auto& t : orderedTimers) {
+                    auto& name = std::get<0>(t.second);
+                    out << "    " << std::setw(width) << name << "\t"
+                        << format(t.first);
+                    if (auto& alreadyRunning = std::get<1>(t.second)) {
+                        out << "  (started " << alreadyRunning
+                            << "x while running)!";
+                    }
+                    if (auto& notStarted = std::get<2>(t.second)) {
+                        out << "  (counted " << notStarted
+                            << "x while not running)!";
+                    }
+                    if (auto& notStopped = std::get<3>(t.second)) {
+                        out << "  (not stopped, measured extra "
+                            << format(notStopped) << ")!";
+                    }
+                    out << "\n";
+                }
+                out << "\n";
             }
-        }
-
-        if (timerMismatches.first || timerMismatches.second) {
-            out << "= Timer mismatches\n";
-            if (timerMismatches.first)
-                out << "" << std::setw(width)
-                    << "Timer started when already running"
-                    << "\t" << timerMismatches.first << "\n";
-            if (timerMismatches.second)
-                out << "" << std::setw(width)
-                    << "Timer counted when not started"
-                    << "\t" << timerMismatches.second << "\n";
         }
 
         {
             std::map<size_t, std::set<std::string>> orderedEvents;
             for (auto& e : events)
-                if (e.second > EVENT_THRESHOLD)
+                if (e.second >= threshold)
                     orderedEvents[e.second].insert(e.first);
             if (!orderedEvents.empty()) {
-                out << "= Events";
-                if (EVENT_THRESHOLD)
-                    out << "   (threshold: " << EVENT_THRESHOLD << ")";
-                out << "\n";
+                out << "  Events";
+                if (threshold)
+                    out << " (threshold " << threshold << ")";
+                out << ":\n";
                 for (auto& e : orderedEvents) {
                     for (auto& n : e.second) {
-                        out << "" << std::setw(width) << n << "\t"
-                            << readable(e.first) << " (" << e.first << ")\n";
+                        out << "    " << std::setw(width) << n << "\t"
+                            << e.first << " (~ " << readable(e.first) << ")\n";
                     }
                 }
             }
@@ -139,52 +144,40 @@ struct MeasuringImpl {
 
 } // namespace
 
-std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
-std::chrono::time_point<std::chrono::high_resolution_clock> endTime;
-bool timerActive = false;
-std::unique_ptr<MeasuringImpl> m = std::unique_ptr<MeasuringImpl>(
-    getenv("PIR_MEASURING") ? new MeasuringImpl : nullptr);
+std::unique_ptr<MeasuringImpl> m = std::make_unique<MeasuringImpl>();
 
-void Measuring::startTimer() {
-    if (!m)
-        return;
-    if (!timerActive) {
-        timerActive = true;
-        startTime = std::chrono::high_resolution_clock::now();
+void Measuring::startTimer(const std::string& name) {
+    auto& t = m->timers[name];
+    if (t.timerActive) {
+        t.alreadyRunning++;
     } else {
-        m->timerAlreadyRunning();
+        t.timerActive = true;
+        t.start = std::chrono::high_resolution_clock::now();
     }
 }
 
 void Measuring::countTimer(const std::string& name) {
-    if (!m)
-        return;
-    if (timerActive) {
-        endTime = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double> duration = endTime - startTime;
-        Measuring::addTime(name, duration.count());
-        timerActive = false;
+    auto end = std::chrono::high_resolution_clock::now();
+    auto& t = m->timers[name];
+    if (!t.timerActive) {
+        t.notStarted++;
     } else {
-        m->timerNotStarted();
+        t.timerActive = false;
+        std::chrono::duration<double> duration = end - t.start;
+        Measuring::addTime(name, duration.count());
     }
 }
 
 void Measuring::addTime(const std::string& name, double time) {
-    if (!m)
-        return;
-    m->addTime(name, time);
+    auto& t = m->timers[name];
+    t.timer += time;
 }
 
-void Measuring::setEventThreshold(size_t n) {
-    if (!m)
-        return;
-    m->EVENT_THRESHOLD = n;
-}
+void Measuring::setEventThreshold(size_t n) { m->threshold = n; }
 
 void Measuring::countEvent(const std::string& name, size_t n) {
-    if (!m)
-        return;
-    m->countEvent(name, n);
+    auto& c = m->events[name];
+    c += n;
 }
 
 } // namespace rir

--- a/rir/src/utils/measuring.cpp
+++ b/rir/src/utils/measuring.cpp
@@ -28,6 +28,7 @@ struct MeasuringImpl {
     std::chrono::time_point<std::chrono::high_resolution_clock> end;
     size_t threshold = 0;
     const unsigned width = 40;
+    bool shouldOutput = false;
 
     MeasuringImpl() : start(std::chrono::high_resolution_clock::now()) {}
 
@@ -49,6 +50,9 @@ struct MeasuringImpl {
     }
 
     void dump(std::ostream& out) {
+        if (!shouldOutput)
+            return;
+
         std::chrono::duration<double> duration = end - start;
         out << "\n---== Measuring breakdown ===---\n\n";
         out << "  Total lifetime: " << format(duration.count()) << "\n\n";
@@ -147,6 +151,7 @@ struct MeasuringImpl {
 std::unique_ptr<MeasuringImpl> m = std::make_unique<MeasuringImpl>();
 
 void Measuring::startTimer(const std::string& name) {
+    m->shouldOutput = true;
     auto& t = m->timers[name];
     if (t.timerActive) {
         t.alreadyRunning++;
@@ -158,6 +163,7 @@ void Measuring::startTimer(const std::string& name) {
 
 void Measuring::countTimer(const std::string& name) {
     auto end = std::chrono::high_resolution_clock::now();
+    m->shouldOutput = true;
     auto& t = m->timers[name];
     if (!t.timerActive) {
         t.notStarted++;
@@ -169,13 +175,18 @@ void Measuring::countTimer(const std::string& name) {
 }
 
 void Measuring::addTime(const std::string& name, double time) {
+    m->shouldOutput = true;
     auto& t = m->timers[name];
     t.timer += time;
 }
 
-void Measuring::setEventThreshold(size_t n) { m->threshold = n; }
+void Measuring::setEventThreshold(size_t n) {
+    m->shouldOutput = true;
+    m->threshold = n;
+}
 
 void Measuring::countEvent(const std::string& name, size_t n) {
+    m->shouldOutput = true;
     auto& c = m->events[name];
     c += n;
 }

--- a/rir/src/utils/measuring.cpp
+++ b/rir/src/utils/measuring.cpp
@@ -176,8 +176,7 @@ void Measuring::countTimer(const std::string& name) {
 
 void Measuring::addTime(const std::string& name, double time) {
     m->shouldOutput = true;
-    auto& t = m->timers[name];
-    t.timer += time;
+    m->timers[name].timer += time;
 }
 
 void Measuring::setEventThreshold(size_t n) {
@@ -187,8 +186,7 @@ void Measuring::setEventThreshold(size_t n) {
 
 void Measuring::countEvent(const std::string& name, size_t n) {
     m->shouldOutput = true;
-    auto& c = m->events[name];
-    c += n;
+    m->events[name] += n;
 }
 
 } // namespace rir

--- a/rir/src/utils/measuring.h
+++ b/rir/src/utils/measuring.h
@@ -7,7 +7,7 @@ namespace rir {
 
 class Measuring {
   public:
-    static void startTimer();
+    static void startTimer(const std::string& name);
     static void countTimer(const std::string& name);
     static void addTime(const std::string& name, double time);
     static void setEventThreshold(size_t n);


### PR DESCRIPTION
See #983. Timers are now named and thus can be nested. Also create the measuring singleton instance always. This removes the need to supply two env variables for measuring.