### PR TITLE
fix upcast in inliner for missing arg

### DIFF
--- a/rir/src/compiler/analysis/verifier.cpp
+++ b/rir/src/compiler/analysis/verifier.cpp
@@ -297,6 +297,15 @@ class TheVerifier {
             }
         }
 
+        if (auto ct = CastType::Cast(i)) {
+            if (ct->type.isVoid()) {
+                std::cerr << "PIR Verifier: Broken cast at ";
+                i->printRef(std::cerr);
+                std::cerr << "\n";
+                ok = false;
+            }
+        }
+
         if (i->branchOrExit())
             if (i != bb->last()) {
                 std::cerr

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -339,14 +339,16 @@ bool Inline::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                                 } else {
                                     // We need to cast from a promise to a lazy
                                     // value
-                                    auto type = mk->isEager()
-                                                    ? mk->eagerArg()
-                                                          ->type.forced()
-                                                          .orPromiseWrapped()
-                                                    : ld->type;
+                                    auto type = ld->type.notMissing();
+                                    if (mk->isEager()) {
+                                        auto inType = mk->eagerArg()->type;
+                                        type =
+                                            inType.forced().orPromiseWrapped();
+                                        if (!inType.maybeMissing())
+                                            type = type.notMissing();
+                                    }
                                     auto cast = new CastType(
-                                        a, CastType::Upcast, RType::prom,
-                                        type.notMissing());
+                                        a, CastType::Upcast, RType::prom, type);
                                     ip = bb->insert(ip + 1, cast);
                                     ip--;
                                     a = cast;

--- a/rir/tests/pir_matrix_regression.R
+++ b/rir/tests/pir_matrix_regression.R
@@ -1,3 +1,6 @@
+if (Sys.getenv("LSAN_OPTIONS") != "")
+  q()
+
 require("Matrix")
 D5. <- Diagonal(x = 5:1)
 D5N <- D5.; D5N[5,5] <- NA


### PR DESCRIPTION
The upcast was broken for arguments which are statically known to be
missing. I.e. the eagerArg() in a MkArg can be the "missing" value.