### PR TITLE
Do not load arguments into local variables

### DIFF
--- a/rir/src/compiler/analysis/force_dominance.h
+++ b/rir/src/compiler/analysis/force_dominance.h
@@ -412,8 +412,9 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
                     if (state.forcedAt(arg, f))
                         res.update();
                 }
-                if (!state.ambiguousForceOrder && !state.maybeForced(arg->id)) {
-                    state.argumentForceOrder.push_back(arg->id);
+                if (!state.ambiguousForceOrder &&
+                    !state.maybeForced(arg->pos)) {
+                    state.argumentForceOrder.push_back(arg->pos);
                     res.update();
                 }
             } else {

--- a/rir/src/compiler/analysis/force_dominance.h
+++ b/rir/src/compiler/analysis/force_dominance.h
@@ -171,6 +171,15 @@ struct ForcedBy {
     AbstractResult merge(const ForcedBy& other, bool exitMerge = false) {
         AbstractResult res;
 
+        for (auto sc = inScope.begin(); sc != inScope.end(); ++sc) {
+            if (!other.inScope.count(*sc)) {
+                sc = inScope.erase(sc);
+                res.update();
+                if (sc == inScope.end())
+                    break;
+            }
+        }
+
         rir::SmallSet<MkArg*> gotAmbiguous;
         for (auto& e : forcedBy) {
             if (!e.second)

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -277,11 +277,10 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
 
         // Forcing an argument can only affect local envs by reflection.
         // Hence, only leaked envs can be affected
-        auto ld = LdArg::Cast(arg->cFollowCastsAndForce());
         auto env = MkEnv::Cast(force->env());
         if (!handled) {
-            if (ld) {
-                if (closure->context().isNonRefl(ld->id)) {
+            if (auto a = LdArg::Cast(arg->cFollowCastsAndForce())) {
+                if (closure->context().isNonRefl(a->pos)) {
                     effect.max(state.envs.taintLeaked());
                     updateReturnValue(AbstractPirValue::tainted());
                     handled = true;
@@ -291,8 +290,8 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
                         if (upd == state.forcedPromise.end()) {
                             if (depth < MAX_DEPTH && !fixedPointReached() &&
                                 force->strict) {
-                                if (ld->id < args.size())
-                                    arg = args[ld->id];
+                                if (a->pos < args.size())
+                                    arg = args[a->pos];
 
                                 // We are certain that we do force something
                                 // here. Let's peek through the argument and see

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -120,7 +120,6 @@ static void lower(Module* module, Code* code) {
         DeadInstructions::IgnoreUsesThatDontObserveIntVsReal);
 
     Visitor::runPostChange(code->entry, [&](BB* bb) {
-
         auto it = bb->begin();
         while (it != bb->end()) {
             auto next = it + 1;

--- a/rir/src/compiler/native/lower_function_llvm.h
+++ b/rir/src/compiler/native/lower_function_llvm.h
@@ -275,6 +275,8 @@ class LowerFunctionLLVM {
     llvm::Value* paramEnv() { return args[2]; }
     llvm::Value* paramClosure() { return args[3]; }
 
+    std::vector<llvm::Value*> loadedArgs;
+
     static llvm::Constant* c(void* i) {
         return llvm::ConstantInt::get(PirJitLLVM::getContext(),
                                       llvm::APInt(64, (intptr_t)i));

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -65,10 +65,10 @@ bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
                         removed = true;
                         force->replaceUsesWith(mkArg->eagerArg());
                         next = bb->remove(ip);
-                    } else if (auto ld =
-                                   LdArg::Cast(arg->followCastsAndForce())) {
+                    } else if (auto a =
+                                   Argument::Cast(arg->followCastsAndForce())) {
                         if (force->hasEnv() &&
-                            cls->context().isNonRefl(ld->id)) {
+                            cls->context().isNonRefl(a->pos)) {
                             force->elideEnv();
                             force->effects.reset(Effect::Reflection);
                         }

--- a/rir/src/compiler/opt/cleanup.cpp
+++ b/rir/src/compiler/opt/cleanup.cpp
@@ -66,7 +66,7 @@ bool Cleanup::apply(Compiler&, ClosureVersion* cls, Code* code, LogStream&,
                         force->replaceUsesWith(mkArg->eagerArg());
                         next = bb->remove(ip);
                     } else if (auto a =
-                                   Argument::Cast(arg->followCastsAndForce())) {
+                                   LdArg::Cast(arg->followCastsAndForce())) {
                         if (force->hasEnv() &&
                             cls->context().isNonRefl(a->pos)) {
                             force->elideEnv();

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -281,7 +281,7 @@ bool EagerCalls::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         [&](ClosureVersion* newCls) {
                             Visitor::run(newCls->entry, [&](Instruction* i) {
                                 if (auto f = Force::Cast(i)) {
-                                    if (auto a = Argument::Cast(f->input())) {
+                                    if (auto a = LdArg::Cast(f->input())) {
                                         if (availableAssumptions.isNonRefl(
                                                 a->pos)) {
                                             f->elideEnv();
@@ -412,11 +412,11 @@ bool EagerCalls::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         anyChange = true;
                         Visitor::run(newCls->entry, [&](Instruction* i) {
                             if (auto ld = LdArg::Cast(i)) {
-                                if (eager.count(ld->id)) {
+                                if (eager.count(ld->pos)) {
                                     ld->type = PirType::promiseWrappedVal()
                                                    .notObject()
                                                    .notMissing();
-                               }
+                                }
                             }
                         });
                     });

--- a/rir/src/compiler/opt/eager_calls.cpp
+++ b/rir/src/compiler/opt/eager_calls.cpp
@@ -281,11 +281,19 @@ bool EagerCalls::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         [&](ClosureVersion* newCls) {
                             Visitor::run(newCls->entry, [&](Instruction* i) {
                                 if (auto f = Force::Cast(i)) {
-                                    if (LdArg::Cast(f)) {
-                                        f->elideEnv();
-                                        f->effects.reset(
-                                            Effect::DependsOnAssume);
-                                        f->effects.reset(Effect::Reflection);
+                                    if (auto a = Argument::Cast(f->input())) {
+                                        if (availableAssumptions.isNonRefl(
+                                                a->pos)) {
+                                            f->elideEnv();
+                                            f->effects.reset(
+                                                Effect::DependsOnAssume);
+                                            f->effects.reset(
+                                                Effect::Reflection);
+                                        }
+                                        if (availableAssumptions.isEager(
+                                                a->pos)) {
+                                            f->effects.reset();
+                                        }
                                     }
                                 }
                             });

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -326,8 +326,8 @@ bool Inline::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         }
 
                         if (ld) {
-                            Value* a = (ld->id < arguments.size())
-                                           ? arguments[ld->id]
+                            Value* a = (ld->pos < arguments.size())
+                                           ? arguments[ld->pos]
                                            : MissingArg::instance();
                             if (auto mk = MkArg::Cast(a)) {
                                 if (!ld->type.maybePromiseWrapped()) {

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -306,7 +306,7 @@ bool ScopeResolution::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                 analysis.lookup(arg, [&](const AbstractPirValue& res) {
                     res.ifSingleValue([&](Value* val) { arg = val; });
                 });
-                if (auto a = Argument::Cast(arg)) {
+                if (auto a = LdArg::Cast(arg)) {
                     if (force->hasEnv() && cls->context().isNonRefl(a->pos)) {
                         force->elideEnv();
                         force->effects.reset(Effect::Reflection);

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -43,9 +43,9 @@ static bool noReflection(ClosureVersion* cls, Code* code, Value* callEnv,
             res.eachSource([&](ValOrig vo) {
                 auto v = vo.val->followCastsAndForce();
                 if (v->type.maybeLazy()) {
-                    if (auto ld = LdArg::Cast(v))
-                        if (cls->context().isNonRefl(ld->id) ||
-                            cls->context().isEager(ld->id))
+                    if (auto a = LdArg::Cast(v))
+                        if (cls->context().isNonRefl(a->pos) ||
+                            cls->context().isEager(a->pos))
                             return;
                     maybe = true;
                 }
@@ -306,15 +306,15 @@ bool ScopeResolution::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                 analysis.lookup(arg, [&](const AbstractPirValue& res) {
                     res.ifSingleValue([&](Value* val) { arg = val; });
                 });
-                if (auto ld = LdArg::Cast(arg)) {
-                    if (force->hasEnv() && cls->context().isNonRefl(ld->id)) {
+                if (auto a = Argument::Cast(arg)) {
+                    if (force->hasEnv() && cls->context().isNonRefl(a->pos)) {
                         force->elideEnv();
                         force->effects.reset(Effect::Reflection);
                         changed = true;
                     }
 
                     if (after.noReflection()) {
-                        force->type.fromContext(cls->context(), ld->id,
+                        force->type.fromContext(cls->context(), a->pos,
                                                 cls->nargs(), true);
                     }
                 }

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -567,7 +567,7 @@ void LdFun::printArgs(std::ostream& out, bool tty) const {
     }
 }
 
-void LdArg::printArgs(std::ostream& out, bool tty) const { out << id; }
+void LdArg::printArgs(std::ostream& out, bool tty) const { out << pos; }
 
 void StVar::printArgs(std::ostream& out, bool tty) const {
     if (isStArg)

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -318,24 +318,27 @@ class Instruction : public Value {
 
     Instruction* hasSingleUse();
     void eraseAndRemove();
+
+    void replaceUsesIn(
+        Value* val, BB* target,
+        const std::function<void(Instruction*, size_t)>& postAction =
+            [](Instruction*, size_t) {},
+        const std::function<bool(Instruction*)>& replaceOnly =
+            [](Instruction*) { return true; }) override final;
+
     void replaceUsesWith(
         Value* val,
         const std::function<void(Instruction*, size_t)>& postAction =
             [](Instruction*, size_t) {},
         const std::function<bool(Instruction*)>& replaceOnly =
             [](Instruction*) { return true; });
+
     void replaceUsesAndSwapWith(Instruction* val,
                                 std::vector<Instruction*>::iterator it);
 
     void replaceDominatedUses(Instruction* replacement,
                               const DominanceGraph& dom,
                               const std::initializer_list<Tag>& skip = {});
-    void
-    replaceUsesIn(Value* val, BB* target,
-                  const std::function<void(Instruction*, size_t)>& postAction =
-                      [](Instruction*, size_t) {},
-                  const std::function<bool(Instruction*)>& replaceOnly =
-                      [](Instruction*) { return true; });
     void replaceUsesOfValue(Value* old, Value* rpl);
 
     bool usesAreOnly(BB*, std::unordered_set<Tag>);
@@ -547,6 +550,18 @@ class Instruction : public Value {
             COMPILER_INSTRUCTIONS(V)
 #undef V
             return static_cast<Instruction*>(v);
+        default: {
+        }
+        }
+        return nullptr;
+    }
+
+    static const Instruction* Cast(const Value* v) {
+        switch (v->tag) {
+#define V(Name) case Tag::Name:
+            COMPILER_INSTRUCTIONS(V)
+#undef V
+            return static_cast<const Instruction*>(v);
         default: {
         }
         }

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1045,13 +1045,14 @@ class FLI(Length, 1, Effects::None()) {
 
 class FLI(LdArg, 0, Effects::None()) {
   public:
-    size_t id;
+    size_t pos;
 
-    explicit LdArg(size_t id) : FixedLenInstruction(PirType::any()), id(id) {}
+    explicit LdArg(size_t pos)
+        : FixedLenInstruction(PirType::any()), pos(pos) {}
 
     void printArgs(std::ostream& out, bool tty) const override;
 
-    size_t gvnBase() const override { return hash_combine(tagHash(), id); }
+    size_t gvnBase() const override { return hash_combine(tagHash(), pos); }
     int minReferenceCount() const override { return MAX_REFCOUNT; }
 };
 

--- a/rir/src/compiler/pir/value.h
+++ b/rir/src/compiler/pir/value.h
@@ -13,6 +13,7 @@ enum class Tag : uint8_t;
 
 class BB;
 class Code;
+class Instruction;
 
 /*
  * A typed PIR value.
@@ -50,6 +51,15 @@ class Value {
     }
 
     void callArgTypeToContext(Context&, unsigned arg) const;
+
+    void checkReplace(Value* replace) const;
+
+    virtual void replaceUsesIn(
+        Value* val, BB* target,
+        const std::function<void(Instruction*, size_t)>& postAction =
+            [](Instruction*, size_t) {},
+        const std::function<bool(Instruction*)>& replaceOnly =
+            [](Instruction*) { return true; });
 };
 static_assert(sizeof(Value) <= 16, "");
 


### PR DESCRIPTION
LdArg loads arguments from the operand stack. These do not need a local variable, as they are already on the stack.