### PR TITLE
Don't disable denoise anymore

### DIFF
--- a/container/benchmark/Dockerfile
+++ b/container/benchmark/Dockerfile
@@ -4,5 +4,4 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip sudo && \
     apt-get clean && rm -rf /var/cache/apt/lists && \
     git clone --depth 1 https://github.com/smarr/ReBench.git /opt/ReBench && cd /opt/ReBench && pip3 install . && \
-    mv /usr/local/bin/rebench-denoise /usr/local/bin/rebench-denoise.bkp && cp /usr/bin/false /usr/local/bin/rebench-denoise && \
     git clone --depth 10 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking && cd /opt/rbenchmarking && git checkout 5977a8ab19d193eb4be262cdcd3ba375e5d436fd


### PR DESCRIPTION
Currently denoise does not make rebench hard-fail anymore. So there is no need to disable it.