### PR TITLE
Time based (re-)compilation heuristics

### DIFF
--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -12,8 +12,11 @@ struct Parameter {
     static bool DEOPT_CHAOS_NO_RETRIGGER;
     static int DEOPT_CHAOS_SEED;
     static size_t MAX_INPUT_SIZE;
-    static unsigned RIR_WARMUP;
-    static unsigned DEOPT_ABANDON;
+
+    static const unsigned PIR_WARMUP;
+    static const unsigned PIR_OPT_TIME;
+    static const unsigned PIR_REOPT_TIME;
+    static const unsigned DEOPT_ABANDON;
 
     static size_t PROMISE_INLINER_MAX_SIZE;
 

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -9,6 +9,9 @@
 #include <cassert>
 #include <cstdint>
 #include <ostream>
+#include <time.h>
+
+#include <asm/msr.h>
 
 namespace rir {
 

--- a/rir/src/runtime/Function.cpp
+++ b/rir/src/runtime/Function.cpp
@@ -67,7 +67,8 @@ void Function::disassemble(std::ostream& out) {
     out << "\n";
     out << "[stats]    ";
     out << "invoked: " << invocationCount()
-        << ", deopt: " << deoptCount();
+        << ", time: " << ((double)invocationTime() / 1e6)
+        << "ms, deopt: " << deoptCount();
     out << "\n";
     body()->disassemble(out);
 }

--- a/rir/tests/test_mark_function.r
+++ b/rir/tests/test_mark_function.r
@@ -31,18 +31,17 @@ f4 <- function(b) {
 }
 
 x=1L
-for (i in 1:10)
+for (i in 1:1000)
   f1()
-for (i in 1:10)
+for (i in 1:1000)
   f2()
-for (i in 1:100)
+for (i in 1:1000)
   f3(x)
-for (i in 1:100)
+for (i in 1:1000)
   f4(x)
 
-rir.disassemble(add_noinline1)
-stopifnot(sum(rir.functionInvocations(add_noinline1)) == 10)
-stopifnot(sum(rir.functionInvocations(add_nospecial)) > 10)
-stopifnot(sum(rir.functionInvocations(add_forceinline)) <= 3)
+stopifnot(sum(rir.functionInvocations(add_noinline1)) == 1000)
+stopifnot(sum(rir.functionInvocations(add_nospecial)) > 100)
+stopifnot(sum(rir.functionInvocations(add_forceinline)) <= 800)
 stopifnot(length(rir.functionInvocations(add_nospecial)) == 2)
 stopifnot(length(rir.functionInvocations(add_noinline2)) >= 4)


### PR DESCRIPTION
use rdtsc to trigger compilation after an instruction threshold.

This is the second try, with only the heuristic changes in isolation