### PR TITLE
deoptless support for normal envs

### DIFF
--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -407,6 +407,17 @@ class DeadStoreAnalysis {
         return !observed.isObserved(st);
     };
 
+    bool escapedEnv(Deopt* d) const {
+        auto fs = d->frameState();
+        auto state = leak.before(d);
+        while (fs) {
+            if (state.leaked.count(fs->env()))
+                return true;
+            fs = fs->next();
+        }
+        return false;
+    }
+
     bool onlyObservedByDeopt(StVar* st) const {
         return observed.isObservedOnlyByDeopt(st);
     };

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -3529,6 +3529,7 @@ void LowerFunctionLLVM::compile() {
                     return call(NativeBuiltins::get(NativeBuiltins::Id::deopt),
                                 {paramCode(), paramClosure(),
                                  convertToPointer(m, t::i8, true), paramArgs(),
+                                 c(deopt->escapedEnv, 1),
                                  load(deopt->deoptReason()),
                                  loadSxp(deopt->deoptTrigger())});
                 });

--- a/rir/src/compiler/opt/dead_store_removal.cpp
+++ b/rir/src/compiler/opt/dead_store_removal.cpp
@@ -27,6 +27,10 @@ bool DeadStoreRemoval::apply(Compiler&, ClosureVersion* cls, Code* code,
                 }
                 ip = next;
             }
+            if (bb->isDeopt()) {
+                auto d = Deopt::Cast(bb->last());
+                d->escapedEnv = analysis.escapedEnv(d);
+            }
         });
 
         VisitorNoDeoptBranch::runBackward(code->entry, [&](BB* bb) {

--- a/rir/src/compiler/pir/continuation_context.cpp
+++ b/rir/src/compiler/pir/continuation_context.cpp
@@ -23,7 +23,9 @@ ContinuationContext::ContinuationContext(Opcode* pc, SEXP env, bool leaked,
         size_t i = 0;
         while (f != R_NilValue) {
             auto n = TAG(f);
+            assert(i < (size_t)l);
             env_.at(i) = {n, PirType(CAR(f)), MISSING(f)};
+            f = CDR(f);
             i++;
         }
     }

--- a/rir/src/compiler/pir/deopt_context.cpp
+++ b/rir/src/compiler/pir/deopt_context.cpp
@@ -5,18 +5,22 @@
 namespace rir {
 namespace pir {
 
-DeoptContext::DeoptContext(Opcode* pc, LazyEnvironment* env, R_bcstack_t* base,
+DeoptContext::DeoptContext(Opcode* pc, size_t envSize, SEXP actualEnv,
+                           LazyEnvironment* env, R_bcstack_t* base,
                            size_t stackSize, const DeoptReason& reason,
                            SEXP deoptTrigger)
-    : ContinuationContext(pc, nullptr, false, base, stackSize), reason_(reason),
-      deoptTrigger_(deoptTrigger) {
-    assert(env->nargs <= MAX_ENV);
-    envSize_ = env->nargs;
+    : ContinuationContext(pc, actualEnv, false, base, stackSize),
+      reason_(reason), deoptTrigger_(deoptTrigger) {
+    assert(!(actualEnv && env));
+    envSize_ = envSize;
+    assert(envSize_ <= MAX_ENV);
     leakedEnv_ = false;
-    for (size_t i = 0; i < envSize(); ++i) {
-        auto n = Pool::get(env->names[i]);
-        env_.at(i) = {TYPEOF(n) == LISTSXP ? CAR(n) : n,
-                      PirType(env->getArg(i)), env->missing[i]};
+    if (env) {
+        for (size_t i = 0; i < envSize_; ++i) {
+            auto n = Pool::get(env->names[i]);
+            env_.at(i) = {TYPEOF(n) == LISTSXP ? CAR(n) : n,
+                          PirType(env->getArg(i)), env->missing[i]};
+        }
     }
 }
 } // namespace pir

--- a/rir/src/compiler/pir/deopt_context.h
+++ b/rir/src/compiler/pir/deopt_context.h
@@ -19,9 +19,9 @@ struct DeoptContext : public ContinuationContext {
     const DeoptReason& reason() const { return reason_; }
     SEXP deoptTrigger() const { return deoptTrigger_; }
 
-    DeoptContext(Opcode* pc, LazyEnvironment* env, R_bcstack_t* base,
-                 size_t stackSize, const DeoptReason& reason,
-                 SEXP deoptTrigger);
+    DeoptContext(Opcode* pc, size_t envSize, SEXP actualEnv,
+                 LazyEnvironment* env, R_bcstack_t* base, size_t stackSize,
+                 const DeoptReason& reason, SEXP deoptTrigger);
 
     const DeoptContext* asDeoptContext() const override final { return this; }
 };

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2702,6 +2702,8 @@ class Checkpoint : public FixedLenInstruction<Tag::Checkpoint, Checkpoint, 0,
 class Deopt : public FixedLenInstruction<Tag::Deopt, Deopt, 3, Effects::AnyI(),
                                          HasEnvSlot::No, Controlflow::Exit> {
   public:
+    bool escapedEnv = true;
+
     explicit Deopt(FrameState* frameState);
 
     Value* frameStateOrTs() const override final { return arg<0>().val(); }


### PR DESCRIPTION
if normal envs have not yet escaped we can use deoptless too.
this is done by marking deopts where escape analysis knows that
envs are not escaped.