### PR TITLE
fix DEBUG_DEOPTS flag

### DIFF
--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -2316,7 +2316,7 @@ void LowerFunctionLLVM::compile() {
 
             case Tag::CastType: {
                 auto in = i->arg(0).val();
-                if (Const::Cast(i->followCasts()) || deadMove(in, i))
+                if (!variables_.count(i))
                     break;
                 setVal(i, load(in, i->type, Rep::Of(i)));
                 break;


### PR DESCRIPTION
liveness of CastType with const arg depends on usage. Needs a variable
when phi input.