### PR TITLE
towards more rir -> pir calls

### DIFF
--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -169,6 +169,8 @@ void stargImpl(SEXP sym, SEXP val, SEXP env) {
             } else {
                 ENSURE_NAMED(val);
             }
+            if (MISSING(loc.cell))
+                SET_MISSING(loc.cell, 2);
             return;
         }
     }
@@ -194,7 +196,7 @@ void setTagImpl(SEXP x, SEXP y) {
     assert(x->sxpinfo.mark && "Use fastpath setTag");
     assert((!y->sxpinfo.mark || y->sxpinfo.gcgen < x->sxpinfo.gcgen) &&
            "use fast path setTag");
-    SETCAR(x, y);
+    SET_TAG(x, y);
 }
 
 void externalsxpSetEntryImpl(SEXP x, int i, SEXP y) {

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -953,9 +953,9 @@ void LowerFunctionLLVM::checkIsSexp(llvm::Value* v, const std::string& msg) {
 llvm::Value* LowerFunctionLLVM::sxpinfoPtr(llvm::Value* v) {
     assert(v->getType() == t::SEXP);
     checkIsSexp(v, "in sxpinfoPtr");
-    auto sxpinfoPtr = builder.CreateGEP(t::SEXPREC, v, {c(0), c(0)});
+    auto sxpinfoPtr = builder.CreateGEP(t::SEXPREC, v, {c(0), c(0), c(0)});
     sxpinfoPtr->setName("sxpinfo");
-    return builder.CreateBitCast(sxpinfoPtr, t::i64ptr);
+    return sxpinfoPtr;
 }
 
 void LowerFunctionLLVM::setSexptype(llvm::Value* v, int t) {
@@ -5465,6 +5465,9 @@ void LowerFunctionLLVM::compile() {
                     assert(cache->getType() == t::SEXP);
                     assert(newVal->getType() == t::SEXP);
                     setCar(cache, newVal);
+                    // Missingness needs not be updated here, because the cache
+                    // hit on the second store, i.e. after a slow-case starg
+                    // builtin, which already updated missingness
                     builder.CreateBr(done);
 
                     builder.SetInsertPoint(identical);


### PR DESCRIPTION
this PR takes another step towards being able to call more optimized
functions from unoptimized ones. Here we mark calls, where `...` is a
formal argument, but the caller does not passes not enough args for any
of them to end up in the `...` as statically matched, ie. when `...` is
missing. 