### PR TITLE
Fix cyclic objects

### DIFF
--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -11,6 +11,17 @@ namespace pir {
 
 struct NeedsRefcountAdjustment {
     enum Kind { EnsureNamed, SetShared };
+    friend std::ostream& operator<<(std::ostream& out, Kind k) {
+        switch (k) {
+        case EnsureNamed:
+            out << "EnsureNamed";
+            break;
+        case SetShared:
+            out << "SetShared";
+            break;
+        }
+        return out;
+    }
 
     // Not needed since we do not use the state in the analysis
     bool changed() { return false; }
@@ -200,8 +211,7 @@ class StaticReferenceCount
                     if (i == j || j->minReferenceCount() > 1)
                         return;
                     if (auto taint = state.isTainted(j)) {
-                        NeedsRefcountAdjustment::Kind k =
-                            NeedsRefcountAdjustment::EnsureNamed;
+                        auto k = NeedsRefcountAdjustment::EnsureNamed;
                         if (taint->kind == AbstractValueTaint::Taint::Override)
                             k = NeedsRefcountAdjustment::SetShared;
                         else
@@ -260,7 +270,7 @@ class StaticReferenceCount
             break;
         }
 
-        // Instructions which never reuse SEXPS can be ignored
+        // Instructions which never reuse SEXPs can be ignored
         case Tag::PirCopy:
         case Tag::Return:
         case Tag::Colon:
@@ -361,7 +371,8 @@ class StaticReferenceCount
         return res;
     }
 };
-}
-}
+
+} // namespace pir
+} // namespace rir
 
 #endif

--- a/rir/src/interpreter/call_context.h
+++ b/rir/src/interpreter/call_context.h
@@ -99,7 +99,7 @@ struct CallContext {
 
     void depromiseArgs() const {
 
-        // Both stackAergs and listargs should point to the same promises
+        // Both stackArgs and listArgs should point to the same promises
         // So forcing twice shouldn't execute the promise twice
 
         // depromise on stack

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1123,8 +1123,12 @@ fallbackToLegacyCall:
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
         // call it
+        for (SEXP a = arglist; a != R_NilValue; a = CDR(a))
+            INCREMENT_NAMED(CAR(a));
         res =
             f(call.ast, call.callee, arglist, materializeCallerEnv(call, ctx));
+        for (SEXP a = arglist; a != R_NilValue; a = CDR(a))
+            DECREMENT_NAMED(CAR(a));
         if (flag < 2)
             R_Visible = static_cast<Rboolean>(flag != 1);
     } else {

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -924,7 +924,7 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
             //   names(x) <- x
             // leads to calling do_namesgets with x with named = 1 as both
             // the target and the value
-            // MARK_ASSIGNMENT_CALL(farrow_ast);
+            MARK_ASSIGNMENT_CALL(farrow_ast);
 
             // We need to append "value = z" to the list of args for f<-
             // Let's create the corresponding cell (directly linked in AST so

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -928,11 +928,6 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
             while (CDR(last_farrow_cell) != R_NilValue) {
                 last_farrow_cell = CDR(last_farrow_cell);
             }
-            // TODO: this can cause cyclic objects sometimes, eg.
-            //   x <- c("a", "b")
-            //   names(x) <- x
-            // leads to calling do_namesgets with x with named = 1 as both
-            // the target and the value
             MARK_ASSIGNMENT_CALL(farrow_ast);
 
             // We need to append "value = z" to the list of args for f<-

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -645,23 +645,27 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
                     // Cant rewrite this statically...
                     return false;
                 }
-            } break;
-            case SYMSXP:
+                break;
+            }
+            case SYMSXP: {
                 l = nullptr;
                 break;
-            case STRSXP:
+            }
+            case STRSXP: {
                 l = nullptr;
                 break;
-            default:
+            }
+            default: {
                 // Probably broken assignment
                 return false;
+            }
             }
         }
 
         if (!superAssign)
             MARK_ASSIGNMENT_CALL(ast);
 
-        // 2) Specialcalse normal assignment (ie. "i <- expr")
+        // 2) Specialcase normal assignment (ie. "i <- expr")
         if (TYPEOF(lhs) == SYMSXP) {
             emitGuardForNamePrimitive(cs, fun);
             compileExpr(ctx, rhs);
@@ -688,24 +692,29 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
         while (!target) {
             switch (TYPEOF(l)) {
             case LANGSXP: {
-                auto fun = l->u.listsxp.carval;
-                auto args = l->u.listsxp.cdrval;
+                auto fun = CAR(l);
+                auto args = CDR(l);
                 assert(TYPEOF(fun) == SYMSXP);
                 lhsParts.push_back(l);
                 l = CAR(args);
-            } break;
+                break;
+            }
             case SYMSXP: {
-                lhsParts.push_back(l);
                 target = l;
-            } break;
+                lhsParts.push_back(target);
+                break;
+            }
             case STRSXP: {
                 assert(Rf_length(l) == 1);
                 target = Rf_install(CHAR(STRING_ELT(l, 0)));
                 lhsParts.push_back(target);
-            } break;
-            default:
-                errorcall(ast, "invalid (do_set) left-hand side to assignment");
                 break;
+            }
+            default: {
+                Rf_errorcall(ast,
+                             "invalid (do_set) left-hand side to assignment");
+                break;
+            }
             }
         }
 

--- a/rir/src/ir/Compiler.cpp
+++ b/rir/src/ir/Compiler.cpp
@@ -919,7 +919,12 @@ bool compileSpecialCall(CompilerContext& ctx, SEXP ast, SEXP fun, SEXP args_,
             while (CDR(last_farrow_cell) != R_NilValue) {
                 last_farrow_cell = CDR(last_farrow_cell);
             }
-            MARK_ASSIGNMENT_CALL(farrow_ast);
+            // TODO: this can cause cyclic objects sometimes, eg.
+            //   x <- c("a", "b")
+            //   names(x) <- x
+            // leads to calling do_namesgets with x with named = 1 as both
+            // the target and the value
+            // MARK_ASSIGNMENT_CALL(farrow_ast);
 
             // We need to append "value = z" to the list of args for f<-
             // Let's create the corresponding cell (directly linked in AST so

--- a/rir/tests/pir_regression_cyclic.r
+++ b/rir/tests/pir_regression_cyclic.r
@@ -1,0 +1,37 @@
+f <- function() {
+    x <- c("a", "b")
+    names(x) <- x
+}
+x <- f()
+x <- f()
+x <- f()
+x <- f()
+y <- 1:5
+y[x]
+print(x)
+print(attributes(x))
+
+
+f <- function() {
+    y <- data.frame(a = 1:5)
+    x <- c("a", "b")
+    names(x) <- x
+    y[, x] <- 0
+    y
+}
+f()
+f()
+f()
+f()
+
+y <- data.frame(a = 1:2)
+f <- function() {
+    x <- c("a", "b")
+    names(x) <- x
+    y[, x] <- 0
+    y
+}
+f()
+f()
+f()
+f()


### PR DESCRIPTION
If we elide a promise, we need to make sure the named is set to max to prevent self-references, as in eg.
  x <- c("a", "b")
  names(x) <- x