### PR TITLE
Fix DI verification

### DIFF
--- a/rir/src/compiler/native/pir_jit_llvm.cpp
+++ b/rir/src/compiler/native/pir_jit_llvm.cpp
@@ -418,20 +418,19 @@ void PirJitLLVM::compile(
 
     funCompiler.compile();
 
-#ifndef NDEBUG
-
-    if (llvm::verifyFunction(*funCompiler.fun, &llvm::errs())) {
-        assert(false &&
-               "Error in llvm::verifyFunction() called from pir_jit_llvm.cpp");
-    }
-#endif
-
     assert(jitFixup.count(code) == 0);
 
     if (LLVMDebugInfo()) {
         DI->LexicalBlocks.pop_back();
         DIB->finalizeSubprogram(SP);
     }
+
+#ifndef NDEBUG
+    if (llvm::verifyFunction(*funCompiler.fun, &llvm::errs())) {
+        assert(false &&
+               "Error in llvm::verifyFunction() called from pir_jit_llvm.cpp");
+    }
+#endif
 
     if (funCompiler.pirTypeFeedback)
         target->pirTypeFeedback(funCompiler.pirTypeFeedback);


### PR DESCRIPTION
Caused by calling `verifyFunction` before finilizing the subprogram debug info (cf. https://stackoverflow.com/questions/34236034/how-to-track-down-llvm-verifyfunction-error-expected-no-forward-declarations)

Closes #1083 