### PR TITLE
remember deopt count

### DIFF
--- a/rir/src/compiler/native/builtins.h
+++ b/rir/src/compiler/native/builtins.h
@@ -3,10 +3,12 @@
 
 #include "R/r_incl.h"
 #include "R_ext/Boolean.h"
+#include "utils/Pool.h"
 
 #include "llvm/IR/Attributes.h"
 
 #include <cstddef>
+#include <unordered_map>
 #include <vector>
 
 extern "C" {
@@ -175,6 +177,8 @@ struct NativeBuiltins {
     }
 
     static void initializeBuiltins();
+
+    static std::vector<BC::PoolIdx> targetCaches;
 
   private:
     // For setting up - returns mutable reference

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -3380,6 +3380,7 @@ void LowerFunctionLLVM::compile() {
                         assert(
                             asmpt.includes(Assumption::StaticallyArgmatched));
                         auto idx = Pool::makeSpace();
+                        NativeBuiltins::targetCaches.push_back(idx);
                         Pool::patch(idx, nativeTarget->container());
                         assert(asmpt.smaller(nativeTarget->context()));
                         auto res = withCallFrame(args, [&]() {

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -3360,23 +3360,6 @@ void LowerFunctionLLVM::compile() {
                         }
                     }
                     if (nativeTarget) {
-                        // TODO: callId is not used here.. should it be?
-                        auto trg = getFunction(target);
-                        if (trg &&
-                            target->properties.includes(
-                                ClosureVersion::Property::NoReflection)) {
-                            auto code = builder.CreateIntToPtr(
-                                c(nativeTarget->body()), t::voidPtr);
-                            llvm::Value* arglist = nodestackPtr();
-                            auto rr = withCallFrame(args, [&]() {
-                                return builder.CreateCall(
-                                    trg, {code, arglist, loadSxp(i->env()),
-                                          constant(callee, t::SEXP)});
-                            });
-                            setVal(i, rr);
-                            break;
-                        }
-
                         assert(
                             asmpt.includes(Assumption::StaticallyArgmatched));
                         auto idx = Pool::makeSpace();

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -546,11 +546,11 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         // If this call was never executed. Might as well compile an
         // unconditional deopt.
         if (!inPromise() && !inlining() && feedback.taken == 0 &&
-            srcCode->funInvocationCount > 1) {
+            srcCode->funInvocationCount > 1 && srcCode->deadCallReached < 3) {
             auto sp =
                 insert.registerFrameState(srcCode, pos, stack, inPromise());
             auto offset = (uintptr_t)pos - (uintptr_t)srcCode;
-            DeoptReason reason = {DeoptReason::Calltarget, srcCode,
+            DeoptReason reason = {DeoptReason::DeadCall, srcCode,
                                   (uint32_t)offset};
             insert(new RecordDeoptReason(reason, target));
             insert(new Deopt(sp));

--- a/rir/src/compiler/util/bb_transform.cpp
+++ b/rir/src/compiler/util/bb_transform.cpp
@@ -181,6 +181,7 @@ BB* BBTransform::lowerExpect(Code* code, BB* src, BB::Instrs::iterator position,
             }
             switch (r) {
             case DeoptReason::Typecheck:
+            case DeoptReason::DeadCall:
             case DeoptReason::Calltarget: {
                 auto offset =
                     (uintptr_t)origin.second - (uintptr_t)origin.first;

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -588,6 +588,9 @@ void recordDeoptReason(SEXP val, const DeoptReason& reason) {
         }
         break;
     }
+    case DeoptReason::DeadCall:
+        reason.srcCode->deadCallReached++;
+        // fall through
     case DeoptReason::Calltarget: {
         assert(*pos == Opcode::record_call_);
         ObservedCallees* feedback = (ObservedCallees*)(pos + 1);

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -55,7 +55,6 @@ inline bool RecompileHeuristic(DispatchTable* table, Function* fun,
     auto& flags = fun->flags;
     return (!flags.contains(Function::NotOptimizable) &&
             (flags.contains(Function::MarkOpt) ||
-             flags.contains(Function::Dead) ||
              (fun->deoptCount() < pir::Parameter::DEOPT_ABANDON &&
               ((fun != table->baseline() && fun->invocationCount() >= 2 &&
                 fun->invocationCount() <= pir::Parameter::RIR_WARMUP) ||
@@ -67,7 +66,7 @@ inline bool RecompileHeuristic(DispatchTable* table, Function* fun,
 inline bool RecompileCondition(DispatchTable* table, Function* fun,
                                const Context& context) {
     return (fun->flags.contains(Function::MarkOpt) ||
-            fun->flags.contains(Function::Dead) || fun == table->baseline() ||
+            fun == table->baseline() ||
             (context.smaller(fun->context()) && context.isImproving(fun)) ||
             fun->body()->flags.contains(Code::Reoptimise));
 }

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -59,8 +59,7 @@ inline bool RecompileHeuristic(DispatchTable* table, Function* fun,
               ((fun != table->baseline() && fun->invocationCount() >= 2 &&
                 fun->invocationCount() <= pir::Parameter::RIR_WARMUP) ||
                (fun->invocationCount() %
-                (factor * (fun->deoptCount() + pir::Parameter::RIR_WARMUP))) ==
-                   0))));
+                (factor * (pir::Parameter::RIR_WARMUP))) == 0))));
 }
 
 inline bool RecompileCondition(DispatchTable* table, Function* fun,

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -90,6 +90,7 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     }
 
     void registerDeopt() {
+        isDeoptimized = true;
         if (deoptCount < UINT_MAX)
             deoptCount++;
     }
@@ -98,6 +99,7 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     // of a function
     unsigned funInvocationCount;
     unsigned deoptCount;
+    bool isDeoptimized = false;
 
     enum Flag {
         NeedsFullEnv,

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -99,6 +99,7 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     // of a function
     unsigned funInvocationCount;
     unsigned deoptCount;
+    unsigned deadCallReached = 0;
     bool isDeoptimized = false;
 
     enum Flag {

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -73,7 +73,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     void registerInvocation() { body()->registerInvocation(); }
     size_t invocationCount() { return body()->funInvocationCount; }
     void registerDeopt() { body()->registerDeopt(); }
-    size_t deoptCount() { return body()->deoptCount; }
+    size_t deoptCount() { return body()->deoptCount - body()->deadCallReached; }
 
     unsigned size; /// Size, in bytes, of the function and its data
 

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -85,7 +85,6 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     V(DepromiseArgs)                                                           \
     V(NotOptimizable)                                                          \
     V(NotInlineable)                                                           \
-    V(Dead)                                                                    \
     V(InnerFunction)                                                           \
     V(DisableAllSpecialization)                                                \
     V(DisableArgumentTypeSpecialization)                                       \

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -73,7 +73,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     void registerInvocation() { body()->registerInvocation(); }
     size_t invocationCount() { return body()->funInvocationCount; }
     void registerDeopt() { body()->registerDeopt(); }
-    size_t deoptCount() { return body()->deoptCount - body()->deadCallReached; }
+    size_t deoptCount() { return body()->deoptCount; }
 
     unsigned size; /// Size, in bytes, of the function and its data
 

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -159,6 +159,7 @@ struct DeoptReason {
     enum Reason : uint32_t {
         None,
         Typecheck,
+        DeadCall,
         Calltarget,
         EnvStubMaterialized,
         DeadBranchReached,


### PR DESCRIPTION
Improved strategy to for deopt count. The count is kept across
recompilations, such that we can actually know if a function keeps
deoptimizing.

This is done by keeping deoptimized versions in the dispatch table, but
skipping them on dispatch