### PR TITLE
non-speculative stubbing in normal elide-env pass

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -3,6 +3,7 @@
 #include "../pir/pir_impl.h"
 #include "../util/visitor.h"
 #include "compiler/analysis/cfg.h"
+#include "compiler/util/env_stub_info.h"
 
 /*
  * When does the verifier run, and is it the fast or slow version?
@@ -387,24 +388,7 @@ class TheVerifier {
             } while (fs);
         }
 
-        static std::unordered_set<Tag> allowStub{
-            Tag::LdVar,       Tag::Force,
-            Tag::PushContext, Tag::StVar,
-            Tag::StVarSuper,  Tag::FrameState,
-            Tag::IsEnvStub,   Tag::MaterializeEnv,
-            Tag::CallBuiltin, Tag::Call,
-            Tag::NamedCall,   Tag::StaticCall,
-            Tag::MkArg,       Tag::Add,
-            Tag::Sub,         Tag::Mul,
-            Tag::IDiv,        Tag::Div,
-            Tag::Eq,          Tag::Neq,
-            Tag::Gt,          Tag::Lt,
-            Tag::Lte,         Tag::Gte,
-            Tag::LAnd,        Tag::LOr,
-            Tag::Colon,       Tag::Mod,
-            Tag::Pow,         Tag::Minus,
-            Tag::Plus,        Tag::Missing};
-        if (i->hasEnv() && !allowStub.count(i->tag)) {
+        if (i->hasEnv() && !EnvStubInfo::of(i->tag).allowed) {
             auto env = MkEnv::Cast(i->env());
             if (env && env->stub) {
                 std::cerr << "Error at instruction '";

--- a/rir/src/compiler/opt/dots.cpp
+++ b/rir/src/compiler/opt/dots.cpp
@@ -115,6 +115,10 @@ bool DotDotDots::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                             auto nc =
                                 new NamedCall(i->env(), c->cls(), args, names,
                                               c->frameStateOrTs(), i->srcIdx);
+                            // TODO: stub envs not supported in named calls,
+                            // needs to be added
+                            if (auto e = MkEnv::Cast(i->env()))
+                                e->stub = false;
                             i->replaceUsesAndSwapWith(nc, ip);
                         } else if (auto c = NamedCall::Cast(i)) {
                             auto nc =

--- a/rir/src/compiler/util/env_stub_info.cpp
+++ b/rir/src/compiler/util/env_stub_info.cpp
@@ -1,0 +1,43 @@
+#include "env_stub_info.h"
+#include <algorithm>
+#include <cassert>
+
+namespace rir {
+namespace pir {
+// If we only see these (and call instructions) then we stub an environment,
+// since it can only be accessed reflectively.
+// These are only stubbed on the second try, since they seem to be better
+// covered by type speculation pass.
+static constexpr auto allowed = {
+    Tag::Force,         Tag::PushContext, Tag::LdVar,      Tag::StVar,
+    Tag::StVarSuper,    Tag::Call,        Tag::FrameState, Tag::CallBuiltin,
+    Tag::StaticCall,    Tag::LdDots,      Tag::Missing,    Tag::IsEnvStub,
+    Tag::MaterializeEnv};
+static constexpr auto allowedExtra = {
+    Tag::Add, Tag::Sub,   Tag::Mul, Tag::IDiv, Tag::Div,   Tag::Eq,
+    Tag::Neq, Tag::Gt,    Tag::Lt,  Tag::Lte,  Tag::Gte,   Tag::LAnd,
+    Tag::LOr, Tag::Colon, Tag::Mod, Tag::Pow,  Tag::Minus, Tag::Plus,
+};
+static constexpr auto allowedInProm = {Tag::LdVar, Tag::StVar, Tag::StVarSuper,
+                                       Tag::LdDots, Tag::FrameState};
+// Those do not materialize the stub in any case. PushContext doesn't
+// materialize itself but it makes the environment accessible, so it's
+// not on this list.
+static constexpr auto dontMaterialize = {
+    Tag::LdVar,     Tag::StVar,  Tag::StVarSuper, Tag::FrameState,
+    Tag::IsEnvStub, Tag::LdDots, Tag::Missing};
+
+EnvStubInfo::Status EnvStubInfo::of(Tag t) {
+    auto a1 = std::find(allowed.begin(), allowed.end(), t) != allowed.end();
+    auto a2 = std::find(allowedExtra.begin(), allowedExtra.end(), t) !=
+              allowedExtra.end();
+    auto p = std::find(allowedInProm.begin(), allowedInProm.end(), t) !=
+             allowedInProm.end();
+    assert(!p || (a1 || a2));
+    auto m = std::find(dontMaterialize.begin(), dontMaterialize.end(), t) !=
+             dontMaterialize.end();
+    assert(!m || (a1 || a2));
+    return {a1 || a2, (unsigned)(a1 ? 0 : (a2 ? 1 : 2)), p, m};
+}
+} // namespace pir
+} // namespace rir

--- a/rir/src/compiler/util/env_stub_info.h
+++ b/rir/src/compiler/util/env_stub_info.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "compiler/pir/tag.h"
+
+#include <initializer_list>
+
+namespace rir {
+namespace pir {
+
+struct EnvStubInfo {
+  public:
+    struct Status {
+        bool allowed;
+        unsigned priority;
+        bool allowedInPromise;
+        bool allowedNotMaterializing;
+    };
+    static Status of(Tag);
+};
+
+} // namespace pir
+} // namespace rir


### PR DESCRIPTION
If all uses of an environment tolerate stubbing we can enable it without
going through the much more complicated elide-env-spec pass.