### PR TITLE
move all flags and counters from Code to Function

### DIFF
--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -217,6 +217,7 @@ struct AbstractREnvironment {
     }
 
     void leak() { leaked_ = true; }
+    void unleak() { leaked_ = false; }
     bool leaked() const { return leaked_; }
 
     AbstractResult merge(const AbstractREnvironment& other) {

--- a/rir/src/compiler/analysis/abstract_value.h
+++ b/rir/src/compiler/analysis/abstract_value.h
@@ -330,6 +330,13 @@ class AbstractREnvironmentHierarchy {
 
     SmallMap<Value*, Value*> aliases;
 
+    bool allTainted() const {
+        for (auto e : envs)
+            if (!e.second.tainted)
+                return false;
+        return true;
+    }
+
     AbstractResult mergeExit(const AbstractREnvironmentHierarchy& other) {
         return merge(other);
     }

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -295,7 +295,8 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
                 auto upd = state.forcedPromise.find(mkarg);
                 if (upd == state.forcedPromise.end()) {
                     if (depth < MAX_DEPTH && !fixedPointReached() &&
-                        force->strict) {
+                        force->strict &&
+                        mkarg->prom()->numInstrs() < MAX_PROM_SIZE) {
 
                         // We are certain that we do force something
                         // here. Let's peek through the argument and see

--- a/rir/src/compiler/analysis/scope.cpp
+++ b/rir/src/compiler/analysis/scope.cpp
@@ -297,7 +297,7 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
                 auto upd = state.forcedPromise.find(mkarg);
                 if (upd == state.forcedPromise.end()) {
                     if (depth < MAX_DEPTH && !fixedPointReached() &&
-                        force->strict &&
+                        force->strict && !state.envs.allTainted() &&
                         mkarg->prom()->numInstrs() < MAX_PROM_SIZE) {
 
                         // We are certain that we do force something
@@ -385,6 +385,9 @@ AbstractResult ScopeAnalysis::doCompute(ScopeAnalysisState& state,
                 return;
 
             if (version->numNonDeoptInstrs() > MAX_SIZE)
+                return;
+
+            if (state.envs.allTainted())
                 return;
 
             std::vector<Value*> args;

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -65,10 +65,11 @@ class ScopeAnalysisState {
         if (forcedPromise.size() != other.forcedPromise.size()) {
             for (auto u = other.forcedPromise.begin();
                  u != other.forcedPromise.end(); u++) {
-                if (!forcedPromise.count(u->first))
+                if (!forcedPromise.count(u->first)) {
                     forcedPromise[u->first] = AbstractPirValue::tainted();
+                    res.lostPrecision();
+                }
             }
-            res.lostPrecision();
         }
 
         return res.max(envs.merge(other.envs));

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -111,8 +111,9 @@ class ScopeAnalysis
 
     static constexpr size_t MAX_DEPTH = 2;
     static constexpr size_t MAX_SIZE = 140;
-    static constexpr size_t MAX_PROM_SIZE = 12;
+    static constexpr size_t MAX_PROM_SIZE = 32;
     static constexpr size_t MAX_RESULTS = 800;
+    static constexpr size_t MAX_SUB_ANALYSIS = 12;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();
     bool inPromise = false;

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -110,6 +110,7 @@ class ScopeAnalysis
 
     static constexpr size_t MAX_DEPTH = 2;
     static constexpr size_t MAX_SIZE = 140;
+    static constexpr size_t MAX_PROM_SIZE = 12;
     static constexpr size_t MAX_RESULTS = 800;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();

--- a/rir/src/compiler/analysis/scope.h
+++ b/rir/src/compiler/analysis/scope.h
@@ -110,10 +110,10 @@ class ScopeAnalysis
     const std::vector<Value*> args;
 
     static constexpr size_t MAX_DEPTH = 2;
-    static constexpr size_t MAX_SIZE = 140;
-    static constexpr size_t MAX_PROM_SIZE = 32;
+    static constexpr size_t MAX_SIZE = 120;
+    static constexpr size_t MAX_PROM_SIZE = 14;
     static constexpr size_t MAX_RESULTS = 800;
-    static constexpr size_t MAX_SUB_ANALYSIS = 12;
+    static constexpr size_t MAX_SUB_ANALYSIS = 10;
     size_t depth;
     Value* staticClosureEnv = Env::notClosed();
     bool inPromise = false;

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -389,6 +389,8 @@ rir::Function* Backend::doCompile(ClosureVersion* cls,
 
     log.finalPIR(cls);
     function.finalize(body, signature, cls->context());
+    for (auto& c : done)
+        c.second->function(function.function());
 
     function.function()->inheritFlags(cls->owner()->rirFunction());
     return function.function();

--- a/rir/src/compiler/compiler.cpp
+++ b/rir/src/compiler/compiler.cpp
@@ -240,7 +240,8 @@ void Compiler::compileClosure(Closure* closure, rir::Function* optFunction,
 
 bool MEASURE_COMPILER_PERF = getenv("PIR_MEASURE_COMPILER") ? true : false;
 
-static void findUnreachable(Module* m, StreamLogger& log) {
+static void findUnreachable(Module* m, StreamLogger& log,
+                            const std::string& where) {
     std::unordered_map<Closure*, std::unordered_set<Context>> reachable;
     bool changed = true;
 
@@ -268,7 +269,22 @@ static void findUnreachable(Module* m, StreamLogger& log) {
                 if (reachableVersions.count(v->context())) {
                     auto check = [&](Instruction* i) {
                         if (auto call = StaticCall::Cast(i)) {
-                            assert(call->tryDispatch());
+                            if (!call->tryDispatch()) {
+                                std::stringstream msg;
+                                msg << "After pass " << where
+                                    << " found a broken static call. Available "
+                                       "versions:\n";
+                                call->cls()->eachVersion(
+                                    [&](ClosureVersion* v) {
+                                        msg << v->context() << "\n";
+                                    });
+                                msg << "Available Assumptions:\n"
+                                    << call->inferAvailableAssumptions()
+                                    << "\n";
+                                msg << "In:\n";
+                                i->printRecursive(msg, 2);
+                                log.warn(msg.str());
+                            }
                             found(call->tryDispatch());
                             found(call->tryOptimisticDispatch());
                             found(call->hint);
@@ -317,7 +333,7 @@ void Compiler::optimizeModule() {
         if (translation->isSlow()) {
             if (MEASURE_COMPILER_PERF)
                 Measuring::startTimer("compiler.cpp: module cleanup");
-            findUnreachable(module, logger);
+            findUnreachable(module, logger, translation->getName());
             if (MEASURE_COMPILER_PERF)
                 Measuring::countTimer("compiler.cpp: module cleanup");
         }

--- a/rir/src/compiler/compiler.cpp
+++ b/rir/src/compiler/compiler.cpp
@@ -73,7 +73,8 @@ void Compiler::compileFunction(rir::DispatchTable* src, const std::string& name,
                    fail, outerFeedback);
 }
 
-void Compiler::compileContinuation(SEXP closure, const ContinuationContext* ctx,
+void Compiler::compileContinuation(SEXP closure, rir::Function* curFun,
+                                   const ContinuationContext* ctx,
                                    MaybeCnt success, Maybe fail) {
 
     assert(isValidClosureSEXP(closure));
@@ -83,7 +84,7 @@ void Compiler::compileContinuation(SEXP closure, const ContinuationContext* ctx,
 
     auto pirClosure = module->getOrDeclareRirClosure(
         ctx->asDeoptContext() ? "deoptless" : "osr", closure, fun, {});
-    auto version = pirClosure->declareContinuation(ctx);
+    auto version = pirClosure->declareContinuation(ctx, curFun);
 
     Builder builder(version, pirClosure->closureEnv());
     auto& log = logger.begin(version);

--- a/rir/src/compiler/compiler.h
+++ b/rir/src/compiler/compiler.h
@@ -39,8 +39,9 @@ class Compiler {
                          SEXP formals, SEXP srcRef, const Context& ctx,
                          MaybeCls success, Maybe fail,
                          std::list<PirTypeFeedback*> outerFeedback);
-    void compileContinuation(SEXP closure, const ContinuationContext* ctx,
-                             MaybeCnt success, Maybe fail);
+    void compileContinuation(SEXP closure, rir::Function* curFun,
+                             const ContinuationContext* ctx, MaybeCnt success,
+                             Maybe fail);
 
     void optimizeModule();
 

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -1370,7 +1370,7 @@ static SEXP nativeCallTrampolineImpl(ArglistOrder::CallId callId, rir::Code* c,
     case TypeAssumption::Arg##__i__##IsNonRefl_:                               \
     case TypeAssumption::Arg##__i__##IsEager_: {                               \
         auto a = call.stackArg(__i__);                                         \
-        if (TYPEOF(a) == PROMSXP && PRVALUE(a) == R_MissingArg)                \
+        if (TYPEOF(a) == PROMSXP && PRVALUE(a) == R_UnboundValue)              \
             fail = true;                                                       \
         break;                                                                 \
     }

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -3500,9 +3500,9 @@ void LowerFunctionLLVM::compile() {
                 auto t = bb->trueBranch();
                 auto f = bb->falseBranch();
                 MDNode* weight = nullptr;
-                bool retrigger =
-                    cls->owner()->rirFunction()->deoptCount() > 0 ||
-                    cls->isContinuation();
+                bool retrigger = (cls->optFunction->isOptimized() &&
+                                  cls->optFunction->deoptCount() > 0) ||
+                                 cls->isContinuation();
                 bool chaos =
                     br->deoptTrigger && Parameter::DEOPT_CHAOS &&
                     (!retrigger || !Parameter::DEOPT_CHAOS_NO_RETRIGGER);
@@ -5934,7 +5934,6 @@ void LowerFunctionLLVM::compile() {
                 break;
 
             case Tag::Int3:
-            case Tag::PrintInvocation:
                 assert(false);
                 break;
 

--- a/rir/src/compiler/osr.cpp
+++ b/rir/src/compiler/osr.cpp
@@ -22,7 +22,7 @@ Function* OSR::compile(SEXP closure, rir::Code* c,
     pir::Backend backend(module, logger, "continuation");
 
     cmp.compileContinuation(
-        closure, &ctx,
+        closure, c->function(), &ctx,
         [&](Continuation* cnt) {
             cmp.optimizeModule();
             fun = backend.getOrCompile(cnt);

--- a/rir/src/compiler/pir/builder.cpp
+++ b/rir/src/compiler/pir/builder.cpp
@@ -170,10 +170,10 @@ Builder::Builder(ClosureVersion* version, Value* closureEnv)
     }
 
     auto mkenv = new MkEnv(closureEnv, closure->formals().names(), args.data());
-    auto rirCode = version->owner()->rirFunction()->body();
-    if (rirCode->flags.contains(rir::Code::NeedsFullEnv))
+    auto rirFun = version->owner()->rirFunction();
+    if (rirFun->flags.contains(rir::Function::NeedsFullEnv))
         mkenv->neverStub = true;
-    mkenv->updateTypeFeedback().feedbackOrigin.srcCode(rirCode);
+    mkenv->updateTypeFeedback().feedbackOrigin.srcCode(rirFun->body());
     add(mkenv);
     this->env = mkenv;
 }

--- a/rir/src/compiler/pir/closure.cpp
+++ b/rir/src/compiler/pir/closure.cpp
@@ -64,10 +64,11 @@ ClosureVersion* Closure::findCompatibleVersion(const Context& ctx) const {
     return nullptr;
 }
 
-Continuation* Closure::declareContinuation(const ContinuationContext* ctx) {
+Continuation* Closure::declareContinuation(const ContinuationContext* ctx,
+                                           rir::Function* fun) {
     for (auto& c : continuations)
         assert(!(c->continuationContext == ctx));
-    continuations.push_back(new Continuation(this, ctx));
+    continuations.push_back(new Continuation(this, fun, ctx));
     return continuations.back();
 }
 

--- a/rir/src/compiler/pir/closure.h
+++ b/rir/src/compiler/pir/closure.h
@@ -77,7 +77,8 @@ class Closure {
 
     ClosureVersion* declareVersion(const Context&, bool root,
                                    rir::Function* optFunction);
-    Continuation* declareContinuation(const ContinuationContext*);
+    Continuation* declareContinuation(const ContinuationContext*,
+                                      rir::Function* fun);
     void erase(const Context& ctx) { versions.erase(ctx); }
 
     bool existsVersion(const Context& ctx) { return versions.count(ctx); }

--- a/rir/src/compiler/pir/continuation.cpp
+++ b/rir/src/compiler/pir/continuation.cpp
@@ -4,9 +4,9 @@
 namespace rir {
 namespace pir {
 
-Continuation::Continuation(Closure* closure,
+Continuation::Continuation(Closure* closure, rir::Function* fun,
                            const ContinuationContext* continuationContext)
-    : ClosureVersion(closure, nullptr, true, Compiler::defaultContext,
+    : ClosureVersion(closure, fun, true, Compiler::defaultContext,
                      Properties()),
       continuationContext(continuationContext) {}
 

--- a/rir/src/compiler/pir/continuation.h
+++ b/rir/src/compiler/pir/continuation.h
@@ -10,7 +10,7 @@ namespace pir {
 class Continuation : public ClosureVersion {
   public:
     const ContinuationContext* continuationContext;
-    Continuation(Closure* closure,
+    Continuation(Closure* closure, rir::Function* fun,
                  const ContinuationContext* continuationContext);
     Continuation* isContinuation() override final { return this; }
 };

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -76,7 +76,7 @@ inline bool RecompileCondition(DispatchTable* table, Function* fun,
             fun == table->baseline() ||
             (context.smaller(fun->context()) &&
              context.isImproving(fun) > table->size()) ||
-            fun->body()->flags.contains(Code::Reoptimise));
+            fun->flags.contains(Function::Reoptimize));
 }
 
 inline void DoRecompile(Function* fun, SEXP ast, SEXP callee, Context given,
@@ -122,7 +122,6 @@ void deoptFramesWithContext(InterpreterInstance* ctx,
                             DeoptMetadata* deoptData, SEXP sysparent,
                             size_t pos, size_t stackHeight,
                             RCNTXT* currentContext);
-void recordDeoptReason(SEXP val, const DeoptReason& reason);
 void jit(SEXP cls, SEXP name, InterpreterInstance* ctx);
 
 SEXP seq_int(int n1, int n2);

--- a/rir/src/interpreter/profiler.cpp
+++ b/rir/src/interpreter/profiler.cpp
@@ -98,7 +98,7 @@ void RuntimeProfiler::sample(int signal) {
     // at least one slot justifies re-opt.
     if (goodValues >= (slotCount / 2) && needReopt) {
         // set global re-opt flag
-        code->flags.set(Code::Reoptimise);
+        code->function()->flags.set(Function::Reoptimize);
         compilations++;
     }
 }

--- a/rir/src/ir/insns.h
+++ b/rir/src/ir/insns.h
@@ -456,6 +456,5 @@ DEF_INSTR(record_type_, 1, 1, 1)
 DEF_INSTR(record_test_, 1, 1, 1)
 
 DEF_INSTR(int3_, 0, 0, 0)
-DEF_INSTR(printInvocation_, 0, 0, 0)
 
 #undef DEF_INSTR

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -55,7 +55,7 @@ struct DispatchTable
                       << "\n";
 #endif
             auto e = get(i);
-            if (a.smaller(e->context()) && !e->body()->isDeoptimized)
+            if (a.smaller(e->context()) && !e->disabled())
                 return e;
         }
         return baseline();
@@ -75,7 +75,7 @@ struct DispatchTable
     bool contains(const Context& assumptions) const {
         for (size_t i = 0; i < size(); ++i)
             if (get(i)->context() == assumptions)
-                return !get(i)->body()->isDeoptimized;
+                return !get(i)->disabled();
         return false;
     }
 
@@ -108,7 +108,7 @@ struct DispatchTable
                 if (i != 0) {
                     // Remember deopt counts across recompilation to avoid
                     // deopt loops
-                    fun->body()->deoptCount += old->body()->deoptCount;
+                    fun->addDeoptCount(old->deoptCount());
                     setEntry(i, fun->container());
                     assert(get(i) == fun);
                 }

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -78,7 +78,10 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
         if (invocationCount_ > 0)
             invocationCount_--;
     }
-    void registerInvocation() { invocationCount_++; }
+    void registerInvocation() {
+        if (invocationCount_ < UINT_MAX)
+            invocationCount_++;
+    }
     size_t invocationCount() { return invocationCount_; }
 
     size_t deoptCount() { return deoptCount_; }

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -78,10 +78,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
         if (invocationCount_ > 0)
             invocationCount_--;
     }
-    void registerInvocation() {
-        if (invocationCount_ < 1e8)
-            invocationCount_++;
-    }
+    void registerInvocation() { invocationCount_++; }
     size_t invocationCount() { return invocationCount_; }
 
     size_t deoptCount() { return deoptCount_; }
@@ -163,8 +160,6 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     unsigned numArgs_;
 
     unsigned invocationCount_ = 0;
-    unsigned long invoked = 0;
-    unsigned long execTime = 0;
 
     unsigned deoptCount_ = 0;
     unsigned deadCallReached_ = 0;

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -62,6 +62,11 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     void serialize(SEXP refTable, R_outpstream_t out) const;
     void disassemble(std::ostream&);
 
+    bool isOptimized() const {
+        return signature_.optimization !=
+               FunctionSignature::OptimizationLevel::Baseline;
+    }
+
     Code* defaultArg(size_t i) const {
         assert(i < numArgs_);
         if (!defaultArg_[i])
@@ -69,11 +74,18 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
         return Code::unpack(defaultArg_[i]);
     }
 
-    void unregisterInvocation() { body()->unregisterInvocation(); }
-    void registerInvocation() { body()->registerInvocation(); }
-    size_t invocationCount() { return body()->funInvocationCount; }
-    void registerDeopt() { body()->registerDeopt(); }
-    size_t deoptCount() { return body()->deoptCount; }
+    void unregisterInvocation() {
+        if (invocationCount_ > 0)
+            invocationCount_--;
+    }
+    void registerInvocation() {
+        if (invocationCount_ < 1e8)
+            invocationCount_++;
+    }
+    size_t invocationCount() { return invocationCount_; }
+
+    size_t deoptCount() { return deoptCount_; }
+    void addDeoptCount(size_t n) { deoptCount_ += n; }
 
     unsigned size; /// Size, in bytes, of the function and its data
 
@@ -88,6 +100,8 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     V(InnerFunction)                                                           \
     V(DisableAllSpecialization)                                                \
     V(DisableArgumentTypeSpecialization)                                       \
+    V(NeedsFullEnv)                                                            \
+    V(Reoptimize)                                                              \
     V(DisableNumArgumentsSpezialization)
 
     enum Flag {
@@ -121,12 +135,39 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     const FunctionSignature& signature() const { return signature_; }
     const Context& context() const { return context_; }
 
-    bool disabled() const {
-        return body()->isDeoptimized || flags.contains(Flag::Deopt);
+    bool disabled() const { return flags.contains(Flag::Deopt); }
+
+    void registerDeopt() {
+        // Deopt counts are kept on the optimized versions
+        assert(isOptimized());
+        flags.set(Flag::Deopt);
+        if (deoptCount_ < UINT_MAX)
+            deoptCount_++;
+    }
+
+    void registerDeoptReason(DeoptReason::Reason r) {
+        // Deopt reasons are counted in the baseline
+        assert(!isOptimized());
+        if (r == DeoptReason::DeadCall)
+            deadCallReached_++;
+        if (r == DeoptReason::EnvStubMaterialized)
+            flags.set(NeedsFullEnv);
+    }
+
+    size_t deadCallReached() const {
+        assert(!isOptimized());
+        return deadCallReached_;
     }
 
   private:
     unsigned numArgs_;
+
+    unsigned invocationCount_ = 0;
+    unsigned long invoked = 0;
+    unsigned long execTime = 0;
+
+    unsigned deoptCount_ = 0;
+    unsigned deadCallReached_ = 0;
 
     FunctionSignature signature_; /// pointer to this version's signature
     Context context_;

--- a/rir/src/runtime/FunctionSignature.h
+++ b/rir/src/runtime/FunctionSignature.h
@@ -28,6 +28,8 @@ struct FunctionSignature {
         FunctionSignature sig(envc, opt);
         sig.numArguments = numArgs;
         sig.dotsPosition = InInteger(inp);
+        sig.hasDotsFormals = InInteger(inp);
+        sig.hasDefaultArgs = InInteger(inp);
         return sig;
     }
 
@@ -36,6 +38,8 @@ struct FunctionSignature {
         OutInteger(out, (int)optimization);
         OutInteger(out, numArguments);
         OutInteger(out, dotsPosition);
+        OutInteger(out, hasDotsFormals);
+        OutInteger(out, hasDefaultArgs);
     }
 
     void pushFormal(SEXP arg, SEXP name) {

--- a/rir/src/runtime/TypeFeedback.h
+++ b/rir/src/runtime/TypeFeedback.h
@@ -235,6 +235,8 @@ struct DeoptReason {
         return DeoptReason(FeedbackOrigin(0, 0), Unknown);
     }
 
+    void record(SEXP val) const;
+
     DeoptReason() = delete;
 
   private:

--- a/rir/src/simple_instruction_list.h
+++ b/rir/src/simple_instruction_list.h
@@ -13,8 +13,6 @@
 // - Add an INSTRUCTION(<name lower case>_) { ... } to interp.cpp:
 //   this defines how to interpret the instruction
 
-#define SIMPLE_INSTRUCTIONS(V, NESTED)                                         \
-V(NESTED, int3, Int3)                                                          \
-V(NESTED, printInvocation, PrintInvocation)                                    \
+#define SIMPLE_INSTRUCTIONS(V, NESTED) V(NESTED, int3, Int3)
 
 #endif

--- a/rir/src/utils/FunctionWriter.h
+++ b/rir/src/utils/FunctionWriter.h
@@ -19,6 +19,7 @@ class FunctionWriter {
   private:
     Function* function_;
     std::vector<SEXP> defaultArgs;
+    std::vector<rir::Code*> codes;
     Preserve preserve;
 
   public:
@@ -54,6 +55,8 @@ class FunctionWriter {
         preserve(store);
 
         assert(fun->info.magic == FUNCTION_MAGIC);
+        for (auto& c : codes)
+            c->function(fun);
 
         function_ = fun;
     }
@@ -184,6 +187,7 @@ class FunctionWriter {
         }
 
         assert(numberOfSources == sources.size());
+        codes.push_back(code);
 
         return code;
     }

--- a/rir/tests/regression_interprocedural_scope.r
+++ b/rir/tests/regression_interprocedural_scope.r
@@ -1,0 +1,8 @@
+a <- function(b, c = nchar(b))
+
+    utils:::.win32consoleCompletion(b, c)
+
+a("")
+a("")
+a("data(")
+a("")

--- a/rir/tests/regression_stats.R
+++ b/rir/tests/regression_stats.R
@@ -1,0 +1,13 @@
+  a <- b <- 0
+  plot(a, b    
+       )
+example(glm )
+d <- c(1,3.8,4.4,5.1, 4,4.2,5, 2.6,5.3, 5.4)
+attributes(d) <- list(Size = 5)
+str(hclust(d ))
+dhc <- as.dendrogram(hclust(dist(USArrests) ))
+e <- dhc
+dendrapply(e, function(f) str(attributes(f)))
+df <- data.frame(id = 4,
+                 visit = I(c("","") ))
+reshape(df, timevar = "visit" , direction = "wide")


### PR DESCRIPTION
Many counters and flags were on the body Code instead of rir::Function,
because the code had no pointer back to function. Let's add that pointer
and move all the counters to where they belong.