### PR TITLE
prevent unsupported na checks

### DIFF
--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -4233,6 +4233,14 @@ void LowerFunctionLLVM::compile() {
                         break;
                     }
 
+                    if (!(arg->type.maybeNAOrNaN() <=
+                          t->typeTest.maybeNAOrNaN())) {
+                        arg->type.print(std::cout);
+                        std::cout << " ";
+                        t->typeTest.print(std::cout);
+                        std::cout << "\n";
+                    }
+
                     // NA checks can only be done on scalars!
                     assert(arg->type.maybeNAOrNaN() <=
                            t->typeTest.maybeNAOrNaN());

--- a/rir/src/compiler/opt/type_test.h
+++ b/rir/src/compiler/opt/type_test.h
@@ -20,6 +20,11 @@ class TypeTest {
                        const std::function<void()>& failed) {
         auto expected = i->type & feedback.type;
 
+        // NA checks are only possible on scalars
+        if (i->type.maybeNAOrNaN() && !expected.maybeNAOrNaN() &&
+            !expected.isSimpleScalar())
+            expected = expected.orNAOrNaN();
+
         if (i->type.isA(expected) && i->type.isA(required))
             return;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -1782,7 +1782,10 @@ class FLI(IsType, 1, Effects::None()) {
     const PirType typeTest;
     IsType(PirType type, Value* v)
         : FixedLenInstruction(PirType::test(), {{PirType::any()}}, {{v}}),
-          typeTest(type) {}
+          typeTest(type) {
+        if (v->type.maybeNAOrNaN() && !type.maybeNAOrNaN())
+            assert(type.isSimpleScalar());
+    }
 
     void printArgs(std::ostream& out, bool tty) const override;
 


### PR DESCRIPTION
ensure we don't accidentally insert na checks we cannot support.