### PR TITLE
set the correct missingness value on bindings created in native code

### DIFF
--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -45,7 +45,7 @@ static SEXP createBindingCellImpl(SEXP val, SEXP name, SEXP rest) {
     SEXP res = CONS_NR(val, rest);
     SET_TAG(res, name);
     if (val == R_MissingArg)
-        SET_MISSING(res, 2);
+        SET_MISSING(res, 1);
     INCREMENT_NAMED(val);
     return res;
 }
@@ -53,7 +53,7 @@ static SEXP createBindingCellImpl(SEXP val, SEXP name, SEXP rest) {
 static SEXP createMissingBindingCellImpl(SEXP val, SEXP name, SEXP rest) {
     SEXP res = CONS_NR(val, rest);
     SET_TAG(res, name);
-    SET_MISSING(res, 2);
+    SET_MISSING(res, val == R_MissingArg ? 1 : 2);
     INCREMENT_NAMED(val);
     return res;
 }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -293,7 +293,10 @@ SEXP materialize(SEXP wrapper) {
             // cons protects its args if needed
             arglist = CONS_NR(val, arglist);
             SET_TAG(arglist, name);
-            SET_MISSING(arglist, lazyEnv->missing[i] ? 2 : 0);
+            if (val == R_MissingArg)
+                SET_MISSING(arglist, 1);
+            else if (lazyEnv->missing[i])
+                SET_MISSING(arglist, 2);
         }
         res = Rf_NewEnvironment(R_NilValue, arglist, lazyEnv->getParent());
         lazyEnv->materialized(res);
@@ -435,7 +438,8 @@ SEXP createLegacyArglist(ArglistOrder::CallId id, size_t length,
 
         // This can happen if context dispatch padded the call with "synthetic"
         // missings to be able to call a version which expects more args
-        if (recreateOriginalPromargs && arg == R_MissingArg && a == R_NilValue)
+        if (recreateOriginalPromargs && arg == R_MissingArg &&
+            expr == R_NilValue)
             continue;
 
         if (eagerCallee && TYPEOF(arg) == PROMSXP) {


### PR DESCRIPTION
afaik 1 for missing and 2 for missing which are replaced by default arg.