### PR TITLE
fix S3 dispatch to RIR

### DIFF
--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -248,7 +248,8 @@ static SEXP callBuiltinImpl(rir::Code* c, Immediate ast, SEXP callee, SEXP env,
                             size_t nargs) {
     auto ctx = globalContext();
     CallContext call(ArglistOrder::NOT_REORDERED, c, callee, nargs, ast,
-                     ostack_cell_at(ctx, nargs - 1), env, Context(), ctx);
+                     ostack_cell_at(ctx, nargs - 1), env, R_NilValue, Context(),
+                     ctx);
     if (debugPrintCallBuiltinImpl) {
         debugPrintCallBuiltinImpl = false;
         std::cout << "call builtin " << nargs << " with\n";
@@ -285,8 +286,8 @@ static SEXP callImplCached(ArglistOrder::CallId callId, rir::Code* c,
                            unsigned long available, Immediate cache) {
     auto ctx = globalContext();
     CallContext call(callId, c, callee, nargs, ast,
-                     ostack_cell_at(ctx, nargs - 1), env, Context(available),
-                     ctx);
+                     ostack_cell_at(ctx, nargs - 1), env, R_NilValue,
+                     Context(available), ctx);
 
     SLOWASSERT(env == symbol::delayedEnv || TYPEOF(env) == ENVSXP ||
                LazyEnvironment::check(env) || env == R_NilValue);
@@ -305,7 +306,7 @@ static SEXP namedCallImpl(ArglistOrder::CallId callId, rir::Code* c,
                           Immediate* names, unsigned long available) {
     auto ctx = globalContext();
     CallContext call(callId, c, callee, nargs, ast,
-                     ostack_cell_at(ctx, nargs - 1), names, env,
+                     ostack_cell_at(ctx, nargs - 1), names, env, R_NilValue,
                      Context(available), ctx);
     SLOWASSERT(env == symbol::delayedEnv || TYPEOF(env) == ENVSXP ||
                LazyEnvironment::check(env));
@@ -335,7 +336,8 @@ static SEXP dotsCallImpl(ArglistOrder::CallId callId, rir::Code* c,
     }
 
     CallContext call(callId, c, callee, nargs, ast,
-                     ostack_cell_at(ctx, nargs - 1), names, env, given, ctx);
+                     ostack_cell_at(ctx, nargs - 1), names, env, R_NilValue,
+                     given, ctx);
     SLOWASSERT(env == symbol::delayedEnv || TYPEOF(env) == ENVSXP ||
                LazyEnvironment::check(env));
     SLOWASSERT(ctx);
@@ -804,7 +806,8 @@ void deoptImpl(Code* c, SEXP cls, DeoptMetadata* m, R_bcstack_t* args) {
         ostack_at(ctx, stackHeight - m->frames[m->numFrames - 1].stackSize - 1);
     CallContext call(ArglistOrder::NOT_REORDERED, c, cls,
                      /* nargs */ -1, src_pool_at(globalContext(), c->src), args,
-                     (Immediate*)nullptr, env, Context(), globalContext());
+                     (Immediate*)nullptr, env, R_NilValue, Context(),
+                     globalContext());
 
     deoptFramesWithContext(globalContext(), &call, m, R_NilValue,
                            m->numFrames - 1, stackHeight,
@@ -1162,8 +1165,8 @@ static SEXP nativeCallTrampolineImpl(ArglistOrder::CallId callId, rir::Code* c,
 
     auto ctx = globalContext();
     CallContext call(callId, c, callee, nargs, astP,
-                     ostack_cell_at(ctx, nargs - 1), env, Context(available),
-                     ctx);
+                     ostack_cell_at(ctx, nargs - 1), env, R_NilValue,
+                     Context(available), ctx);
 
     auto fail = !call.givenContext.smaller(fun->context());
     if (fail) {

--- a/rir/src/interpreter/builtins.cpp
+++ b/rir/src/interpreter/builtins.cpp
@@ -174,7 +174,7 @@ SEXP tryFastSpecialCall(const CallContext& call, InterpreterInstance* ctx) {
         CallContext innerCall(ArglistOrder::NOT_REORDERED, call.caller, fun,
                               nargs, ast, call.stackArgs + 2,
                               call.names ? call.names + 2 : nullptr,
-                              call.callerEnv, innerCtxt, ctx);
+                              call.callerEnv, R_NilValue, innerCtxt, ctx);
 
         if (TYPEOF(fun) == BUILTINSXP || TYPEOF(fun) == CLOSXP) {
             for (int i = 0; i < n; i++) {

--- a/rir/src/interpreter/call_context.h
+++ b/rir/src/interpreter/call_context.h
@@ -25,11 +25,12 @@ struct CallContext {
 
     CallContext(ArglistOrder::CallId callId, const Code* c, SEXP callee,
                 size_t nargs, SEXP ast, R_bcstack_t* stackArgs,
-                const Immediate* names, SEXP callerEnv,
+                const Immediate* names, SEXP callerEnv, SEXP suppliedvars,
                 const Context& givenContext, InterpreterInstance* ctx)
         : callId(callId), caller(c), suppliedArgs(nargs), passedArgs(nargs),
-          stackArgs(stackArgs), names(names), callerEnv(callerEnv), ast(ast),
-          callee(callee), givenContext(givenContext) {
+          stackArgs(stackArgs), names(names), callerEnv(callerEnv),
+          suppliedvars(suppliedvars), ast(ast), callee(callee),
+          givenContext(givenContext) {
         assert(callerEnv);
         assert(callee &&
                (TYPEOF(callee) == CLOSXP || TYPEOF(callee) == SPECIALSXP ||
@@ -42,17 +43,18 @@ struct CallContext {
     // cppcheck-suppress uninitMemberVar
     CallContext(ArglistOrder::CallId callId, Code* c, SEXP callee, size_t nargs,
                 Immediate ast, R_bcstack_t* stackArgs, Immediate* names,
-                SEXP callerEnv, const Context& givenContext,
+                SEXP callerEnv, SEXP suppliedvars, const Context& givenContext,
                 InterpreterInstance* ctx)
         : CallContext(callId, c, callee, nargs, cp_pool_at(ctx, ast), stackArgs,
-                      names, callerEnv, givenContext, ctx) {}
+                      names, callerEnv, suppliedvars, givenContext, ctx) {}
 
     // cppcheck-suppress uninitMemberVar
     CallContext(ArglistOrder::CallId callId, Code* c, SEXP callee, size_t nargs,
                 Immediate ast, R_bcstack_t* stackArgs, SEXP callerEnv,
-                const Context& givenContext, InterpreterInstance* ctx)
+                SEXP suppliedvars, const Context& givenContext,
+                InterpreterInstance* ctx)
         : CallContext(callId, c, callee, nargs, cp_pool_at(ctx, ast), stackArgs,
-                      nullptr, callerEnv, givenContext, ctx) {}
+                      nullptr, callerEnv, suppliedvars, givenContext, ctx) {}
 
     const ArglistOrder::CallId callId;
     const Code* caller;
@@ -61,6 +63,7 @@ struct CallContext {
     R_bcstack_t* stackArgs;
     const Immediate* names;
     SEXP callerEnv;
+    SEXP suppliedvars;
     const SEXP ast;
     const SEXP callee;
     Context givenContext;

--- a/rir/tests/S3_regression.R
+++ b/rir/tests/S3_regression.R
@@ -1,0 +1,15 @@
+setClass("a", slots=c(myint="numeric"))
+
+myfun.a <- function(x) {
+  print(.Generic)
+}
+
+myfun <- function(x) {
+  # dispatch on the class of x
+  UseMethod("myfun")
+}
+
+x <- new("a")
+myfun(x)
+myfun(x)
+myfun(x)


### PR DESCRIPTION
when calling RIR code directly from S3 dispatch in gnu R we must respect
the suppliedvars list of additional bindings.

Thanks @vogr for documenting the issue.

Closes #1048