### PR TITLE
fix type checks for scalars

### DIFF
--- a/rir/src/compiler/pir/type.h
+++ b/rir/src/compiler/pir/type.h
@@ -439,6 +439,11 @@ struct PirType {
         return PirType(t_.r & ~RTypeSet(RType::missing), flags_);
     }
 
+    PirType constexpr orWrappedMissing() const {
+        assert(isRType());
+        return PirType(t_.r, flags_ & ~FlagSet(TypeFlags::notWrappedMissing));
+    }
+
     PirType constexpr notWrappedMissing() const {
         assert(isRType());
         return PirType(t_.r, flags_ | TypeFlags::notWrappedMissing);


### PR DESCRIPTION
the noWrappedMissing flag would cause scalar checks to accidentally end up in the slow generic case. 

plus adding support for non-na checks