### PR TITLE
using a dominance tree while renumbering is unsound

### DIFF
--- a/rir/src/compiler/util/bb_transform.cpp
+++ b/rir/src/compiler/util/bb_transform.cpp
@@ -319,13 +319,13 @@ void BBTransform::mergeRedundantBBs(Code* closure) {
 }
 
 void BBTransform::renumber(Code* fun) {
-    DominanceGraph dom(fun);
-    fun->nextBBId = 0;
-    DominatorTreeVisitor<VisitorHelpers::PointerMarker>(dom).run(
+    size_t nextBBId = 0;
+    DepthFirstVisitor<VisitorHelpers::PointerMarker>::run(
         fun->entry, [&](BB* bb) {
-            bb->unsafeSetId(fun->nextBBId++);
+            bb->unsafeSetId(nextBBId++);
             bb->gc();
         });
+    fun->nextBBId = nextBBId;
 }
 
 void BBTransform::removeDeadInstrs(Code* fun, uint8_t maxBurstSize) {

--- a/rir/src/compiler/util/visitor.h
+++ b/rir/src/compiler/util/visitor.h
@@ -349,8 +349,8 @@ class VisitorNoDeoptBranch
 class BreadthFirstVisitor
     : public VisitorImplementation<Order::Breadth, VisitorHelpers::IDMarker> {};
 
-class DepthFirstVisitor
-    : public VisitorImplementation<Order::Depth, VisitorHelpers::IDMarker> {};
+template <class Marker = VisitorHelpers::IDMarker>
+class DepthFirstVisitor : public VisitorImplementation<Order::Depth, Marker> {};
 
 class LoweringVisitor
     : public VisitorImplementation<Order::Lowering, VisitorHelpers::IDMarker> {


### PR DESCRIPTION
the dominance tree implementation actually uses BB ids internally...