### PR TITLE
speculate on call targets later in the pipeline

### DIFF
--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -46,22 +46,24 @@ bool Query::pureExceptDeopt(Code* c) {
 }
 
 PirType Query::returnType(Code* c) {
-    PirType ret = PirType::bottom();
-    bool first = false;
+    struct {
+        PirType t = PirType::bottom();
+        bool seen = false;
+    } ret;
     Visitor::run(c->entry, [&](BB* bb) {
         if (bb->isExit()) {
             if (auto r = Return::Cast(bb->last())) {
                 auto t = r->arg(0).val()->type;
-                if (first) {
-                    first = false;
-                    ret = t;
+                if (!ret.seen) {
+                    ret.seen = true;
+                    ret.t = t;
                 } else {
-                    ret = ret | t;
+                    ret.t = ret.t | t;
                 }
             }
         }
     });
-    return ret;
+    return ret.t;
 }
 
 std::unordered_set<Value*> Query::returned(Code* c) {

--- a/rir/src/compiler/analysis/query.cpp
+++ b/rir/src/compiler/analysis/query.cpp
@@ -45,6 +45,25 @@ bool Query::pureExceptDeopt(Code* c) {
     });
 }
 
+PirType Query::returnType(Code* c) {
+    PirType ret = PirType::bottom();
+    bool first = false;
+    Visitor::run(c->entry, [&](BB* bb) {
+        if (bb->isExit()) {
+            if (auto r = Return::Cast(bb->last())) {
+                auto t = r->arg(0).val()->type;
+                if (first) {
+                    first = false;
+                    ret = t;
+                } else {
+                    ret = ret | t;
+                }
+            }
+        }
+    });
+    return ret;
+}
+
 std::unordered_set<Value*> Query::returned(Code* c) {
     std::unordered_set<Value*> returned;
     Visitor::run(c->entry, [&](BB* bb) {

--- a/rir/src/compiler/analysis/query.h
+++ b/rir/src/compiler/analysis/query.h
@@ -22,6 +22,7 @@ class Query {
     static bool noParentEnv(Code* c);
     static bool noEnvSpec(Code* c);
     static bool noDeopt(Code* c);
+    static PirType returnType(Code* c);
     static std::unordered_set<Value*> returned(Code* c);
 };
 } // namespace pir

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -420,7 +420,9 @@ bool EagerCalls::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                                    ClosureVersion::Property::NoReflection)) {
                     call->eachCallArg([&](InstrArg& arg) {
                         if (auto mk = MkArg::Cast(arg.val())) {
-                            if (mk->isEager()) {
+                            if (mk->isEager() &&
+                                !mk->eagerArg()->type.maybeMissing()) {
+                                anyChange = true;
                                 arg.val() = mk->eagerArg();
                             }
                         }

--- a/rir/src/compiler/opt/match_call_args.cpp
+++ b/rir/src/compiler/opt/match_call_args.cpp
@@ -64,9 +64,13 @@ bool MatchCallArgs::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         matchedArgs, argOrderOrig);
                 }
 
-                auto asmpt = calli->inferAvailableAssumptions();
+                Context asmpt;
 
-                if (staticallyArgmatched && !target) {
+                if (staticallyArgmatched) {
+                    Call fake((*ip)->env(), calli->tryGetClsArg(), matchedArgs,
+                              Tombstone::framestate(), (*ip)->srcIdx);
+                    asmpt = fake.inferAvailableAssumptions();
+
                     // We can add these because arguments will be statically
                     // matched
                     asmpt.add(Assumption::StaticallyArgmatched);

--- a/rir/src/compiler/opt/match_call_args.cpp
+++ b/rir/src/compiler/opt/match_call_args.cpp
@@ -85,12 +85,13 @@ bool MatchCallArgs::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                                 false,
                                 [&](ClosureVersion* fun) { target = fun; },
                                 []() {}, {});
-                    }
-                    if (auto mk = MkFunCls::Cast(calli->tryGetClsArg())) {
+                    } else if (auto mk =
+                                   MkFunCls::Cast(calli->tryGetClsArg())) {
+                        if (auto cls = mk->tryGetCls())
+                            target = cls->findCompatibleVersion(asmpt);
                         auto dt = mk->originalBody;
-                        auto srcRef = mk->srcRef;
-                        assert(!mk->tryGetCls());
-                        if (dt) {
+                        if (!target && dt) {
+                            auto srcRef = mk->srcRef;
                             cmp.compileFunction(dt, "unknown--fromMkFunCls",
                                                 formals, srcRef, asmpt,
                                                 [&](ClosureVersion* fun) {

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -23,8 +23,8 @@ void PassScheduler::add(std::unique_ptr<const Pass>&& t) {
 PassScheduler::PassScheduler() {
     auto addDefaultOpt = [&]() {
         add<DotDotDots>();
-        add<MatchCallArgs>();
         add<EagerCalls>();
+        add<MatchCallArgs>();
 
         add<InlineForcePromises>();
         add<Inline>();

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -924,6 +924,7 @@ class FLIE(LdFun, 2, Effects::Any()) {
   public:
     SEXP varName;
     SEXP hint = nullptr;
+    bool hintIsInnerFunction = false;
 
     LdFun(const char* name, Value* env)
         : FixedLenInstructionWithEnvSlot(PirType::closure(), {{PirType::any()}},

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2078,6 +2078,7 @@ class VLIE(Call, Effects::Any()), public CallInstruction {
          Value* fs, unsigned srcIdx);
 
     Value* cls() const { return arg(1).val(); }
+    void cls(Value * v) { arg(1).val() = v; }
 
     Value* tryGetClsArg() const override final {
         return cls()->followCastsAndForce();

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -228,7 +228,7 @@ void PirType::fromContext(const Context& assumptions, unsigned arg,
         type = type.notLazy();
 
     if (afterForce)
-        type = type.notPromiseWrapped();
+        type = type.forced();
 
     if (assumptions.isEager(i) || afterForce) {
         type = type.notLazy();

--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -518,8 +518,6 @@ struct PirType {
     PirType constexpr forced() const {
         if (!maybePromiseWrapped())
             return *this;
-        if (!maybeLazy())
-            return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::promiseWrapped));
         return PirType(
             // forcing can return the missing marker value
             t_.r | RType::missing,

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -623,9 +623,15 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         auto ti = checkCallTarget(callee, srcCode, callTargetFeedback);
 
         auto ldfun = LdFun::Cast(callee);
-        if (ldfun)
-            ldfun->hint =
-                ti.monomorphic ? ti.monomorphic : symbol::ambiguousCallTarget;
+        if (ldfun) {
+            if (ti.monomorphic) {
+                ldfun->hint = ti.monomorphic;
+                if (!ti.stableEnv)
+                    ldfun->hintIsInnerFunction = true;
+            } else {
+                ldfun->hint = symbol::ambiguousCallTarget;
+            }
+        }
 
         // Deopt in promise not possible
         if (inPromise())

--- a/rir/src/compiler/test/PirCheck.cpp
+++ b/rir/src/compiler/test/PirCheck.cpp
@@ -95,7 +95,7 @@ static bool testNoExternalCalls(ClosureVersion* f) {
 }
 
 static bool testReturns42L(ClosureVersion* f) {
-    if (!Query::noEnv(f))
+    if (!Query::noEnvSpec(f))
         return false;
     auto r = Query::returned(f);
     if (r.size() != 1)

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -860,26 +860,21 @@ void inferCurrentContext(CallContext& call, size_t formalNargs,
             given.setNonRefl(i);
         }
 
-        // Eager in the context translates to the notLazy().notMissing()
-        // type in pir. Thus we need to ensure that we don't set it for
-        // wrapped missings.
-        if (arg != R_MissingArg) {
-            if (isEager) {
-                given.setEager(i);
-                SLOWASSERT(TYPEOF(call.stackArg(i)) != PROMSXP ||
-                           PRVALUE(call.stackArg(i)) != R_UnboundValue);
-            }
+        if (isEager) {
+            given.setEager(i);
+            SLOWASSERT(TYPEOF(call.stackArg(i)) != PROMSXP ||
+                       PRVALUE(call.stackArg(i)) != R_UnboundValue);
+        }
 
-            // Without isEager, these are the results of executing a trivial
-            // expression, given no reflective change happens.
-            if (arg != R_UnboundValue) {
-                if (!isObject(arg))
-                    given.setNotObj(i);
-                if (IS_SIMPLE_SCALAR(arg, REALSXP))
-                    given.setSimpleReal(i);
-                if (IS_SIMPLE_SCALAR(arg, INTSXP))
-                    given.setSimpleInt(i);
-            }
+        // Without isEager, these are the results of executing a trivial
+        // expression, given no reflective change happens.
+        if (arg != R_UnboundValue && arg != R_MissingArg) {
+            if (!isObject(arg))
+                given.setNotObj(i);
+            if (IS_SIMPLE_SCALAR(arg, REALSXP))
+                given.setSimpleReal(i);
+            if (IS_SIMPLE_SCALAR(arg, INTSXP))
+                given.setSimpleInt(i);
         }
     };
 

--- a/rir/tests/annotations_depromise.R
+++ b/rir/tests/annotations_depromise.R
@@ -30,6 +30,7 @@ g <- function() {
 
     result <- f({  performStep(2);  6L })
     stopifnot(result == 7L)
+    print(steps)
     stopifnot(steps == c(1, 2, 3,4))
 
 }

--- a/rir/tests/pir_check.R
+++ b/rir/tests/pir_check.R
@@ -491,3 +491,10 @@ h <- function(r,s,t) {
   forceAndCall(3, x, r,s,t)
 }
 stopifnot(pir.check(f, NoExternalCalls, warmup=function(f) {f();f()}))
+
+f <- function() 1L
+g <- function(x) x
+h <- function() {
+  g(g(g(f()) + g(g(f()))) + g(40L))
+}
+stopifnot(pir.check(h, NoExternalCalls, Returns42L, warmup=function(h) {h();h()}))

--- a/rir/tests/sapply_repro.R
+++ b/rir/tests/sapply_repro.R
@@ -1,0 +1,4 @@
+a <- c( "", "", "",  "formals(lm)[[2]]")
+b <- sapply(a, function(d) eval(parse(text = d)))
+print(b)
+t(sapply(b, function(d) c(typeof(d))))

--- a/rir/tests/sapply_repro.R
+++ b/rir/tests/sapply_repro.R
@@ -2,3 +2,11 @@ a <- c( "", "", "",  "formals(lm)[[2]]")
 b <- sapply(a, function(d) eval(parse(text = d)))
 print(b)
 t(sapply(b, function(d) c(typeof(d))))
+
+cex3 <- c("NULL", "1", "1:1", "1i", "list(1)", "data.frame(x = 1)",
+   "pairlist(pi)", "c", "lm", "formals(lm)[[1]]",  "formals(lm)[[2]]",
+   "y ~ x","expression((1))[[1]]", "(y ~ x)[[1]]",
+   "expression(x <- pi)[[1]][[1]]")
+lex3 <- sapply(cex3, function(x) eval(parse(text = x)))
+mex3 <- t(sapply(lex3,
+                  function(x) c(typeof(x), storage.mode(x), mode(x))))


### PR DESCRIPTION
currently we only speculate on call targets in rir2pir. this change
inserts guards late in the pipeline, that should allow the existing
match arg pass to turn them into static calls.