### PR TITLE
Fix naked dots miscompilation

### DIFF
--- a/rir/src/R/Printing.cpp
+++ b/rir/src/R/Printing.cpp
@@ -1,6 +1,7 @@
-#include "Printing.h"
-
+#include "R/Printing.h"
 #include "R/Funtab.h"
+#include "R/Symbols.h"
+
 #include <iostream>
 #include <string>
 
@@ -11,6 +12,8 @@ std::string Print::dumpSexp(SEXP src, size_t length) {
         return "R_UnboundValue";
     } else if (src == R_MissingArg) {
         return "R_MissingArg";
+    } else if (src == symbol::expandDotsTrigger) {
+        return "`...`";
     }
 
     static auto deparseBlt = getBuiltinFun("deparse");

--- a/rir/src/R/Protect.h
+++ b/rir/src/R/Protect.h
@@ -9,13 +9,13 @@ namespace rir {
 
 class Protect {
   public:
-    Protect(const Protect& other) = delete;
-
     Protect() {}
     explicit Protect(SEXP init) {
         Rf_protect(init);
         ++protectedValues_;
     }
+    Protect(const Protect& other) = delete;
+    ~Protect() { clear(); }
 
     SEXP operator()(SEXP value) {
         Rf_protect(value);
@@ -23,7 +23,7 @@ class Protect {
         return value;
     }
 
-    ~Protect() { Rf_unprotect(protectedValues_); }
+    void clear() { Rf_unprotect(protectedValues_); }
 
   private:
     /* Prevents heap allocation. */
@@ -34,6 +34,7 @@ class Protect {
 
     unsigned protectedValues_ = 0;
 };
-}
+
+} // namespace rir
 
 #endif // PROTECT_H

--- a/rir/src/R/Protect.h
+++ b/rir/src/R/Protect.h
@@ -9,13 +9,13 @@ namespace rir {
 
 class Protect {
   public:
+    Protect(const Protect& other) = delete;
+
     Protect() {}
     explicit Protect(SEXP init) {
         Rf_protect(init);
         ++protectedValues_;
     }
-    Protect(const Protect& other) = delete;
-    ~Protect() { clear(); }
 
     SEXP operator()(SEXP value) {
         Rf_protect(value);
@@ -23,7 +23,7 @@ class Protect {
         return value;
     }
 
-    void clear() { Rf_unprotect(protectedValues_); }
+    ~Protect() { Rf_unprotect(protectedValues_); }
 
   private:
     /* Prevents heap allocation. */

--- a/rir/src/R/Symbols.cpp
+++ b/rir/src/R/Symbols.cpp
@@ -7,15 +7,15 @@ namespace {
 // Copy-paste from names.c
 // Bypass Rf_install to avoid having this in the symbol table - there shouldn't
 // be any way for users to get to this symbol
-SEXP mkSymMarker(SEXP pname) {
-    PROTECT(pname);
-    SEXP ans = allocSExp(SYMSXP);
-    SET_SYMVALUE(ans, ans);
-    SET_ATTRIB(ans, R_NilValue);
-    SET_PRINTNAME(ans, pname);
-    UNPROTECT(1);
-    return ans;
-}
+// SEXP mkSymMarker(SEXP pname) {
+//     PROTECT(pname);
+//     SEXP ans = allocSExp(SYMSXP);
+//     SET_SYMVALUE(ans, ans);
+//     SET_ATTRIB(ans, R_NilValue);
+//     SET_PRINTNAME(ans, pname);
+//     UNPROTECT(1);
+//     return ans;
+// }
 
 } // namespace
 
@@ -23,7 +23,7 @@ SEXP mkSymMarker(SEXP pname) {
 SYMBOLS(V)
 #undef V
 
-SEXP expandDotsTrigger = mkSymMarker(Rf_mkChar(".expandDotsTrigger."));
+// SEXP expandDotsTrigger = mkSymMarker(Rf_mkChar(".expandDotsTrigger."));
 
 } // namespace symbol
 } // namespace rir

--- a/rir/src/R/Symbols.cpp
+++ b/rir/src/R/Symbols.cpp
@@ -1,11 +1,29 @@
 #include "Symbols.h"
 
 namespace rir {
-
 namespace symbol {
+namespace {
+
+// Copy-paste from names.c
+// Bypass Rf_install to avoid having this in the symbol table - there shouldn't
+// be any way for users to get to this symbol
+SEXP mkSymMarker(SEXP pname) {
+    PROTECT(pname);
+    SEXP ans = allocSExp(SYMSXP);
+    SET_SYMVALUE(ans, ans);
+    SET_ATTRIB(ans, R_NilValue);
+    SET_PRINTNAME(ans, pname);
+    UNPROTECT(1);
+    return ans;
+}
+
+} // namespace
+
 #define V(name, txt) SEXP name = Rf_install(txt);
 SYMBOLS(V)
 #undef V
-} // namespace symbol
 
+SEXP expandDotsTrigger = mkSymMarker(Rf_mkChar(".expandDotsTrigger."));
+
+} // namespace symbol
 } // namespace rir

--- a/rir/src/R/Symbols.cpp
+++ b/rir/src/R/Symbols.cpp
@@ -2,28 +2,10 @@
 
 namespace rir {
 namespace symbol {
-namespace {
-
-// Copy-paste from names.c
-// Bypass Rf_install to avoid having this in the symbol table - there shouldn't
-// be any way for users to get to this symbol
-// SEXP mkSymMarker(SEXP pname) {
-//     PROTECT(pname);
-//     SEXP ans = allocSExp(SYMSXP);
-//     SET_SYMVALUE(ans, ans);
-//     SET_ATTRIB(ans, R_NilValue);
-//     SET_PRINTNAME(ans, pname);
-//     UNPROTECT(1);
-//     return ans;
-// }
-
-} // namespace
 
 #define V(name, txt) SEXP name = Rf_install(txt);
 SYMBOLS(V)
 #undef V
-
-// SEXP expandDotsTrigger = mkSymMarker(Rf_mkChar(".expandDotsTrigger."));
 
 } // namespace symbol
 } // namespace rir

--- a/rir/src/R/Symbols.h
+++ b/rir/src/R/Symbols.h
@@ -11,7 +11,7 @@ namespace symbol {
 SYMBOLS(V)
 #undef V
 
-extern SEXP expandDotsTrigger;
+// extern SEXP expandDotsTrigger;
 
 } // namespace symbol
 } // namespace rir

--- a/rir/src/R/Symbols.h
+++ b/rir/src/R/Symbols.h
@@ -11,8 +11,6 @@ namespace symbol {
 SYMBOLS(V)
 #undef V
 
-// extern SEXP expandDotsTrigger;
-
 } // namespace symbol
 } // namespace rir
 

--- a/rir/src/R/Symbols.h
+++ b/rir/src/R/Symbols.h
@@ -5,13 +5,15 @@
 #include "symbol_list.h"
 
 namespace rir {
-
 namespace symbol {
+
 #define V(name, txt) extern SEXP name;
 SYMBOLS(V)
 #undef V
-} // namespace symbol
 
+extern SEXP expandDotsTrigger;
+
+} // namespace symbol
 } // namespace rir
 
 #endif // SYMBOLS_H_

--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -90,6 +90,7 @@
     V(forceAndCall, "forceAndCall")                                            \
     V(remove, "remove")                                                        \
     V(rm, "rm")                                                                \
-    V(Recall, "Recall")
+    V(Recall, "Recall")                                                        \
+    V(expandDotsTrigger, "\x02expandDotsTrigger\x03")
 
 #endif // SYMBOLS_LIST_H_

--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -92,5 +92,10 @@
     V(rm, "rm")                                                                \
     V(Recall, "Recall")                                                        \
     V(expandDotsTrigger, "\x02expandDotsTrigger\x03")
+/*
+ * The expandDotsTrigger symbol uses unprintable characters in hopes the users
+ * won't create it from R (however, they still can, eg. `as.name("\x1a")`).
+ * The other option is to make this a serializable EXTERNALSXP object.
+ */
 
 #endif // SYMBOLS_LIST_H_

--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -5,6 +5,7 @@
 #define SYMBOLS_SIMPLE_INSTRUCTION_V(V, name, _) V(name, "." #name)
 
 #define SYMBOLS(V)                                                             \
+    SIMPLE_INSTRUCTIONS(SYMBOLS_SIMPLE_INSTRUCTION_V, V)                       \
     V(UnknownDeoptTrigger, ".unknownDeoptTrigger")                             \
     V(SuperAssignBracket, "[<<-")                                              \
     V(SuperAssignDoubleBracket, "[[<<-")                                       \
@@ -76,11 +77,11 @@
     V(c, "c")                                                                  \
     V(standardGeneric, "standardGeneric")                                      \
     V(dispatchGeneric, "dispatchGeneric")                                      \
-    SIMPLE_INSTRUCTIONS(SYMBOLS_SIMPLE_INSTRUCTION_V, V)                       \
     V(UseMethod, "UseMethod")                                                  \
     V(sysframe, "sys.frame")                                                   \
     V(syscall, "sys.call")                                                     \
     V(srcref, "srcref")                                                        \
+    V(expandDotsTrigger, ".expandDotsTrigger.")                                \
     V(ambiguousCallTarget, ".ambiguousCallTarget.")                            \
     V(delayedEnv, ".delayedEnv.")                                              \
     V(eval, "eval")                                                            \

--- a/rir/src/R/symbol_list.h
+++ b/rir/src/R/symbol_list.h
@@ -81,7 +81,6 @@
     V(sysframe, "sys.frame")                                                   \
     V(syscall, "sys.call")                                                     \
     V(srcref, "srcref")                                                        \
-    V(expandDotsTrigger, ".expandDotsTrigger.")                                \
     V(ambiguousCallTarget, ".ambiguousCallTarget.")                            \
     V(delayedEnv, ".delayedEnv.")                                              \
     V(eval, "eval")                                                            \

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -1816,7 +1816,7 @@ bool LowerFunctionLLVM::compileDotcall(
     calli->eachCallArg([&](Value* v) {
         if (auto exp = ExpandDots::Cast(v)) {
             args.push_back(exp);
-            newNames.push_back(Pool::insert(R_DotsSymbol));
+            newNames.push_back(Pool::insert(symbol::expandDotsTrigger));
             seenDots = true;
         } else {
             assert(!DotsList::Cast(v));
@@ -2293,19 +2293,22 @@ void LowerFunctionLLVM::compile() {
             case Tag::DotsList: {
                 auto mk = DotsList::Cast(i);
                 auto arglist = constant(R_NilValue, t::SEXP);
-                std::stack<llvm::Value*> argsLoaded;
-                mk->eachElement(
-                    [&](SEXP name, Value* v) { argsLoaded.push(loadSxp(v)); });
-                mk->eachElementRev([&](SEXP name, Value* v) {
-                    auto val = argsLoaded.top();
-                    argsLoaded.pop();
-                    incrementNamed(val);
-                    arglist =
-                        call(NativeBuiltins::get(NativeBuiltins::Id::consNr),
-                             {val, arglist});
-                    setTag(arglist, constant(name, t::SEXP), false);
-                });
-                setSexptype(arglist, DOTSXP);
+                if (mk->nargs()) {
+                    std::stack<llvm::Value*> argsLoaded;
+                    mk->eachElement([&](SEXP name, Value* v) {
+                        argsLoaded.push(loadSxp(v));
+                    });
+                    mk->eachElementRev([&](SEXP name, Value* v) {
+                        auto val = argsLoaded.top();
+                        argsLoaded.pop();
+                        incrementNamed(val);
+                        arglist = call(
+                            NativeBuiltins::get(NativeBuiltins::Id::consNr),
+                            {val, arglist});
+                        setTag(arglist, constant(name, t::SEXP), false);
+                    });
+                    setSexptype(arglist, DOTSXP);
+                }
                 setVal(i, arglist);
                 break;
             }

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -231,7 +231,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         } else if (c == R_FalseValue ||
                    (IS_SIMPLE_SCALAR(c, LGLSXP) && *LOGICAL(c) == 0)) {
             push(False::instance());
-        } else if (c == R_DotsSymbol) {
+        } else if (c == symbol::expandDotsTrigger) {
             auto d = insert(new LdDots(insert.env));
             push(insert(new ExpandDots(d)));
         } else {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1,5 +1,6 @@
 #include "interp.h"
 #include "R/Funtab.h"
+#include "R/Protect.h"
 #include "R/RList.h"
 #include "R/Symbols.h"
 #include "cache.h"
@@ -1679,50 +1680,57 @@ void deoptFramesWithContext(InterpreterInstance* ctx,
 
 size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
                                Immediate* names_, SEXP env, bool explicitDots) {
+    Protect p;
     std::vector<SEXP> args;
     std::vector<SEXP> names;
     bool hasNames = false;
     for (size_t i = 0; i < n; ++i) {
         auto arg = ostack_at(ctx, n - i - 1);
         auto name = cp_pool_at(ctx, names_[i]);
-        if (name != R_DotsSymbol) {
-            args.push_back(arg);
-            names.push_back(name);
-            if (name != R_NilValue)
-                hasNames = true;
-        } else {
-            SEXP ellipsis = arg;
-            if (ellipsis == symbol::expandDotsTrigger)
-                ellipsis = Rf_findVar(R_DotsSymbol, env);
+        if (arg == symbol::expandDotsTrigger ||
+            name == symbol::expandDotsTrigger) {
+            // If we come from rir, we have to look up `...`
+            // If we come from pir, `...` is already loaded
+            assert(arg != symbol::expandDotsTrigger ||
+                   name != symbol::expandDotsTrigger);
+            bool pir = (name == symbol::expandDotsTrigger);
+            SEXP ellipsis = pir ? arg : Rf_findVar(R_DotsSymbol, env);
 
-            if (TYPEOF(ellipsis) == PROMSXP)
-                ellipsis = evaluatePromise(ellipsis, ctx);
-
-            if (TYPEOF(ellipsis) == DOTSXP) {
+            if (TYPEOF(ellipsis) == DOTSXP || ellipsis == R_NilValue) {
                 while (ellipsis != R_NilValue) {
-                    auto arg = CAR(ellipsis);
-                    if (TYPEOF(arg) == LANGSXP || TYPEOF(arg) == SYMSXP)
-                        arg = Rf_mkPROMISE(arg, env);
-                    args.push_back(arg);
+                    auto dotArg = CAR(ellipsis);
+                    if (TYPEOF(dotArg) == LANGSXP ||
+                        (TYPEOF(dotArg) == SYMSXP && dotArg != R_MissingArg)) {
+                        args.push_back(p(Rf_mkPROMISE(dotArg, env)));
+                    } else {
+                        args.push_back(dotArg);
+                    }
                     names.push_back(TAG(ellipsis));
                     if (TAG(ellipsis) != R_NilValue)
                         hasNames = true;
                     ellipsis = CDR(ellipsis);
                 }
             } else if (ellipsis == R_MissingArg) {
-                // empty ... occurring in the middle of an argument list needs
+                // Empty `...` occurring in the middle of an argument list needs
                 // to be explicit, since pir optimized functions expect it that
                 // way.
                 if (explicitDots) {
                     args.push_back(R_MissingArg);
                     names.push_back(R_NilValue);
                 }
-            } else if (ellipsis == R_NilValue || ellipsis == R_UnboundValue) {
             } else {
-                // TODO: why does this happen in SERIALIZE CHAOS?
-                args.push_back(ellipsis);
-                names.push_back(R_NilValue);
+                // Protect stack should be restored after Rf_error but to be
+                // safe...
+                p.clear();
+                args = std::vector<SEXP>();
+                names = std::vector<SEXP>();
+                Rf_error("'...' used in an incorrect context");
             }
+        } else {
+            args.push_back(arg);
+            names.push_back(name);
+            if (name != R_NilValue)
+                hasNames = true;
         }
     }
     if (hasNames) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1696,8 +1696,9 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
             bool pir = (name == symbol::expandDotsTrigger);
             SEXP ellipsis = pir ? arg : Rf_findVar(R_DotsSymbol, env);
 
-            if (TYPEOF(ellipsis) == PROMSXP)
+            if (TYPEOF(ellipsis) == PROMSXP) {
                 ellipsis = evaluatePromise(ellipsis, ctx);
+            }
 
             if (TYPEOF(ellipsis) == DOTSXP || ellipsis == R_NilValue) {
                 while (ellipsis != R_NilValue) {
@@ -1722,10 +1723,9 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
                     names.push_back(R_NilValue);
                 }
             } else if (ellipsis == R_UnboundValue) {
-            } else {
-                // TODO: why does this happen in SERIALIZE CHAOS?
-                args.push_back(ellipsis);
-                names.push_back(R_NilValue);
+                assert(false);
+            } else if (pir) {
+                assert(false);
             }
         } else {
             args.push_back(arg);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1692,7 +1692,7 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
                 hasNames = true;
         } else {
             SEXP ellipsis = arg;
-            if (ellipsis == R_DotsSymbol)
+            if (ellipsis == symbol::expandDotsTrigger)
                 ellipsis = Rf_findVar(R_DotsSymbol, env);
 
             if (TYPEOF(ellipsis) == PROMSXP)

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1726,12 +1726,6 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
                 // TODO: why does this happen in SERIALIZE CHAOS?
                 args.push_back(ellipsis);
                 names.push_back(R_NilValue);
-                // // Protect stack should be restored after Rf_error but to be
-                // // safe...
-                // p.clear();
-                // args = std::vector<SEXP>();
-                // names = std::vector<SEXP>();
-                // Rf_error("'...' used in an incorrect context booooo");
             }
         } else {
             args.push_back(arg);

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1687,14 +1687,13 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
     for (size_t i = 0; i < n; ++i) {
         auto arg = ostack_at(ctx, n - i - 1);
         auto name = cp_pool_at(ctx, names_[i]);
-        if (arg == symbol::expandDotsTrigger ||
-            name == symbol::expandDotsTrigger) {
-            // If we come from rir, we have to look up `...`
-            // If we come from pir, `...` is already loaded
-            assert(arg != symbol::expandDotsTrigger ||
-                   name != symbol::expandDotsTrigger);
-            bool pir = (name == symbol::expandDotsTrigger);
-            SEXP ellipsis = pir ? arg : Rf_findVar(R_DotsSymbol, env);
+        if (name == symbol::expandDotsTrigger) {
+            // If we come from rir, we have to look up `...`, marked by the arg
+            // being the symbol expandDotsTrigger If we come from pir, `...` is
+            // already loaded
+            SEXP ellipsis = (arg == symbol::expandDotsTrigger)
+                                ? Rf_findVar(R_DotsSymbol, env)
+                                : arg;
 
             if (TYPEOF(ellipsis) == PROMSXP) {
                 ellipsis = evaluatePromise(ellipsis, ctx);
@@ -1722,10 +1721,6 @@ size_t expandDotDotDotCallArgs(InterpreterInstance* ctx, size_t n,
                     args.push_back(R_MissingArg);
                     names.push_back(R_NilValue);
                 }
-            } else if (ellipsis == R_UnboundValue) {
-                assert(false);
-            } else if (pir) {
-                assert(false);
             }
         } else {
             args.push_back(arg);

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1584,7 +1584,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
                 std::vector<SEXP> names;
                 for (RListIter arg = args.begin(); arg != RList::end(); ++arg) {
                     if (*arg == R_DotsSymbol) {
-                        cs << BC::push(R_DotsSymbol);
+                        cs << BC::push(symbol::expandDotsTrigger);
                         names.push_back(R_DotsSymbol);
                         continue;
                     }
@@ -1702,7 +1702,7 @@ static void compileLoadOneArg(CompilerContext& ctx, SEXP arg, ArgType arg_type, 
     res.numArgs += 1;
 
     if (CAR(arg) == R_DotsSymbol) {
-        cs << BC::push(R_DotsSymbol);
+        cs << BC::push(symbol::expandDotsTrigger);
         res.names.push_back(R_DotsSymbol);
         res.hasDots = true;
         return;

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -1698,7 +1698,7 @@ static void compileLoadOneArg(CompilerContext& ctx, SEXP arg, ArgType arg_type,
         return;
     }
 
-    // remember if the argument had a name associated
+    // remember if the argument had a name associated (for missing too)
     res.names.push_back(TAG(arg));
     if (TAG(arg) != R_NilValue)
         res.hasNames = true;

--- a/rir/tests/pir_dots.r
+++ b/rir/tests/pir_dots.r
@@ -1,0 +1,3 @@
+f <- function() quote(...)
+for (i in 1:5)
+    stopifnot(identical(f(), quote(...)))


### PR DESCRIPTION
In rir, we use `R_DotsSymbol` for marking an argument that should be expanded at runtime, but also when we need to push the actual symbol (in `quote(...)`).
In pir we don't know anymore which case this was, and so try to always expand the dots.
This adds a symbol placeholder `.expandDotsTrigger.` to be used in the arglists instead.