### PR TITLE
Extend support for stub environments

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -388,11 +388,22 @@ class TheVerifier {
         }
 
         static std::unordered_set<Tag> allowStub{
-            Tag::LdVar,     Tag::Force,          Tag::PushContext,
-            Tag::StVar,     Tag::StVarSuper,     Tag::FrameState,
-            Tag::IsEnvStub, Tag::MaterializeEnv, Tag::CallBuiltin,
-            Tag::Call,      Tag::NamedCall,      Tag::StaticCall,
-            Tag::MkArg};
+            Tag::LdVar,       Tag::Force,
+            Tag::PushContext, Tag::StVar,
+            Tag::StVarSuper,  Tag::FrameState,
+            Tag::IsEnvStub,   Tag::MaterializeEnv,
+            Tag::CallBuiltin, Tag::Call,
+            Tag::NamedCall,   Tag::StaticCall,
+            Tag::MkArg,       Tag::Add,
+            Tag::Sub,         Tag::Mul,
+            Tag::IDiv,        Tag::Div,
+            Tag::Eq,          Tag::Neq,
+            Tag::Gt,          Tag::Lt,
+            Tag::Lte,         Tag::Gte,
+            Tag::LAnd,        Tag::LOr,
+            Tag::Colon,       Tag::Mod,
+            Tag::Pow,         Tag::Minus,
+            Tag::Plus,        Tag::Missing};
         if (i->hasEnv() && !allowStub.count(i->tag)) {
             auto env = MkEnv::Cast(i->env());
             if (env && env->stub) {

--- a/rir/src/compiler/compiler.cpp
+++ b/rir/src/compiler/compiler.cpp
@@ -281,7 +281,8 @@ static void findUnreachable(Module* m, StreamLogger& log) {
 void Compiler::optimizeModule() {
     logger.flush();
     size_t passnr = 0;
-    PassScheduler::instance().run([&](const Pass* translation) {
+    PassScheduler::instance().run([&](const Pass* translation,
+                                      size_t iteration) {
         bool changed = false;
         if (translation->isSlow()) {
             if (MEASURE_COMPILER_PERF)
@@ -299,7 +300,7 @@ void Compiler::optimizeModule() {
                     Measuring::startTimer("compiler.cpp: " +
                                           translation->getName());
 
-                if (translation->apply(*this, v, log.out()))
+                if (translation->apply(*this, v, log.out(), iteration))
                     changed = true;
                 if (MEASURE_COMPILER_PERF)
                     Measuring::countTimer("compiler.cpp: " +

--- a/rir/src/compiler/opt/assumptions.cpp
+++ b/rir/src/compiler/opt/assumptions.cpp
@@ -185,7 +185,7 @@ struct AvailableAssumptions
 };
 
 bool OptimizeAssumptions::apply(Compiler&, ClosureVersion* vers, Code* code,
-                                LogStream& log) const {
+                                LogStream& log, size_t) const {
     {
         Visitor::run(code->entry, [&](BB* bb) {
             if (bb->isBranch()) {

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -14,8 +14,8 @@
 namespace rir {
 namespace pir {
 
-bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code,
-                    LogStream&) const {
+bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
+                    size_t) const {
     std::unordered_set<size_t> usedProms;
     std::unordered_map<BB*, std::unordered_set<Phi*>> usedBB;
     std::deque<Promise*> todoUsedProms;

--- a/rir/src/compiler/opt/cleanup_checkpoints.cpp
+++ b/rir/src/compiler/opt/cleanup_checkpoints.cpp
@@ -7,7 +7,7 @@ namespace rir {
 namespace pir {
 
 bool CleanupCheckpoints::apply(Compiler&, ClosureVersion* cls, Code* code,
-                               LogStream&) const {
+                               LogStream&, size_t) const {
     bool anyChange = false;
     std::unordered_set<Checkpoint*> used;
     Visitor::run(code->entry, [&](Instruction* i) {

--- a/rir/src/compiler/opt/cleanup_framestate.cpp
+++ b/rir/src/compiler/opt/cleanup_framestate.cpp
@@ -7,7 +7,7 @@ namespace rir {
 namespace pir {
 
 bool CleanupFramestate::apply(Compiler&, ClosureVersion* function, Code* code,
-                              LogStream&) const {
+                              LogStream&, size_t) const {
     bool anyChange = false;
     Visitor::run(code->entry, [&](Instruction* i) {
         if (!Deopt::Cast(i) && i->frameState()) {

--- a/rir/src/compiler/opt/constantfold.cpp
+++ b/rir/src/compiler/opt/constantfold.cpp
@@ -152,9 +152,9 @@ static bool isStaticallyNA(Value* i) {
 }
 
 bool Constantfold::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                         LogStream& log) const {
+                         LogStream& log, size_t iteration) const {
     EarlyConstantfold cf;
-    cf.apply(cmp, cls, code, log);
+    cf.apply(cmp, cls, code, log, iteration);
 
     bool anyChange = false;
 

--- a/rir/src/compiler/opt/context.cpp
+++ b/rir/src/compiler/opt/context.cpp
@@ -13,7 +13,7 @@ namespace rir {
 namespace pir {
 
 bool OptimizeContexts::apply(Compiler&, ClosureVersion* cls, Code* code,
-                             LogStream& log) const {
+                             LogStream& log, size_t) const {
     bool anyChange = false;
     Visitor::run(code->entry, [&](BB* bb) {
         for (auto it = bb->begin(); it != bb->end(); ++it) {

--- a/rir/src/compiler/opt/dead_store_removal.cpp
+++ b/rir/src/compiler/opt/dead_store_removal.cpp
@@ -5,7 +5,7 @@ namespace rir {
 namespace pir {
 
 bool DeadStoreRemoval::apply(Compiler&, ClosureVersion* cls, Code* code,
-                             LogStream& log) const {
+                             LogStream& log, size_t) const {
     bool noStores = Visitor::check(
         code->entry, [&](Instruction* i) { return !StVar::Cast(i); });
     if (noStores)

--- a/rir/src/compiler/opt/delay_env.cpp
+++ b/rir/src/compiler/opt/delay_env.cpp
@@ -8,8 +8,8 @@
 namespace rir {
 namespace pir {
 
-bool DelayEnv::apply(Compiler&, ClosureVersion* cls, Code* code,
-                     LogStream&) const {
+bool DelayEnv::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
+                     size_t) const {
     bool anyChange = false;
     Visitor::run(code->entry, [&](BB* bb) {
         std::unordered_set<MkEnv*> done;

--- a/rir/src/compiler/opt/delay_instr.cpp
+++ b/rir/src/compiler/opt/delay_instr.cpp
@@ -7,8 +7,8 @@
 namespace rir {
 namespace pir {
 
-bool DelayInstr::apply(Compiler&, ClosureVersion* cls, Code* code,
-                       LogStream&) const {
+bool DelayInstr::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
+                       size_t) const {
     bool anyChange = false;
 
     auto isTarget = [](Instruction* j) {

--- a/rir/src/compiler/opt/dots.cpp
+++ b/rir/src/compiler/opt/dots.cpp
@@ -15,7 +15,7 @@ namespace pir {
 
 // Search for ExpandDots(Dotlist(...)) pairs and statically expand them
 bool DotDotDots::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                       LogStream& log) const {
+                       LogStream& log, size_t) const {
     bool anyChange = false;
     Visitor::run(code->entry, [&](BB* bb) {
         auto ip = bb->begin();

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -16,7 +16,7 @@ namespace rir {
 namespace pir {
 
 bool EagerCalls::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                       LogStream& log) const {
+                       LogStream& log, size_t) const {
     AvailableCheckpoints checkpoint(cls, code, log);
 
     struct Speculation {

--- a/rir/src/compiler/opt/early_constantfold.cpp
+++ b/rir/src/compiler/opt/early_constantfold.cpp
@@ -53,7 +53,7 @@ static long isStaticForceAndCall(Call* call) {
 }
 
 bool EarlyConstantfold::apply(Compiler&, ClosureVersion* cls, Code* code,
-                              LogStream&) const {
+                              LogStream&, size_t) const {
     bool anyChange = false;
 
     Visitor::run(code->entry, [&](BB* bb) {

--- a/rir/src/compiler/opt/elide_env.cpp
+++ b/rir/src/compiler/opt/elide_env.cpp
@@ -10,8 +10,8 @@
 namespace rir {
 namespace pir {
 
-bool ElideEnv::apply(Compiler&, ClosureVersion* cls, Code* code,
-                     LogStream&) const {
+bool ElideEnv::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
+                     size_t) const {
     bool anyChange = false;
     std::unordered_set<Value*> envNeeded;
     std::unordered_map<Value*, Value*> envDependency;
@@ -33,7 +33,7 @@ bool ElideEnv::apply(Compiler&, ClosureVersion* cls, Code* code,
                 }
 
                 if (envIsNeeded) {
-                    if (!StVar::Cast(i))
+                    if (!StVar::Cast(i) && !IsEnvStub::Cast(i))
                         envNeeded.insert(i->env());
                     if (!Env::isPirEnv(i))
                         envDependency[i] = i->env();

--- a/rir/src/compiler/opt/elide_env_spec.cpp
+++ b/rir/src/compiler/opt/elide_env_spec.cpp
@@ -146,15 +146,20 @@ bool ElideEnvSpec::apply(Compiler&, ClosureVersion* cls, Code* code,
     static constexpr auto allowed = {
         Tag::Force,      Tag::PushContext, Tag::LdVar,      Tag::StVar,
         Tag::StVarSuper, Tag::Call,        Tag::FrameState, Tag::CallBuiltin,
-        Tag::StaticCall, Tag::LdDots};
-    static constexpr auto allowedInProm = {Tag::LdVar, Tag::StVar,
-                                           Tag::StVarSuper, Tag::LdDots};
+        Tag::StaticCall, Tag::LdDots,      Tag::Add,        Tag::Sub,
+        Tag::Mul,        Tag::IDiv,        Tag::Div,        Tag::Eq,
+        Tag::Neq,        Tag::Gt,          Tag::Lt,         Tag::Lte,
+        Tag::Gte,        Tag::LAnd,        Tag::LOr,        Tag::Colon,
+        Tag::Mod,        Tag::Pow,         Tag::Minus,      Tag::Plus,
+        Tag::Missing};
+    static constexpr auto allowedInProm = {
+        Tag::LdVar, Tag::StVar, Tag::StVarSuper, Tag::LdDots, Tag::FrameState};
     // Those do not materialize the stub in any case. PushContext doesn't
     // materialize itself but it makes the environment accessible, so it's
     // not on this list.
-    static constexpr auto dontMaterialize = {Tag::LdVar,      Tag::StVar,
-                                             Tag::StVarSuper, Tag::FrameState,
-                                             Tag::IsEnvStub,  Tag::LdDots};
+    static constexpr auto dontMaterialize = {
+        Tag::LdVar,     Tag::StVar,  Tag::StVarSuper, Tag::FrameState,
+        Tag::IsEnvStub, Tag::LdDots, Tag::Missing};
     VisitorNoDeoptBranch::run(code->entry, [&](Instruction* i) {
         i->eachArg([&](Value* val) {
             if (auto m = MkEnv::Cast(val)) {

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -40,7 +40,7 @@ namespace pir {
  */
 
 bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
-                           LogStream& log) const {
+                           LogStream& log, size_t) const {
     bool anyChange = false;
 
     // Do this first so dead code elimination will remove the dependencies

--- a/rir/src/compiler/opt/gvn.cpp
+++ b/rir/src/compiler/opt/gvn.cpp
@@ -10,8 +10,8 @@
 namespace rir {
 namespace pir {
 
-bool GVN::apply(Compiler&, ClosureVersion* cls, Code* code,
-                LogStream& log) const {
+bool GVN::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream& log,
+                size_t) const {
     std::unordered_map<size_t, SmallSet<Value*>> reverseNumber;
     std::unordered_map<Value*, size_t> number;
     {

--- a/rir/src/compiler/opt/hoist_instruction.cpp
+++ b/rir/src/compiler/opt/hoist_instruction.cpp
@@ -13,7 +13,7 @@ namespace rir {
 namespace pir {
 
 bool HoistInstruction::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                             LogStream& log) const {
+                             LogStream& log, size_t) const {
     bool anyChange = false;
     DominanceGraph dom(code);
     ContextStack cs(cls, code, log);

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -21,7 +21,7 @@ namespace rir {
 namespace pir {
 
 bool Inline::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                   LogStream& log) const {
+                   LogStream& log, size_t) const {
     bool anyChange = false;
     size_t fuel = Parameter::INLINER_INITIAL_FUEL;
 

--- a/rir/src/compiler/opt/inline_force_prom.cpp
+++ b/rir/src/compiler/opt/inline_force_prom.cpp
@@ -25,7 +25,7 @@ namespace rir {
 namespace pir {
 
 bool InlineForcePromises::apply(Compiler&, ClosureVersion* cls, Code* code,
-                                LogStream& log) const {
+                                LogStream& log, size_t) const {
 
     bool anyChange = false;
 

--- a/rir/src/compiler/opt/load_elision.cpp
+++ b/rir/src/compiler/opt/load_elision.cpp
@@ -92,7 +92,7 @@ struct AvailableLoads : public StaticAnalysis<IntersectionSet<ALoad>> {
 };
 
 bool LoadElision::apply(Compiler&, ClosureVersion* cls, Code* code,
-                        LogStream& log) const {
+                        LogStream& log, size_t) const {
     AvailableLoads loads(cls, code, log);
     bool anyChange = false;
 

--- a/rir/src/compiler/opt/loop_invariant.cpp
+++ b/rir/src/compiler/opt/loop_invariant.cpp
@@ -144,7 +144,7 @@ static bool replaceWithOuterLoopEquivalent(Instruction* instruction,
 }
 
 bool LoopInvariant::apply(Compiler&, ClosureVersion* cls, Code* code,
-                          LogStream& log) const {
+                          LogStream& log, size_t) const {
     LoopDetection loops(code);
     bool anyChange = false;
 

--- a/rir/src/compiler/opt/match_call_args.cpp
+++ b/rir/src/compiler/opt/match_call_args.cpp
@@ -15,7 +15,7 @@ namespace pir {
 
 // Try to match callsite arguments to formals
 bool MatchCallArgs::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                          LogStream& log) const {
+                          LogStream& log, size_t) const {
     bool anyChange = false;
     Visitor::run(code->entry, [&](BB* bb) {
         auto ip = bb->begin();

--- a/rir/src/compiler/opt/overflow.cpp
+++ b/rir/src/compiler/opt/overflow.cpp
@@ -7,8 +7,8 @@
 namespace rir {
 namespace pir {
 
-bool Overflow::apply(Compiler&, ClosureVersion* cls, Code* code,
-                     LogStream&) const {
+bool Overflow::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
+                     size_t) const {
     UsesTree uses(code);
 
     auto willDefinitelyNotOverflow = [&](Instruction* instr) {

--- a/rir/src/compiler/opt/pass.cpp
+++ b/rir/src/compiler/opt/pass.cpp
@@ -5,12 +5,13 @@
 namespace rir {
 namespace pir {
 
-bool Pass::apply(Compiler& cmp, ClosureVersion* function,
-                 LogStream& log) const {
-    bool res = apply(cmp, function, function, log);
+bool Pass::apply(Compiler& cmp, ClosureVersion* function, LogStream& log,
+                 size_t iteration) const {
+    bool res = apply(cmp, function, function, log, iteration);
     if (runOnPromises()) {
-        function->eachPromise(
-            [&](Promise* p) { res = apply(cmp, function, p, log) && res; });
+        function->eachPromise([&](Promise* p) {
+            res = apply(cmp, function, p, log, iteration) && res;
+        });
     }
     changedAnything_ = res;
     return res;

--- a/rir/src/compiler/opt/pass.h
+++ b/rir/src/compiler/opt/pass.h
@@ -17,9 +17,10 @@ class Pass {
     virtual bool runOnPromises() const { return false; }
     virtual bool isSlow() const { return false; }
 
-    bool apply(Compiler& cmp, ClosureVersion* function, LogStream& log) const;
-    virtual bool apply(Compiler& cmp, ClosureVersion*, Code*,
-                       LogStream&) const = 0;
+    bool apply(Compiler& cmp, ClosureVersion* function, LogStream& log,
+               size_t iteration) const;
+    virtual bool apply(Compiler& cmp, ClosureVersion*, Code*, LogStream&,
+                       size_t iteration) const = 0;
 
     std::string getName() const { return this->name; }
     bool changedAnything() const { return changedAnything_; }

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -16,7 +16,7 @@ class Closure;
       public:                                                                  \
         name() : Pass(#name){};                                                \
         bool apply(Compiler& cmp, ClosureVersion* function, Code* code,        \
-                   LogStream& log) const final override;                       \
+                   LogStream& log, size_t iteration) const final override;     \
         bool runOnPromises() const final override {                            \
             return __runOnPromises__;                                          \
         }                                                                      \
@@ -165,8 +165,8 @@ class PASS(HoistInstruction, false, false);
 class PhaseMarker : public Pass {
   public:
     explicit PhaseMarker(const std::string& name) : Pass(name) {}
-    bool apply(Compiler&, ClosureVersion*, Code*,
-               LogStream&) const final override {
+    bool apply(Compiler&, ClosureVersion*, Code*, LogStream&,
+               size_t) const final override {
         return false;
     }
     bool isPhaseMarker() const final override { return true; }

--- a/rir/src/compiler/opt/pass_scheduler.h
+++ b/rir/src/compiler/opt/pass_scheduler.h
@@ -30,10 +30,11 @@ class PassScheduler {
         return i;
     }
 
-    void run(const std::function<bool(const Pass*)>& apply) const {
+    void run(const std::function<bool(const Pass*, size_t)>& apply) const {
         for (auto& phase : schedule_.phases) {
             auto budget = phase.budget;
             bool changed = false;
+            int iteration = 0;
             do {
                 changed = false;
                 for (auto& pass : phase.passes) {
@@ -44,10 +45,11 @@ class PassScheduler {
                         }
                         budget -= pass->cost();
                     }
-                    if (apply(pass.get())) {
+                    if (apply(pass.get(), iteration)) {
                         changed = true;
                     }
                 }
+                iteration++;
             } while (changed && budget && !phase.once);
         }
     }

--- a/rir/src/compiler/opt/promise_splitter.cpp
+++ b/rir/src/compiler/opt/promise_splitter.cpp
@@ -9,7 +9,7 @@ namespace rir {
 namespace pir {
 
 bool PromiseSplitter::apply(Compiler&, ClosureVersion* cls, Code* code,
-                            LogStream&) const {
+                            LogStream&, size_t) const {
 
     bool anyChange = false;
     SmallSet<CastType*> candidates;

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -95,7 +95,7 @@ namespace rir {
 namespace pir {
 
 bool ScopeResolution::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
-                            LogStream& log) const {
+                            LogStream& log, size_t) const {
 
     DominanceGraph dom(code);
     DominanceFrontier dfront(code, dom);

--- a/rir/src/compiler/opt/type_speculation.cpp
+++ b/rir/src/compiler/opt/type_speculation.cpp
@@ -14,7 +14,7 @@ namespace rir {
 namespace pir {
 
 bool TypeSpeculation::apply(Compiler&, ClosureVersion* cls, Code* code,
-                            LogStream& log) const {
+                            LogStream& log, size_t) const {
 
     AvailableCheckpoints checkpoint(cls, code, log);
     DeadInstructions maybeUsedUnboxed(code, 1, Effects::Any(),

--- a/rir/src/compiler/opt/types.cpp
+++ b/rir/src/compiler/opt/types.cpp
@@ -15,7 +15,7 @@ namespace rir {
 namespace pir {
 
 bool TypeInference::apply(Compiler&, ClosureVersion* cls, Code* code,
-                          LogStream& log) const {
+                          LogStream& log, size_t) const {
 
     RangeAnalysis rangeAnalysis(cls, code, log);
 

--- a/rir/src/compiler/opt/visibility.cpp
+++ b/rir/src/compiler/opt/visibility.cpp
@@ -13,7 +13,7 @@ namespace rir {
 namespace pir {
 
 bool OptimizeVisibility::apply(Compiler&, ClosureVersion* cls, Code* code,
-                               LogStream& log) const {
+                               LogStream& log, size_t) const {
     VisibilityAnalysis visible(cls, code, log);
 
     bool anyChange = false;

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -1672,11 +1672,11 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert) {
     if (!inPromise()) {
         // EarlyConstantfold is used to expand specials such as forceAndCall
         // which can be expressed in PIR.
-        ecf.apply(compiler, cls, insert.code, log.out());
+        ecf.apply(compiler, cls, insert.code, log.out(), 0);
         // This early pass of scope resolution helps to find local call targets
         // and thus leads to better assumptions in the delayed compilation
         // below.
-        sr.apply(compiler, cls, insert.code, log.out());
+        sr.apply(compiler, cls, insert.code, log.out(), 0);
     }
 
     if (auto last = insert.getCurrentBB()) {

--- a/rir/src/runtime/LazyEnvironment.cpp
+++ b/rir/src/runtime/LazyEnvironment.cpp
@@ -6,7 +6,10 @@ namespace rir {
 size_t LazyEnvironment::getArgIdx(SEXP n) {
     size_t i = 0;
     while (i < nargs) {
-        if (Pool::get(names[i]) == n)
+        auto name = Pool::get(names[i]);
+        if (TYPEOF(name) == LISTSXP)
+            name = CAR(name);
+        if (name == n)
             break;
         i++;
     }

--- a/rir/src/runtime/LazyEnvironment.cpp
+++ b/rir/src/runtime/LazyEnvironment.cpp
@@ -24,6 +24,11 @@ bool LazyEnvironment::isMissing(SEXP n) {
     auto i = getArgIdx(n);
     if (i == nargs)
         return false;
+    return isMissing(i);
+}
+
+bool LazyEnvironment::isMissing(size_t i) {
+    assert(i < nargs);
     return missing[i] || getArg(i) == R_MissingArg;
 }
 

--- a/rir/src/runtime/LazyEnvironment.h
+++ b/rir/src/runtime/LazyEnvironment.h
@@ -46,6 +46,7 @@ struct LazyEnvironment
     }
     SEXP getArg(SEXP n);
     bool isMissing(SEXP n);
+    bool isMissing(size_t i);
     size_t getArgIdx(SEXP n);
 
     SEXP getParent() { return getEntry(1); }


### PR DESCRIPTION
Support for stub environments in more instructions. Mainly in binops/unops and the `missing` instruction. This also fixes a bug in missingness implementation in native, when a missing argument does not set the missing flag in the stub environment. Also I had to tweak the heuristics when to stub, to not block optimizations. We'll see how that goes...