### PR TITLE
Fix leak env analysis

### DIFF
--- a/rir/R/rir.R
+++ b/rir/R/rir.R
@@ -81,7 +81,7 @@ pir.tests <- function() {
     invisible(.Call("pirTests"))
 }
 
-# returns TRUE f, when PIR compiled, satisfies the the given checks (e.g.
+# returns TRUE if, when PIR compiled, satisfies the the given checks (e.g.
 # environment was elided). Max assumptions compiled (+ minimal) are used, if
 # warmup=<FUN> will call <FUN> repeatedly to get better assumptions.
 pir.check <- function(f, ..., warmup=NULL) {

--- a/rir/src/compiler/analysis/dead_store.h
+++ b/rir/src/compiler/analysis/dead_store.h
@@ -109,6 +109,15 @@ class DeadStoreAnalysis {
             if (i->leaksEnv()) {
                 markEnv(i->env());
             }
+            if (i->leaksArg()) {
+                i->eachArg([&](Value* v) {
+                    if (auto mk = MkArg::Cast(v)) {
+                        markEnv(mk->env());
+                    } else if (auto mk = MkFunCls::Cast(v)) {
+                        markEnv(mk->env());
+                    }
+                });
+            }
             if (auto fs = i->frameState()) {
                 do {
                     markEnv(fs->env());

--- a/rir/src/compiler/analysis/force_dominance.h
+++ b/rir/src/compiler/analysis/force_dominance.h
@@ -466,7 +466,7 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
 
         // 3. Figure out where promises escape to
         std::function<void(Instruction*)> traceEscapes = [&](Instruction* i) {
-            if (!i->effects.includes(Effect::LeakArg) && !MkEnv::Cast(i))
+            if (!i->effects.includes(Effect::LeaksArg) && !MkEnv::Cast(i))
                 return;
             i->eachArg([&](Value* v) {
                 if (auto m = MkArg::Cast(v->followCasts()))

--- a/rir/src/compiler/analysis/force_dominance.h
+++ b/rir/src/compiler/analysis/force_dominance.h
@@ -466,7 +466,7 @@ class ForceDominanceAnalysis : public StaticAnalysis<ForcedBy> {
 
         // 3. Figure out where promises escape to
         std::function<void(Instruction*)> traceEscapes = [&](Instruction* i) {
-            if (!i->effects.includes(Effect::LeaksArg) && !MkEnv::Cast(i))
+            if (!i->leaksArg() && !MkEnv::Cast(i))
                 return;
             i->eachArg([&](Value* v) {
                 if (auto m = MkArg::Cast(v->followCasts()))

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -374,7 +374,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                                     if (SafeBuiltinsList::nonObject(builtinId))
                                         return true;
                                 }
-                                if (i->effects.includes(Effect::LeakArg) ||
+                                if (i->effects.includes(Effect::LeaksArg) ||
                                     i->effects.includes(Effect::Reflection)) {
                                     return false;
                                 }

--- a/rir/src/compiler/opt/force_dominance.cpp
+++ b/rir/src/compiler/opt/force_dominance.cpp
@@ -353,7 +353,7 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                     }
                 }
             } else if (auto cast = CastType::Cast(*ip)) {
-                // Only replace upcasts, or we loose information
+                // Only replace upcasts, or we lose information
                 if (cast->kind == CastType::Upcast) {
                     if (auto mk = MkArg::Cast(cast->arg<0>().val())) {
                         if (mk->isEager()) {
@@ -367,15 +367,14 @@ bool ForceDominance::apply(Compiler&, ClosureVersion* cls, Code* code,
                                     builtinId = b->builtinId;
                                 if (auto b = CallSafeBuiltin::Cast(i))
                                     builtinId = b->builtinId;
-                                if (builtinId) {
+                                if (builtinId != -1) {
                                     if (eager->type.maybeObj())
                                         if (SafeBuiltinsList::always(builtinId))
                                             return true;
                                     if (SafeBuiltinsList::nonObject(builtinId))
                                         return true;
                                 }
-                                if (i->effects.includes(Effect::LeaksArg) ||
-                                    i->effects.includes(Effect::Reflection)) {
+                                if (i->leaksArg() || i->mayUseReflection()) {
                                     return false;
                                 }
                                 // Depromised and promised missing do not behave

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -136,7 +136,7 @@ void Instruction::printEffects(std::ostream& out, bool tty) const {
             CASE(Error, "e")
             CASE(Force, "f")
             CASE(Reflection, "r")
-            CASE(LeakArg, "l")
+            CASE(LeaksArg, "l")
             CASE(ChangesContexts, "C")
             CASE(ReadsEnv, "R")
             CASE(WritesEnv, "W")

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -259,11 +259,7 @@ class Instruction : public Value {
 
     bool mayObserveContext(MkEnv* c = nullptr) const;
 
-    // TODO: Add verify, then replace with effects.includes(Effect::LeaksArg)
-    bool leaksArg(Value* val) const {
-        return leaksEnv() || effects.includes(Effect::LeaksArg);
-    }
-
+    bool leaksArg() const { return effects.includes(Effect::LeaksArg); }
     bool readsEnv() const {
         return hasEnv() && effects.includes(Effect::ReadsEnv);
     }
@@ -1191,9 +1187,10 @@ class NonLocalReturn
                                          {{ret}}, env) {}
 };
 
-class Return
-    : public FixedLenInstruction<Tag::Return, Return, 1, Effects::NoneI(),
-                                 HasEnvSlot::No, Controlflow::Exit> {
+class Return : public FixedLenInstruction<Tag::Return, Return, 1,
+                                          static_cast<Effects::StoreType>(
+                                              Effects(Effect::LeaksArg)),
+                                          HasEnvSlot::No, Controlflow::Exit> {
   public:
     explicit Return(Value* ret)
         : FixedLenInstruction(PirType::voyd(), {{PirType::val()}}, {{ret}}) {}


### PR DESCRIPTION
Promises and closures can leak their environments but by themselves they don't leak anything, only when they are used (forced / called). Our dead store removal was imprecise here, so it would break code like the following, removing the store to `n`, even though it's observable through calling the closure:
```
function() {
  n <- 5
  function() n
}
```