### PR TITLE
fix a type confusion in subassign

### DIFF
--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -153,8 +153,8 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                         "is.raw",      "is.object",    "isS4",
                         "is.numeric",  "is.matrix",    "is.array",
                         "is.atomic",   "is.recursive", "is.call",
-                        "is.language", "is.function",  "is.single",
-                        "all",         "any"};
+                        "is.language", "is.function",  "all",
+                        "any"};
                     if (tests.count(name)) {
                         if (!getType(c->callArg(0).val()).maybeObj())
                             inferred = PirType(RType::logical)

--- a/rir/src/compiler/util/safe_builtins_list.cpp
+++ b/rir/src/compiler/util/safe_builtins_list.cpp
@@ -304,7 +304,6 @@ bool SafeBuiltinsList::nonObject(int builtin) {
         blt("is.call"),
         blt("is.language"),
         blt("is.function"),
-        blt("is.single"),
         blt("is.na"),
         blt("is.nan"),
         blt("is.finite"),
@@ -444,8 +443,8 @@ bool SafeBuiltinsList::nonObjectIdempotent(int builtin) {
 
         blt("is.numeric"), blt("is.matrix"), blt("is.array"),
         blt("is.recursive"), blt("is.call"), blt("is.language"),
-        blt("is.function"), blt("is.single"), blt("is.na"), blt("is.nan"),
-        blt("is.finite"), blt("is.infinite"),
+        blt("is.function"), blt("is.na"), blt("is.nan"), blt("is.finite"),
+        blt("is.infinite"),
 
         blt("cumsum"), blt("colSums"),
 


### PR DESCRIPTION
boolean scalar stored as unboxed int would get materialized as integer
scalar in some subassign builtins.