### PR TITLE
avoid unreachable dockerhub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,12 +19,13 @@ variables:
 
 rir_container:
   stage: Build container
-  image: docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+      alias: docker
   before_script:
     - docker info
   script:
@@ -38,12 +39,13 @@ benchmark_container:
   stage: Build benchmark container
   needs:
     - rir_container
-  image: docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+      alias: docker
   before_script:
     - docker info
   tags:
@@ -356,12 +358,13 @@ deploy:
   stage: Deploy
   except:
     - schedules
-  image: docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+      alias: docker
   before_script:
     - docker info
   variables:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
 ARG CI_COMMIT_SHA
 ADD . /opt/rir
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
For some reason registry.dockerhub.io is unreachable from cesnet at the
moment. Let's work around this by caching our images at gitlab...