### PR TITLE
refactor deopt reason

### DIFF
--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -5,6 +5,7 @@
 #define SYMBOLS_SIMPLE_INSTRUCTION_V(V, name, _) V(name, "." #name)
 
 #define SYMBOLS(V)                                                             \
+    V(UnknownDeoptTrigger, ".unknownDeoptTrigger")                             \
     V(SuperAssignBracket, "[<<-")                                              \
     V(SuperAssignDoubleBracket, "[[<<-")                                       \
     V(AssignBracket, "[<-")                                                    \

--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -302,7 +302,7 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
     pir::StreamLogger logger(debug);
     logger.title("Compiling " + name);
     pir::Compiler cmp(m, logger);
-    pir::Backend backend(logger, name);
+    pir::Backend backend(m, logger, name);
     auto compile = [&](pir::ClosureVersion* c) {
         logger.flush();
         cmp.optimizeModule();

--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -286,9 +286,11 @@ class StaticReferenceCount
         case Tag::MkArg:
         case Tag::UpdatePromise:
         case Tag::PopContext:
+        case Tag::Extract2_1D:
         case Tag::Extract2_2D:
         case Tag::ColonCastLhs:
         case Tag::ColonCastRhs:
+        case Tag::FrameState:
             break;
 
         // Those may override the vector (which is arg 1)
@@ -328,7 +330,6 @@ class StaticReferenceCount
 
         // Default: instructions which might update in-place, if named
         // count is 0
-        case Tag::Extract2_1D:
         default:
             i->eachArg([&](Value* v) {
                 if (auto j = Instruction::Cast(v->followCasts())) {

--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -189,35 +189,41 @@ class StaticReferenceCount
         // Check if this instruction uses a tainted value. If so, we need to
         // record the fact that there is a adjustment needed.
         // We collect the result in the global state.
-        i->eachArg([&](Value* v) {
-            if (auto j = Instruction::Cast(v->followCasts())) {
-                assert(!PirCopy::Cast(j));
-                if (i == j || j->minReferenceCount() > 1)
+        if (!Phi::Cast(i) && !CastType::Cast(i))
+            i->eachArg([&](Value* v) {
+                // DeoptTrigger value is best effort. We should not duplicate
+                // just for that.
+                if (Deopt::Cast(i) && v == Deopt::Cast(i)->deoptTrigger())
                     return;
-                if (auto taint = state.isTainted(j)) {
-                    NeedsRefcountAdjustment::Kind k =
-                        NeedsRefcountAdjustment::EnsureNamed;
-                    if (taint->kind == AbstractValueTaint::Taint::Override)
-                        k = NeedsRefcountAdjustment::SetShared;
-                    else
-                        assert(taint->kind == AbstractValueTaint::Taint::Reuse);
+                if (auto j = Instruction::Cast(v->followCasts())) {
+                    assert(!PirCopy::Cast(j));
+                    if (i == j || j->minReferenceCount() > 1)
+                        return;
+                    if (auto taint = state.isTainted(j)) {
+                        NeedsRefcountAdjustment::Kind k =
+                            NeedsRefcountAdjustment::EnsureNamed;
+                        if (taint->kind == AbstractValueTaint::Taint::Override)
+                            k = NeedsRefcountAdjustment::SetShared;
+                        else
+                            assert(taint->kind ==
+                                   AbstractValueTaint::Taint::Reuse);
 
-                    if (taint->origin) {
-                        if (globalState->beforeUse[taint->origin][j] < k) {
-                            globalState->beforeUse[taint->origin][j] = k;
-                        }
-                    } else {
-                        auto exists = globalState->atCreation.find(j);
-                        if (exists != globalState->atCreation.end()) {
-                            if (exists->second < k)
-                                exists->second = k;
+                        if (taint->origin) {
+                            if (globalState->beforeUse[taint->origin][j] < k) {
+                                globalState->beforeUse[taint->origin][j] = k;
+                            }
                         } else {
-                            globalState->atCreation[j] = k;
+                            auto exists = globalState->atCreation.find(j);
+                            if (exists != globalState->atCreation.end()) {
+                                if (exists->second < k)
+                                    exists->second = k;
+                            } else {
+                                globalState->atCreation[j] = k;
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
 
         switch (i->tag) {
 

--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -256,7 +256,6 @@ class StaticReferenceCount
 
         // Instructions which never reuse SEXPS can be ignored
         case Tag::PirCopy:
-        case Tag::RecordDeoptReason:
         case Tag::Return:
         case Tag::Colon:
         case Tag::CastType:
@@ -286,7 +285,6 @@ class StaticReferenceCount
         case Tag::MkEnv:
         case Tag::MkArg:
         case Tag::UpdatePromise:
-        case Tag::ScheduledDeopt:
         case Tag::PopContext:
         case Tag::Extract2_2D:
         case Tag::ColonCastLhs:

--- a/rir/src/compiler/backend.h
+++ b/rir/src/compiler/backend.h
@@ -16,8 +16,8 @@ namespace pir {
 
 class Backend {
   public:
-    Backend(StreamLogger& logger, const std::string& name)
-        : jit(name), logger(logger) {}
+    Backend(Module* m, StreamLogger& logger, const std::string& name)
+        : module(m), jit(name), logger(logger) {}
     Backend(const Backend&) = delete;
     Backend& operator=(const Backend&) = delete;
 
@@ -30,6 +30,8 @@ class Backend {
     };
     LastDestructor firstMember_;
     Preserve preserve;
+
+    Module* module;
     PirJitLLVM jit;
     std::unordered_map<ClosureVersion*, Function*> done;
     StreamLogger& logger;

--- a/rir/src/compiler/compiler.h
+++ b/rir/src/compiler/compiler.h
@@ -42,8 +42,9 @@ class Compiler {
 
     void preserve(SEXP c) { preserve_(c); }
 
-  private:
     Module* module;
+
+  private:
     StreamLogger& logger;
 
     void compileClosure(Closure* closure, rir::Function* optFunction,

--- a/rir/src/compiler/log/stream_logger.cpp
+++ b/rir/src/compiler/log/stream_logger.cpp
@@ -1,6 +1,7 @@
 #include "stream_logger.h"
 #include "compiler/opt/pass.h"
-#include "compiler/pir/pir_impl.h"
+#include "compiler/pir/closure.h"
+#include "compiler/pir/closure_version.h"
 #include "runtime/Function.h"
 #include "utils/Pool.h"
 #include "utils/Terminal.h"

--- a/rir/src/compiler/native/builtins.h
+++ b/rir/src/compiler/native/builtins.h
@@ -110,7 +110,6 @@ struct NativeBuiltins {
         asLogicalBlt,
         length,
         deopt,
-        recordDeopt,
         assertFail,
         printValue,
         extract11,

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -1241,7 +1241,7 @@ void LowerFunctionLLVM::ensureNamedIfNeeded(Instruction* i, llvm::Value* val) {
             } else if (adjust->second == NeedsRefcountAdjustment::EnsureNamed) {
                 if (!val)
                     val = load(i);
-                ensureShared(val);
+                ensureNamed(val);
             }
         }
     }
@@ -3213,7 +3213,7 @@ void LowerFunctionLLVM::compile() {
                             ensureNamed(vn);
                             builder.CreateCondBr(isNamed(vn), isnamed, cont);
                             builder.SetInsertPoint(isnamed);
-                            ensureShared(vn);
+                            ensureNamed(vn);
                             builder.CreateBr(cont);
                             builder.SetInsertPoint(cont);
                         }

--- a/rir/src/compiler/native/lower_function_llvm.h
+++ b/rir/src/compiler/native/lower_function_llvm.h
@@ -188,7 +188,7 @@ class LowerFunctionLLVM {
     void setVariable(Instruction* variable, llvm::Value* val,
                      bool volatile_ = false) {
         // silently drop dead variables...
-        if (!liveness.count(variable))
+        if (variable->type.isVoid() || !liveness.count(variable))
             return;
         assert(liveness.live(currentInstr, variable));
         variables_.at(variable).set(builder, val, volatile_);

--- a/rir/src/compiler/native/lower_function_llvm.h
+++ b/rir/src/compiler/native/lower_function_llvm.h
@@ -23,7 +23,8 @@ namespace rir {
 namespace pir {
 
 typedef std::unordered_map<Code*, std::pair<unsigned, MkArg*>> PromMap;
-struct Representation;
+struct Rep;
+
 class LowerFunctionLLVM {
 
     std::string name;
@@ -228,6 +229,7 @@ class LowerFunctionLLVM {
         return variables_.at(variable).get(builder);
     }
 
+    llvm::Value* constant(SEXP co, const Rep& needed);
     llvm::Value* constant(SEXP co, llvm::Type* needed);
     llvm::Value* nodestackPtr();
     llvm::Value* nodestackPtrAddr = nullptr;
@@ -239,10 +241,10 @@ class LowerFunctionLLVM {
     llvm::Value* withCallFrame(const std::vector<Value*>& args,
                                const std::function<llvm::Value*()>& theCall,
                                bool pop = true);
-    llvm::Value* load(Value* v, Representation r);
+    llvm::Value* load(Value* v, Rep r);
     llvm::Value* load(Value* v);
     llvm::Value* loadSxp(Value* v);
-    llvm::Value* load(Value* val, PirType type, Representation needed);
+    llvm::Value* load(Value* val, PirType type, Rep needed);
     llvm::Value* dataPtr(llvm::Value* v, bool enableAsserts = true);
     llvm::Value* accessVector(llvm::Value* vector, llvm::Value* position,
                               PirType type);

--- a/rir/src/compiler/native/lower_function_llvm_variable.cpp
+++ b/rir/src/compiler/native/lower_function_llvm_variable.cpp
@@ -22,9 +22,9 @@ LowerFunctionLLVM::Variable
 LowerFunctionLLVM::Variable::RVariable(Instruction* i, size_t pos,
                                        llvm::IRBuilder<>& builder,
                                        llvm::Value* basepointer) {
-    assert(i->producesRirResult());
+    assert(i->type.isRType());
     assert(!LdConst::Cast(i));
-    assert(Representation::Of(i) == Representation::Sexp);
+    assert(Rep::Of(i) == Rep::SEXP);
     auto ptr = builder.CreateGEP(basepointer, {c(pos), c(2)});
     ptr->setName(i->getRef());
     return {ImmutableLocalRVariable, ptr, false, pos};
@@ -33,18 +33,20 @@ LowerFunctionLLVM::Variable::RVariable(Instruction* i, size_t pos,
 LowerFunctionLLVM::Variable
 LowerFunctionLLVM::Variable::Mutable(Instruction* i,
                                      llvm::AllocaInst* location) {
-    assert(i->producesRirResult());
-    auto r = Representation::Of(i);
-    assert(r != Representation::Sexp);
+    assert(!i->type.isVoid() && !i->type.isVirtualValue() &&
+           !i->type.isCompositeValue());
+    auto r = Rep::Of(i);
+    assert(r != Rep::SEXP);
     location->setName(i->getRef());
     return {MutablePrimitive, location, false, (size_t)-1};
 }
 
 LowerFunctionLLVM::Variable
 LowerFunctionLLVM::Variable::Immutable(Instruction* i) {
-    assert(i->producesRirResult());
-    auto r = Representation::Of(i);
-    assert(r != Representation::Sexp);
+    assert(!i->type.isVoid() && !i->type.isVirtualValue() &&
+           !i->type.isCompositeValue());
+    auto r = Rep::Of(i);
+    assert(r != Rep::SEXP);
     return {ImmutablePrimitive, nullptr, false, (size_t)-1};
 }
 

--- a/rir/src/compiler/native/representation_llvm.cpp
+++ b/rir/src/compiler/native/representation_llvm.cpp
@@ -4,28 +4,31 @@
 namespace rir {
 namespace pir {
 
-Representation Representation::Of(PirType t) {
+Rep Rep::Of(PirType t) {
     // Combined types like integer|real cannot be unbox, since we do not know
     // how to re-box again.
     if (!t.maybeMissing() && !t.maybePromiseWrapped()) {
+        if (t.isA(NativeType::deoptReason)) {
+            return Rep::DeoptReason;
+        }
         if (t.isA(PirType(RType::logical).simpleScalar().notObject())) {
             assert(t.unboxable());
-            return Representation::Integer;
+            return Rep::i32;
         }
         if (t.isA(PirType(RType::integer).simpleScalar().notObject())) {
             assert(t.unboxable());
-            return Representation::Integer;
+            return Rep::i32;
         }
         if (t.isA(PirType(RType::real).simpleScalar().notObject())) {
             assert(t.unboxable());
-            return Representation::Real;
+            return Rep::f64;
         }
     }
     assert(!t.unboxable());
-    return Representation::Sexp;
+    return Rep::SEXP;
 }
 
-Representation Representation::Of(Value* v) { return Of(v->type); }
+Rep Rep::Of(Value* v) { return Of(v->type); }
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/native/types_llvm.cpp
+++ b/rir/src/compiler/native/types_llvm.cpp
@@ -112,6 +112,7 @@ void initializeTypes(LLVMContext& context) {
     t::DeoptReason = StructType::create(context, "DeoptReason");
     fields = {t::i32, t::i32, t::voidPtr};
     t::DeoptReason->setBody(fields, true);
+    t::DeoptReasonPtr = llvm::PointerType::get(t::DeoptReason, 0);
 
 #define DECLARE(name, ret, ...)                                                \
     fields = {__VA_ARGS__};                                                    \
@@ -176,6 +177,7 @@ StructType* RCNTXT;
 PointerType* RCNTXT_ptr;
 
 StructType* DeoptReason;
+PointerType* DeoptReasonPtr;
 
 Type* t_void;
 Type* voidPtr;

--- a/rir/src/compiler/native/types_llvm.h
+++ b/rir/src/compiler/native/types_llvm.h
@@ -36,6 +36,7 @@ extern llvm::StructType* RirRuntimeObject;
 extern llvm::StructType* LazyEnvironment;
 
 extern llvm::StructType* DeoptReason;
+extern llvm::PointerType* DeoptReasonPtr;
 
 extern llvm::StructType* RCNTXT;
 extern llvm::PointerType* RCNTXT_ptr;

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -320,56 +320,8 @@ bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code,
         if (code->entry == bb)
             return;
 
-        // A Checkpoint where the normal continue branch ends in a deopt is
-        // unnecessary. We remove it by unconditionally going into the deopt
-        // branch.
-        bool uselessCheckpoint = !bb->isEmpty() &&
-                                 Checkpoint::Cast(bb->last()) &&
-                                 bb->nonDeoptSuccessors().size() == 0;
-        std::vector<Instruction*> deoptReason;
-        // We need to preserve the deopt reason from the main branch. To do so
-        // we copy the instruction with all dependencies into the deopt branch.
-        if (uselessCheckpoint) {
-            for (auto i : *bb->trueBranch())
-                if (RecordDeoptReason::Cast(i)) {
-                    std::vector<Instruction*> todo = {i->clone()};
-                    while (!todo.empty()) {
-                        auto d = todo.back();
-                        todo.pop_back();
-                        deoptReason.push_back(d);
-                        d->eachArg([&](InstrArg& arg) {
-                            if (auto j = Instruction::Cast(arg.val()))
-                                if (j->bb() == bb->trueBranch()) {
-                                    auto clone = j->clone();
-                                    arg.val() = clone;
-                                    todo.push_back(clone);
-                                }
-                        });
-                    }
-                }
-        }
-        if (uselessCheckpoint || (bb->isJmp() && bb->hasSinglePred() &&
-                                  bb->next()->hasSinglePred())) {
-            BB* d;
-            if (uselessCheckpoint) {
-                d = bb->deoptBranch();
-                auto dead = bb->trueBranch();
-                assert(dead != d);
-                while (true) {
-                    toDel[dead] = nullptr;
-                    if (dead->successors().size())
-                        dead = dead->next();
-                    else
-                        break;
-                }
-                bb->remove(bb->end() - 1);
-                while (!deoptReason.empty()) {
-                    bb->append(deoptReason.back());
-                    deoptReason.pop_back();
-                }
-            } else {
-                d = bb->next();
-            }
+        if (bb->isJmp() && bb->hasSinglePred() && bb->next()->hasSinglePred()) {
+            BB* d = bb->next();
             while (!d->isEmpty()) {
                 d->moveToEnd(d->begin(), bb);
             }

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -24,7 +24,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
         bool done = false;
         auto apply = [&]() {
             Visitor::run(code->entry, [&](Instruction* i) {
-                if (!i->producesRirResult())
+                if (!i->type.isRType())
                     return;
 
                 auto getType = [&](Value* v) {
@@ -263,7 +263,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
                             }
                         }
                         break;
-                }
+                    }
 
                 default:
                     inferred = i->inferType(getType);
@@ -285,7 +285,7 @@ bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
     }
 
     Visitor::run(code->entry, [&](Instruction* i) {
-        if (!i->producesRirResult())
+        if (!i->type.isRType())
             return;
         if (types.count(i))
             i->type = types.at(i);

--- a/rir/src/compiler/pir/bb.cpp
+++ b/rir/src/compiler/pir/bb.cpp
@@ -103,9 +103,7 @@ void BB::printBBGraph(std::ostream& out, bool omitDeoptBranches) {
     out << "\n";
 }
 
-bool BB::isDeopt() const {
-    return !isEmpty() && (Deopt::Cast(last()) || ScheduledDeopt::Cast(last()));
-}
+bool BB::isDeopt() const { return !isEmpty() && Deopt::Cast(last()); }
 
 bool BB::isEndUnreachable() const {
     return !isEmpty() && (Unreachable::Cast(last()));

--- a/rir/src/compiler/pir/bb.h
+++ b/rir/src/compiler/pir/bb.h
@@ -85,6 +85,11 @@ class BB {
     Instrs::iterator begin() { return instrs.begin(); }
     Instrs::iterator end() { return instrs.end(); }
 
+    Instrs::const_iterator begin() const { return instrs.cbegin(); }
+    Instrs::const_iterator end() const { return instrs.cend(); }
+    Instrs::const_iterator cbegin() const { return instrs.cbegin(); }
+    Instrs::const_iterator cend() const { return instrs.cend(); }
+
     Instrs::reverse_iterator rbegin() { return instrs.rbegin(); }
     Instrs::reverse_iterator rend() { return instrs.rend(); }
 

--- a/rir/src/compiler/pir/builder.cpp
+++ b/rir/src/compiler/pir/builder.cpp
@@ -52,7 +52,6 @@ void Builder::add(Instruction* i) {
     case Tag::_UNUSED_:
         assert(false && "Invalid instruction");
     case Tag::PirCopy:
-    case Tag::ScheduledDeopt:
         assert(false && "This instruction is only allowed during lowering");
     default: {}
     }

--- a/rir/src/compiler/pir/deopt_reason.cpp
+++ b/rir/src/compiler/pir/deopt_reason.cpp
@@ -1,0 +1,19 @@
+#include "deopt_reason.h"
+
+#include "tag.h"
+
+namespace rir {
+namespace pir {
+
+DeoptReasonWrapper::DeoptReasonWrapper(const DeoptReason& r)
+    : Value(NativeType::deoptReason, Tag::DeoptReason), reason(r) {}
+
+void DeoptReasonWrapper::printRef(std::ostream& out) const { out << reason; }
+
+DeoptReasonWrapper* DeoptReasonWrapper::unknown() {
+    static DeoptReasonWrapper instance(DeoptReason::unknown());
+    return &instance;
+}
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/pir/deopt_reason.h
+++ b/rir/src/compiler/pir/deopt_reason.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "runtime/TypeFeedback.h"
+#include "value.h"
+
+namespace rir {
+namespace pir {
+
+class DeoptReasonWrapper : public Value {
+  private:
+    explicit DeoptReasonWrapper(const DeoptReason&);
+    virtual ~DeoptReasonWrapper(){};
+
+  public:
+    const DeoptReason reason;
+    static DeoptReasonWrapper* unknown();
+    void printRef(std::ostream& out) const override final;
+
+    friend class Module;
+};
+
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -92,7 +92,6 @@
     V(Checkpoint)                                                              \
     V(Assume)                                                                  \
     V(Deopt)                                                                   \
-    V(ScheduledDeopt)                                                          \
     V(Force)                                                                   \
     V(CastType)                                                                \
     V(Missing)                                                                 \
@@ -101,7 +100,6 @@
     V(Names)                                                                   \
     V(SetNames)                                                                \
     V(PirCopy)                                                                 \
-    V(RecordDeoptReason)                                                       \
     V(Nop)
 
 #endif

--- a/rir/src/compiler/pir/module.cpp
+++ b/rir/src/compiler/pir/module.cpp
@@ -1,5 +1,8 @@
 #include "module.h"
+
+#include "deopt_reason.h"
 #include "pir_impl.h"
+#include "runtime/TypeFeedback.h"
 
 namespace rir {
 namespace pir {
@@ -67,6 +70,15 @@ Module::~Module() {
         delete e.second;
     for (auto& cs : closures)
         delete cs.second;
+    for (auto dr : deoptReasons)
+        delete dr;
+}
+
+DeoptReasonWrapper* Module::deoptReasonValue(const DeoptReason& reason) {
+    for (auto dr : deoptReasons)
+        if (dr->reason == reason)
+            return dr;
+    return *deoptReasons.emplace(new DeoptReasonWrapper(reason)).first;
 }
 }
 }

--- a/rir/src/compiler/pir/module.h
+++ b/rir/src/compiler/pir/module.h
@@ -14,6 +14,8 @@
 namespace rir {
 namespace pir {
 
+class DeoptReasonWrapper;
+
 class Module {
     std::unordered_map<SEXP, Env*> environments;
 
@@ -33,10 +35,13 @@ class Module {
     void eachPirClosure(PirClosureIterator it);
     void eachPirClosureVersion(PirClosureVersionIterator it);
 
+    DeoptReasonWrapper* deoptReasonValue(const DeoptReason&);
+
     ~Module();
   private:
     typedef std::pair<Function*, Env*> Idx;
     std::map<Idx, Closure*> closures;
+    std::unordered_set<DeoptReasonWrapper*> deoptReasons;
 };
 
 }

--- a/rir/src/compiler/pir/pir_impl.h
+++ b/rir/src/compiler/pir/pir_impl.h
@@ -8,6 +8,7 @@
 #include "bb.h"
 #include "closure.h"
 #include "closure_version.h"
+#include "deopt_reason.h"
 #include "env.h"
 #include "instruction.h"
 #include "module.h"

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -1,6 +1,7 @@
 #ifndef COMPILER_SINGLETON_VALUES_H
 #define COMPILER_SINGLETON_VALUES_H
 
+#include "R/Symbols.h"
 #include "instruction_list.h"
 #include "tag.h"
 #include "value.h"
@@ -108,6 +109,18 @@ class NaLogical : public SingletonValue<NaLogical> {
     friend class SingletonValue;
     NaLogical()
         : SingletonValue(PirType::simpleScalarLogical(), Tag::NaLogical) {}
+};
+
+class UnknownDeoptTrigger : public SingletonValue<UnknownDeoptTrigger> {
+  public:
+    void printRef(std::ostream& out) const override final { out << "unknown"; }
+
+    SEXP asRValue() const override final { return symbol::UnknownDeoptTrigger; }
+
+  private:
+    friend class SingletonValue;
+    UnknownDeoptTrigger()
+        : SingletonValue(RType::sym, Tag::UnknownDeoptTrigger) {}
 };
 
 class Tombstone : public Value {

--- a/rir/src/compiler/pir/value.cpp
+++ b/rir/src/compiler/pir/value.cpp
@@ -1,6 +1,7 @@
 #include "value.h"
 #include "instruction.h"
 #include "pir_impl.h"
+#include <unordered_map>
 
 namespace rir {
 namespace pir {

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -43,10 +43,6 @@ class Value {
         return nullptr;
     }
 
-    bool producesRirResult() const {
-        return type != PirType::voyd() && type.isRType();
-    }
-
     static constexpr int MAX_REFCOUNT = 2;
 
     virtual int minReferenceCount() const {
@@ -55,7 +51,6 @@ class Value {
 
     void callArgTypeToContext(Context&, unsigned arg) const;
 };
-
 static_assert(sizeof(Value) <= 16, "");
 
 } // namespace pir

--- a/rir/src/compiler/pir/value_list.h
+++ b/rir/src/compiler/pir/value_list.h
@@ -6,10 +6,12 @@
     V(False)                                                                   \
     V(OpaqueTrue)                                                              \
     V(NaLogical)                                                               \
+    V(UnknownDeoptTrigger)                                                     \
     V(Tombstone)                                                               \
     V(MissingArg)                                                              \
     V(UnboundValue)                                                            \
     V(Env)                                                                     \
-    V(Nil)
+    V(Nil)                                                                     \
+    V(DeoptReason)
 
 #endif

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -568,8 +568,9 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             DeoptReason reason = DeoptReason(FeedbackOrigin(srcCode, pos),
                                              DeoptReason::DeadCall);
 
-            insert(new RecordDeoptReason(reason, target));
-            insert(new Deopt(sp));
+            auto d = insert(new Deopt(sp));
+            d->setDeoptReason(compiler.module->deoptReasonValue(reason),
+                              target);
             stack.clear();
         } else {
             std::get<ObservedCallees>(callTargetFeedback[target]) =

--- a/rir/src/compiler/util/bb_transform.h
+++ b/rir/src/compiler/util/bb_transform.h
@@ -2,6 +2,7 @@
 #define BB_TRANSFORM_H
 
 #include "../pir/bb.h"
+#include "../pir/deopt_reason.h"
 #include "../pir/pir.h"
 #include "compiler/analysis/cfg.h"
 #include "runtime/TypeFeedback.h"
@@ -25,7 +26,7 @@ class BBTransform {
                      Code* target);
     static Value* forInline(BB* inlinee, BB* cont, Value* context,
                             Checkpoint* entryCp);
-    static BB* lowerExpect(Code* closure, BB* src,
+    static BB* lowerExpect(Module* m, Code* closure, BB* src,
                            BB::Instrs::iterator position, Assume* assume,
                            bool condition, BB* deoptBlock,
                            const std::string& debugMesage,

--- a/rir/src/compiler/util/lowering/allocators.h
+++ b/rir/src/compiler/util/lowering/allocators.h
@@ -61,9 +61,7 @@ class SSAAllocator {
         computed = true;
     }
 
-    virtual bool needsASlot(Value* val) const {
-        return val->producesRirResult();
-    }
+    virtual bool needsASlot(Value* val) const { return val->type.isRType(); }
 
     virtual bool interfere(Instruction* i, Instruction* j) const {
         return livenessIntervals.interfere(i, j);

--- a/rir/src/compiler/util/visitor.h
+++ b/rir/src/compiler/util/visitor.h
@@ -275,7 +275,7 @@ class VisitorImplementation {
                     return;
                 if (ORDER == Order::Lowering) {
                     bool deoptBranch =
-                        !bb->isEmpty() && ScheduledDeopt::Cast(bb->last());
+                        !bb->isEmpty() && Deopt::Cast(bb->last());
                     bool returnBranch =
                         !bb->isEmpty() && (NonLocalReturn::Cast(bb->last()) ||
                                            Return::Cast(bb->last()));

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -521,10 +521,11 @@ void checkUserInterrupt() {
 }
 
 void recordDeoptReason(SEXP val, const DeoptReason& reason) {
-
     auto pos = reason.pc();
 
     switch (reason.reason) {
+    case DeoptReason::Unknown:
+        break;
     case DeoptReason::DeadBranchReached: {
         assert(*pos == Opcode::record_test_);
         ObservedTest* feedback = (ObservedTest*)(pos + 1);
@@ -533,6 +534,8 @@ void recordDeoptReason(SEXP val, const DeoptReason& reason) {
     }
     case DeoptReason::Typecheck: {
         assert(*pos == Opcode::record_type_);
+        if (val == symbol::UnknownDeoptTrigger)
+            break;
         ObservedValues* feedback = (ObservedValues*)(pos + 1);
         feedback->record(val);
         if (TYPEOF(val) == PROMSXP) {
@@ -552,6 +555,8 @@ void recordDeoptReason(SEXP val, const DeoptReason& reason) {
         [[clang::fallthrough]];
     case DeoptReason::Calltarget: {
         assert(*pos == Opcode::record_call_);
+        if (val == symbol::UnknownDeoptTrigger)
+            break;
         ObservedCallees* feedback = (ObservedCallees*)(pos + 1);
         feedback->record(reason.srcCode(), val);
         assert(feedback->taken > 0);

--- a/rir/src/runtime/TypeFeedback.cpp
+++ b/rir/src/runtime/TypeFeedback.cpp
@@ -28,10 +28,11 @@ SEXP ObservedCallees::getTarget(const Code* code, size_t pos) const {
 
 FeedbackOrigin::FeedbackOrigin(rir::Code* src, Opcode* p)
     : offset_((uintptr_t)p - (uintptr_t)src), srcCode_(src) {
-    assert(p);
-    assert(p >= src->code());
-    assert(p < src->endCode());
-    assert(pc() == p);
+    if (p) {
+        assert(p >= src->code());
+        assert(p < src->endCode());
+        assert(pc() == p);
+    }
 }
 
 DeoptReason::DeoptReason(const FeedbackOrigin& origin,
@@ -48,6 +49,7 @@ DeoptReason::DeoptReason(const FeedbackOrigin& origin,
                o == Opcode::record_test_);
         break;
     }
+    case DeoptReason::Unknown:
     case DeoptReason::EnvStubMaterialized:
         break;
     }


### PR DESCRIPTION
This PR is a preparation to more intelligent deopts. For that we remove
the RecordDeoptReason instruction. Instead the deopt reason becomes a
PIR value that can be passed around and passed to the deopt instruction.

Also this patch removes ScheduledDeopt in favor of just handling the
normal Deopt instruction in the backend. To that end some better
handling of value liveness was needed.

While refactoring I also got rid of automatic conversion between
Representation and llvm::Type. This makes some code less confusing.