### PR TITLE
fix compilation of nested loops

### DIFF
--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -166,6 +166,11 @@ class CompilerContext {
         code.top()->loops.emplace(next_, break_);
     }
 
+    void pushFakeLoop() {
+        code.top()->loops.emplace(-1, -1);
+        code.top()->setContextNeeded();
+    }
+
     void popLoop() { code.top()->loops.pop(); }
 
     void push(SEXP ast, SEXP env) {
@@ -361,7 +366,9 @@ bool compileSimpleFor(CompilerContext& ctx, SEXP fullAst, SEXP sym, SEXP seq,
         size_t seqPromIdx = cs.addPromise(seqProm);
 
         // 2) Create a promise with the body
+        ctx.pushFakeLoop();
         Code* bodyProm = compilePromise(ctx, body);
+        ctx.popLoop();
         size_t bodyPromIdx = cs.addPromise(bodyProm);
 
         // 3) Add the function, arguments, and call

--- a/rir/tests/nested_loops.R
+++ b/rir/tests/nested_loops.R
@@ -1,0 +1,9 @@
+f <- function(x) {
+    for (i in 1:x)
+        for (j in 1:x)
+            for (k in 1:x)
+                break
+}
+for (i in 1:100)
+    f(10)
+stopifnot(length(rir.functionVersions(f)) == 2)

--- a/rir/tests/nested_loops.R
+++ b/rir/tests/nested_loops.R
@@ -4,6 +4,7 @@ f <- function(x) {
             for (k in 1:x)
                 break
 }
+rir.compile(f)
 for (i in 1:100)
     f(10)
 stopifnot(length(rir.functionVersions(f)) == 2)

--- a/rir/tests/nested_loops.R
+++ b/rir/tests/nested_loops.R
@@ -1,3 +1,8 @@
+if (Sys.getenv("PIR_ENABLE") == "off" ||
+    Sys.getenv("RIR_SERIALIZE_CHAOS") != "") {
+  q()
+}
+
 f <- function(x) {
     for (i in 1:x)
         for (j in 1:x)

--- a/rir/tests/nested_loops.R
+++ b/rir/tests/nested_loops.R
@@ -1,4 +1,4 @@
-if (Sys.getenv("PIR_ENABLE") == "off" ||
+if (Sys.getenv("PIR_ENABLE") != "" ||
     Sys.getenv("RIR_SERIALIZE_CHAOS") != "") {
   q()
 }


### PR DESCRIPTION
When we have nested simple loops, then a break or continue in the body
of an inner loop caused the loops to have contexts. The reason is that
when we compile the fallback case for the simple loop, then we forgot to
set up a loop context. This means that the break being compiled for
fallback would taint the wrong (ie. outer) loop context.