### PR TITLE
Skip unnecessary optimization passes

### DIFF
--- a/rir/src/compiler/opt/pass.cpp
+++ b/rir/src/compiler/opt/pass.cpp
@@ -5,6 +5,12 @@
 namespace rir {
 namespace pir {
 
+namespace detail {
+
+size_t IDCounter::nextId = 0;
+
+} // namespace detail
+
 bool Pass::apply(Compiler& cmp, ClosureVersion* function,
                  LogStream& log) const {
     bool res = apply(cmp, function, function, log);

--- a/rir/src/compiler/opt/pass.h
+++ b/rir/src/compiler/opt/pass.h
@@ -1,14 +1,32 @@
 #ifndef PIR_PASS_H
 #define PIR_PASS_H
 
-#include "../pir/module.h"
 #include "compiler/log/stream_logger.h"
+#include "compiler/pir/module.h"
+
 #include <string>
 
 namespace rir {
 namespace pir {
 
 class Compiler;
+
+namespace detail {
+
+struct IDCounter {
+    static size_t nextId;
+};
+
+template <typename Derived>
+struct HasIDCounter : IDCounter {
+    HasIDCounter() { _id(); }
+    static size_t _id() {
+        static size_t c = detail::IDCounter::nextId++;
+        return c;
+    }
+};
+
+} // namespace detail
 
 class Pass {
   public:
@@ -26,6 +44,7 @@ class Pass {
     virtual ~Pass() {}
     virtual bool isPhaseMarker() const { return false; }
     virtual unsigned cost() const { return 1; }
+    virtual size_t id() const = 0;
 
   protected:
     std::string name;

--- a/rir/src/compiler/opt/pass_scheduler.cpp
+++ b/rir/src/compiler/opt/pass_scheduler.cpp
@@ -135,5 +135,6 @@ void PassScheduler::nextPhase(const std::string& name, unsigned budget) {
     currentPhase->passes.push_back(
         std::unique_ptr<const Pass>(new PhaseMarker(name)));
 }
-}
-}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/opt/pass_scheduler.h
+++ b/rir/src/compiler/opt/pass_scheduler.h
@@ -41,7 +41,7 @@ class PassScheduler {
     void run(const std::function<bool(const Pass*)>& apply) const {
         std::vector<size_t> lastRun(detail::IDCounter::nextId, 0);
         // These passes "lie" about not changing anything
-        SmallSet<size_t> blacklist {Constantfold::_id()};
+        SmallSet<size_t> blacklist {Constantfold::_id(), GVN::_id()};
         size_t lastChange = 1, now = 1;
         for (auto& phase : schedule_.phases) {
             auto budget = phase.budget;


### PR DESCRIPTION
* (experiment) track when the last change happened, if the current pass was run after the last change, we can skip it since it would be repeating the run on the same code