### PR TITLE
fix analysis to detect instructions that care about int/double

### DIFF
--- a/rir/src/compiler/analysis/dead.cpp
+++ b/rir/src/compiler/analysis/dead.cpp
@@ -59,7 +59,6 @@ DeadInstructions::DeadInstructions(Code* code, uint8_t maxBurstSize,
                     if (std::find(IgnoreIntVsReal.begin(),
                                   IgnoreIntVsReal.end(),
                                   use->tag) == IgnoreIntVsReal.end() &&
-                        !use->effects.includes(Effect::ExecuteCode) &&
                         isAlive(use))
                         addToDead = false;
                     break;


### PR DESCRIPTION
double negation ftw... This was trying to be extra cautious and ended up
allowing way more instructions than intended.

closes #1056 