### PR TITLE
Support for deopts in promises

### DIFF
--- a/rir/src/compiler/analysis/context_stack.h
+++ b/rir/src/compiler/analysis/context_stack.h
@@ -15,7 +15,7 @@ struct ContextStackState {
             if (auto mk = MkEnv::Cast((*i)->env()))
                 it(mk);
     }
-    size_t context() const { return contextStack.size(); }
+    size_t numContexts() const { return contextStack.size(); }
     AbstractResult merge(const ContextStackState& other) {
         assert(contextStack.size() == other.contextStack.size() &&
                "stack imbalance");

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -1,5 +1,6 @@
 #include "backend.h"
 #include "R/BuiltinIds.h"
+#include "analysis/context_stack.h"
 #include "analysis/dead.h"
 #include "bc/CodeStream.h"
 #include "bc/CodeVerifier.h"
@@ -106,10 +107,27 @@ static void approximateNeedsLdVarForUpdate(
     });
 }
 
-static void lower(Module* module, Code* code) {
+static void lower(Module* module, ClosureVersion* cls, Code* code,
+                  AbstractLog& log) {
     DeadInstructions representAsReal(
         code, 1, Effects::Any(),
         DeadInstructions::IgnoreUsesThatDontObserveIntVsReal);
+
+    // If we take a deopt that's in between a PushContext/PopContext pair but
+    // whose Checkpoint is not, we have to remove the extra context(s). We emit
+    // DropContext instructions for this while lowering the Assume to a branch.
+    ContextStack cs(cls, code, log);
+    std::unordered_map<Assume*, size_t> nDropContexts;
+    Visitor::run(code->entry, [&](Instruction* i) {
+        if (auto a = Assume::Cast(i)) {
+            auto beforeA = cs.before(a).numContexts();
+            auto beforeCp = cs.before(a->checkpoint()).numContexts();
+
+            assert(nDropContexts.count(a) == 0);
+            assert(beforeCp <= beforeA);
+            nDropContexts[a] = beforeA - beforeCp;
+        }
+    });
 
     Visitor::runPostChange(code->entry, [&](BB* bb) {
         auto it = bb->begin();
@@ -207,8 +225,8 @@ static void lower(Module* module, Code* code) {
                         debugMessage += " failed\n";
                     }
                     BBTransform::lowerAssume(
-                        module, code, bb, it, assume, expectation,
-                        assume->checkpoint()->deoptBranch(),
+                        module, code, bb, it, assume, nDropContexts.at(assume),
+                        expectation, assume->checkpoint()->deoptBranch(),
                         debugMessage);
                     // lowerExpect splits the bb from current position. There
                     // remains nothing to process. Breaking seems more robust
@@ -324,7 +342,7 @@ rir::Function* Backend::doCompile(ClosureVersion* cls, ClosureLog& log) {
     std::function<void(Code*)> lowerAndScanForPromises = [&](Code* c) {
         if (promMap.count(c))
             return;
-        lower(module, c);
+        lower(module, cls, c, log);
         toCSSA(module, c);
         log.CSSA(c);
 #ifdef FULLVERIFIER

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -58,7 +58,7 @@ static void approximateNeedsLdVarForUpdate(
                     }
                 }
                 if (auto mk = MkEnv::Cast(ld->env()))
-                    if (mk->stub && mk->arg(mk->indexOf(ld->varName)).val() !=
+                    if (mk->stub && mk->argNamed(ld->varName).val() !=
                                         UnboundValue::instance())
                         return;
 

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -184,31 +184,31 @@ static void lower(Module* module, Code* code) {
                                              Tombstone::framestate(), 0));
                     next = it + 2;
                 }
-            } else if (auto expect = Assume::Cast(*it)) {
-                if (expect->triviallyHolds()) {
+            } else if (auto assume = Assume::Cast(*it)) {
+                if (assume->triviallyHolds()) {
                     next = bb->remove(it);
                 } else {
-                    auto expectation = expect->assumeTrue;
+                    auto expectation = assume->assumeTrue;
                     std::string debugMessage;
                     if (Parameter::DEBUG_DEOPTS) {
                         debugMessage = "DEOPT, assumption ";
                         {
                             std::stringstream dump;
                             if (auto i =
-                                    Instruction::Cast(expect->condition())) {
+                                    Instruction::Cast(assume->condition())) {
                                 dump << "\n";
                                 i->printRecursive(dump, 4);
                                 dump << "\n";
                             } else {
-                                expect->condition()->printRef(dump);
+                                assume->condition()->printRef(dump);
                             }
                             debugMessage += dump.str();
                         }
                         debugMessage += " failed\n";
                     }
-                    BBTransform::lowerExpect(
-                        module, code, bb, it, expect, expectation,
-                        expect->checkpoint()->bb()->falseBranch(),
+                    BBTransform::lowerAssume(
+                        module, code, bb, it, assume, expectation,
+                        assume->checkpoint()->deoptBranch(),
                         debugMessage);
                     // lowerExpect splits the bb from current position. There
                     // remains nothing to process. Breaking seems more robust

--- a/rir/src/compiler/compiler.cpp
+++ b/rir/src/compiler/compiler.cpp
@@ -155,7 +155,7 @@ void Compiler::compileClosure(Closure* closure, rir::Function* optFunction,
         auto arg = closure->formals().defaultArgs()[idx];
         assert(rir::Code::check(arg) && "Default arg not compiled");
         auto code = rir::Code::unpack(arg);
-        auto res = rir2pir.tryCreateArg(code, builder, false);
+        auto res = rir2pir.tryCreateArg(code, builder);
         if (!res) {
             failedToCompileDefaultArgs = true;
             return;

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -2163,8 +2163,7 @@ void initClosureContextImpl(ArglistOrder::CallId callId, rir::Code* c, SEXP ast,
 }
 
 static void endClosureContextImpl(RCNTXT* cntxt, SEXP result) {
-    cntxt->returnValue = result;
-    Rf_endcontext(cntxt);
+    endClosureContext(cntxt, result);
 }
 
 int ncolsImpl(SEXP v) { return getMatrixDim(v).col; }

--- a/rir/src/compiler/native/builtins.h
+++ b/rir/src/compiler/native/builtins.h
@@ -87,6 +87,7 @@ struct NativeBuiltins {
         length,
         recordTypefeedback,
         deopt,
+        deoptProm,
         assertFail,
         printValue,
         extract11,

--- a/rir/src/compiler/native/lower_function_llvm.cpp
+++ b/rir/src/compiler/native/lower_function_llvm.cpp
@@ -2112,6 +2112,7 @@ void LowerFunctionLLVM::compile() {
         stack({container(paramCode())});
         additionalStackSlots++;
     }
+
     {
         SmallSet<std::pair<Value*, SEXP>> bindings;
         Visitor::run(code->entry, [&](Instruction* i) {

--- a/rir/src/compiler/opt/hoist_instruction.cpp
+++ b/rir/src/compiler/opt/hoist_instruction.cpp
@@ -145,7 +145,8 @@ bool HoistInstruction::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                 while (b->isEmpty())
                     b = *b->predecessors().begin();
 
-                if (cs.after(b->last()).context() > cs.before(i).context()) {
+                if (cs.after(b->last()).numContexts() >
+                    cs.before(i).numContexts()) {
                     ip = next;
                     continue;
                 }

--- a/rir/src/compiler/opt/inline.cpp
+++ b/rir/src/compiler/opt/inline.cpp
@@ -36,486 +36,477 @@ bool Inline::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
         return cls->rirFunction()->flags.contains(rir::Function::NotInlineable);
     };
 
-    Visitor::run(
-        code->entry, [&](BB* bb) {
-            // Dangerous iterater usage, works since we do only update it in
-            // one place.
-            for (auto it = bb->begin(); it != bb->end() && fuel; it++) {
-                if (!CallInstruction::CastCall(*it))
+    Visitor::run(code->entry, [&](BB* bb) {
+        // Dangerous iterater usage, works since we do only update it in
+        // one place.
+        for (auto it = bb->begin(); it != bb->end() && fuel; it++) {
+            if (!CallInstruction::CastCall(*it))
+                continue;
+
+            Closure* inlineeCls = nullptr;
+            ClosureVersion* inlinee = nullptr;
+            Value* staticEnv = nullptr;
+
+            bool hasDotslistArg = false;
+            const FrameState* callerFrameState = nullptr;
+            if (auto call = Call::Cast(*it)) {
+                auto mk = MkCls::Cast(call->cls()->followCastsAndForce());
+                if (!mk)
                     continue;
-
-                Closure* inlineeCls = nullptr;
-                ClosureVersion* inlinee = nullptr;
-                Value* staticEnv = nullptr;
-
-                bool hasDotslistArg = false;
-                const FrameState* callerFrameState = nullptr;
-                if (auto call = Call::Cast(*it)) {
-                    auto mk = MkCls::Cast(call->cls()->followCastsAndForce());
-                    if (!mk)
-                        continue;
-                    inlineeCls = mk->tryGetCls();
-                    if (!inlineeCls)
-                        continue;
-                    if (dontInline(inlineeCls))
-                        continue;
-                    inlinee = call->tryDispatch(inlineeCls);
-                    if (!inlinee)
-                        continue;
-                    bool hasDotArgs = false;
-                    call->eachCallArg([&](Value* v) {
-                        if (ExpandDots::Cast(v))
-                            hasDotArgs = true;
-                    });
-                    // TODO do some argument matching
-                    if (hasDotArgs)
-                        continue;
-                    staticEnv = mk->lexicalEnv();
-                    callerFrameState = call->frameState();
-                } else if (auto call = StaticCall::Cast(*it)) {
-                    inlineeCls = call->cls();
-                    if (dontInline(inlineeCls))
-                        continue;
-                    inlinee = call->tryDispatch();
-                    if (!inlinee)
-                        continue;
-                    // if we don't know the closure of the inlinee, we can't
-                    // inline.
-                    staticEnv = inlineeCls->closureEnv();
-                    if (inlineeCls->closureEnv() == Env::notClosed() &&
-                        inlinee != cls) {
-                        if (Query::noParentEnv(inlinee)) {
-                        } else if (auto mk =
-                                       MkCls::Cast(call->runtimeClosure())) {
-                            staticEnv = mk->lexicalEnv();
-                        } else if (call->runtimeClosure() !=
-                                   Tombstone::closure()) {
-                            static SEXP b = nullptr;
-                            if (!b) {
-                                auto idx = rir::blt("environment");
-                                b = Rf_allocSExp(BUILTINSXP);
-                                b->u.primsxp.offset = idx;
-                                R_PreserveObject(b);
-                            }
-                            auto e = new CallSafeBuiltin(
-                                b, {call->runtimeClosure()}, 0);
-                            e->type = PirType::env();
-                            e->effects.reset();
-                            it = bb->insert(it, e);
-                            it++;
-                            staticEnv = e;
-                        } else {
-                            continue;
-                        }
-                    }
-                    call->eachCallArg([&](Value* v) {
-                        assert(!ExpandDots::Cast(v));
-                        if (DotsList::Cast(v))
-                            hasDotslistArg = true;
-                    });
-                    callerFrameState = call->frameState();
-                } else {
+                inlineeCls = mk->tryGetCls();
+                if (!inlineeCls)
                     continue;
-                }
-
                 if (dontInline(inlineeCls))
                     continue;
-
-                enum SafeToInline {
-                    Yes,
-                    NeedsContext,
-                    No,
-                };
-
-                // TODO: instead of blacklisting those, we could also create
-                // contexts for inlined functions.
-                SafeToInline allowInline = SafeToInline::Yes;
-                std::function<void(Code*)> updateAllowInline = [&](Code* code) {
-                    Visitor::check(code->entry, [&](Instruction* i) {
-                        if (LdFun::Cast(i) || LdVar::Cast(i)) {
-                            auto n = LdFun::Cast(i) ? LdFun::Cast(i)->varName
-                                                    : LdVar::Cast(i)->varName;
-                            if (!SafeBuiltinsList::forInlineByName(n)) {
-                                allowInline = SafeToInline::No;
-                                return false;
-                            }
-                        }
-                        if (auto call = CallInstruction::CastCall(i)) {
-                            if (auto trg = call->tryGetClsArg()) {
-                                if (auto c = Const::Cast(trg)) {
-                                    if (TYPEOF(c->c()) == SPECIALSXP ||
-                                        TYPEOF(c->c()) == BUILTINSXP) {
-                                        if (!SafeBuiltinsList::forInline(
-                                                c->c()->u.primsxp.offset)) {
-                                            allowInline = SafeToInline::No;
-                                            return false;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if (auto call = CallBuiltin::Cast(i)) {
-                            if (!SafeBuiltinsList::forInline(call->builtinId)) {
-                                allowInline = SafeToInline::No;
-                                return false;
-                            }
-                        }
-                        if (allowInline == SafeToInline::Yes &&
-                            i->mayObserveContext()) {
-                            allowInline = SafeToInline::NeedsContext;
-                        }
-                        if (auto mk = MkArg::Cast(i)) {
-                            updateAllowInline(mk->prom());
-                        }
-                        return true;
-                    });
-                };
-
-                size_t weight = inlinee->numNonDeoptInstrs();
-                // The taken information of the call instruction tells us how
-                // many times a call was executed relative to function
-                // invocation. 0 means never, 1 means on every call, above 1
-                // means more than once per call, ie. in a loop.
-                if (auto c = CallInstruction::CastCall(*it)) {
-                    if (c->taken != CallInstruction::UnknownTaken &&
-                        !Parameter::INLINER_INLINE_UNLIKELY) {
-                        // Policy: for calls taken about 80% the time the weight
-                        // stays unchanged. Below it's increased and above it
-                        // is decreased, but not more than 4x
-                        double adjust = 1.25 * c->taken;
-                        if (adjust > 4)
-                            adjust = 4;
-                        if (adjust < 0.2)
-                            adjust = 0.2;
-                        weight = (double)weight / adjust;
-                        // Inline only small methods if we are getting close to
-                        // the limit.
-                        auto limit = (double)inlinee->numNonDeoptInstrs() /
-                                     (double)Parameter::INLINER_MAX_SIZE;
-                        limit = (limit * 4) + 1;
-                        weight *= limit;
-                    }
-                }
-                auto env = Env::Cast(inlineeCls->closureEnv());
-                if (env && env->rho && R_IsNamespaceEnv(env->rho)) {
-                    auto expr = BODY_EXPR(inlineeCls->rirClosure());
-                    // Closure wrappers for internals
-                    if (CAR(expr) == rir::symbol::Internal)
-                        weight *= 0.6;
-                    // those usually strongly benefit type
-                    // inference, since they have a lot of case
-                    // distinctions
-                    static auto profitable = std::unordered_set<std::string>(
-                        {"matrix", "array", "vector", "cat"});
-                    if (profitable.count(inlineeCls->name()))
-                        weight *= 0.4;
-                }
-                if (hasDotslistArg)
-                    weight *= 0.4;
-                if (!(*it)->typeFeedback().type.isVoid() &&
-                    (*it)->typeFeedback().type.unboxable())
-                    weight *= 0.9;
-
-                // No recursive inlining
-                if (inlinee->owner() == cls->owner() ||
-                    (callerFrameState &&
-                     callerFrameState->code ==
-                         inlinee->owner()->rirFunction()->body())) {
+                inlinee = call->tryDispatch(inlineeCls);
+                if (!inlinee)
                     continue;
-                } else if (weight > Parameter::INLINER_MAX_INLINEE_SIZE) {
-                    if (!inlineeCls->rirFunction()->flags.contains(
-                            rir::Function::ForceInline) &&
-                        inlinee->numNonDeoptInstrs() >
-                            Parameter::INLINER_MAX_INLINEE_SIZE * 4)
-                        inlineeCls->rirFunction()->flags.set(
-                            rir::Function::NotInlineable);
+                bool hasDotArgs = false;
+                call->eachCallArg([&](Value* v) {
+                    if (ExpandDots::Cast(v))
+                        hasDotArgs = true;
+                });
+                // TODO do some argument matching
+                if (hasDotArgs)
                     continue;
-                } else {
-                    updateAllowInline(inlinee);
-                    inlinee->eachPromise(
-                        [&](Promise* p) { updateAllowInline(p); });
-                    if (allowInline == SafeToInline::No) {
-                        inlineeCls->rirFunction()->flags.set(
-                            rir::Function::NotInlineable);
+                staticEnv = mk->lexicalEnv();
+                callerFrameState = call->frameState();
+            } else if (auto call = StaticCall::Cast(*it)) {
+                inlineeCls = call->cls();
+                if (dontInline(inlineeCls))
+                    continue;
+                inlinee = call->tryDispatch();
+                if (!inlinee)
+                    continue;
+                // if we don't know the closure of the inlinee, we can't
+                // inline.
+                staticEnv = inlineeCls->closureEnv();
+                if (inlineeCls->closureEnv() == Env::notClosed() &&
+                    inlinee != cls) {
+                    if (Query::noParentEnv(inlinee)) {
+                    } else if (auto mk = MkCls::Cast(call->runtimeClosure())) {
+                        staticEnv = mk->lexicalEnv();
+                    } else if (call->runtimeClosure() != Tombstone::closure()) {
+                        static SEXP b = nullptr;
+                        if (!b) {
+                            auto idx = rir::blt("environment");
+                            b = Rf_allocSExp(BUILTINSXP);
+                            b->u.primsxp.offset = idx;
+                            R_PreserveObject(b);
+                        }
+                        auto e =
+                            new CallSafeBuiltin(b, {call->runtimeClosure()}, 0);
+                        e->type = PirType::env();
+                        e->effects.reset();
+                        it = bb->insert(it, e);
+                        it++;
+                        staticEnv = e;
+                    } else {
                         continue;
                     }
                 }
+                call->eachCallArg([&](Value* v) {
+                    assert(!ExpandDots::Cast(v));
+                    if (DotsList::Cast(v))
+                        hasDotslistArg = true;
+                });
+                callerFrameState = call->frameState();
+            } else {
+                continue;
+            }
 
+            if (dontInline(inlineeCls))
+                continue;
+
+            enum SafeToInline {
+                Yes,
+                NeedsContext,
+                No,
+            };
+
+            // TODO: instead of blacklisting those, we could also create
+            // contexts for inlined functions.
+            SafeToInline allowInline = SafeToInline::Yes;
+            std::function<void(Code*)> updateAllowInline = [&](Code* code) {
+                Visitor::check(code->entry, [&](Instruction* i) {
+                    if (LdFun::Cast(i) || LdVar::Cast(i)) {
+                        auto n = LdFun::Cast(i) ? LdFun::Cast(i)->varName
+                                                : LdVar::Cast(i)->varName;
+                        if (!SafeBuiltinsList::forInlineByName(n)) {
+                            allowInline = SafeToInline::No;
+                            return false;
+                        }
+                    }
+                    if (auto call = CallInstruction::CastCall(i)) {
+                        if (auto trg = call->tryGetClsArg()) {
+                            if (auto c = Const::Cast(trg)) {
+                                if (TYPEOF(c->c()) == SPECIALSXP ||
+                                    TYPEOF(c->c()) == BUILTINSXP) {
+                                    if (!SafeBuiltinsList::forInline(
+                                            c->c()->u.primsxp.offset)) {
+                                        allowInline = SafeToInline::No;
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (auto call = CallBuiltin::Cast(i)) {
+                        if (!SafeBuiltinsList::forInline(call->builtinId)) {
+                            allowInline = SafeToInline::No;
+                            return false;
+                        }
+                    }
+                    if (allowInline == SafeToInline::Yes &&
+                        i->mayObserveContext()) {
+                        allowInline = SafeToInline::NeedsContext;
+                    }
+                    if (auto mk = MkArg::Cast(i)) {
+                        updateAllowInline(mk->prom());
+                    }
+                    return true;
+                });
+            };
+
+            size_t weight = inlinee->numNonDeoptInstrs();
+            // The taken information of the call instruction tells us how
+            // many times a call was executed relative to function
+            // invocation. 0 means never, 1 means on every call, above 1
+            // means more than once per call, ie. in a loop.
+            if (auto c = CallInstruction::CastCall(*it)) {
+                if (c->taken != CallInstruction::UnknownTaken &&
+                    !Parameter::INLINER_INLINE_UNLIKELY) {
+                    // Policy: for calls taken about 80% the time the weight
+                    // stays unchanged. Below it's increased and above it
+                    // is decreased, but not more than 4x
+                    double adjust = 1.25 * c->taken;
+                    if (adjust > 4)
+                        adjust = 4;
+                    if (adjust < 0.2)
+                        adjust = 0.2;
+                    weight = (double)weight / adjust;
+                    // Inline only small methods if we are getting close to
+                    // the limit.
+                    auto limit = (double)inlinee->numNonDeoptInstrs() /
+                                 (double)Parameter::INLINER_MAX_SIZE;
+                    limit = (limit * 4) + 1;
+                    weight *= limit;
+                }
+            }
+            auto env = Env::Cast(inlineeCls->closureEnv());
+            if (env && env->rho && R_IsNamespaceEnv(env->rho)) {
+                auto expr = BODY_EXPR(inlineeCls->rirClosure());
+                // Closure wrappers for internals
+                if (CAR(expr) == rir::symbol::Internal)
+                    weight *= 0.6;
+                // those usually strongly benefit type
+                // inference, since they have a lot of case
+                // distinctions
+                static auto profitable = std::unordered_set<std::string>(
+                    {"matrix", "array", "vector", "cat"});
+                if (profitable.count(inlineeCls->name()))
+                    weight *= 0.4;
+            }
+            if (hasDotslistArg)
+                weight *= 0.4;
+            if (!(*it)->typeFeedback().type.isVoid() &&
+                (*it)->typeFeedback().type.unboxable())
+                weight *= 0.9;
+
+            // No recursive inlining
+            if (inlinee->owner() == cls->owner() ||
+                (callerFrameState &&
+                 callerFrameState->code ==
+                     inlinee->owner()->rirFunction()->body())) {
+                continue;
+            } else if (weight > Parameter::INLINER_MAX_INLINEE_SIZE) {
                 if (!inlineeCls->rirFunction()->flags.contains(
-                        rir::Function::ForceInline))
-                    fuel--;
+                        rir::Function::ForceInline) &&
+                    inlinee->numNonDeoptInstrs() >
+                        Parameter::INLINER_MAX_INLINEE_SIZE * 4)
+                    inlineeCls->rirFunction()->flags.set(
+                        rir::Function::NotInlineable);
+                continue;
+            } else {
+                updateAllowInline(inlinee);
+                inlinee->eachPromise([&](Promise* p) { updateAllowInline(p); });
+                if (allowInline == SafeToInline::No) {
+                    inlineeCls->rirFunction()->flags.set(
+                        rir::Function::NotInlineable);
+                    continue;
+                }
+            }
 
-                cls->inlinees++;
+            if (!inlineeCls->rirFunction()->flags.contains(
+                    rir::Function::ForceInline))
+                fuel--;
 
-                BB* split = BBTransform::split(cls->nextBBId++, bb, it, cls);
-                auto theCall = *split->begin();
-                auto theCallInstruction = CallInstruction::CastCall(theCall);
-                std::vector<Value*> arguments;
-                theCallInstruction->eachCallArg(
-                    [&](Value* v) { arguments.push_back(v); });
+            cls->inlinees++;
 
-                // Clone the version
-                BB* copy = BBTransform::clone(inlinee->entry, code, cls);
+            BB* split = BBTransform::split(cls->nextBBId++, bb, it, cls);
+            auto theCall = *split->begin();
+            auto theCallInstruction = CallInstruction::CastCall(theCall);
+            std::vector<Value*> arguments;
+            theCallInstruction->eachCallArg(
+                [&](Value* v) { arguments.push_back(v); });
 
-                bool needsEnvPatching = inlineeCls->closureEnv() != staticEnv;
+            // Clone the version
+            BB* copy = BBTransform::clone(inlinee->entry, code, cls);
 
-                bool failedToInline = false;
-                bool hasNonLocalReturn = false;
-                bool hasReturn = false;
-                Visitor::run(copy, [&](BB* bb) {
-                    auto ip = bb->begin();
-                    while (!failedToInline && ip != bb->end()) {
-                        auto next = ip + 1;
-                        auto ld = LdArg::Cast(*ip);
-                        Instruction* i = *ip;
+            bool needsEnvPatching = inlineeCls->closureEnv() != staticEnv;
 
-                        if (auto l = LdFunctionEnv::Cast(i)) {
-                            l->replaceUsesWith(staticEnv);
-                            l->effects.reset();
+            bool failedToInline = false;
+            bool hasNonLocalReturn = false;
+            bool hasReturn = false;
+            Visitor::run(copy, [&](BB* bb) {
+                auto ip = bb->begin();
+                while (!failedToInline && ip != bb->end()) {
+                    auto next = ip + 1;
+                    auto ld = LdArg::Cast(*ip);
+                    Instruction* i = *ip;
+
+                    if (auto l = LdFunctionEnv::Cast(i)) {
+                        l->replaceUsesWith(staticEnv);
+                        l->effects.reset();
+                    }
+
+                    if (Return::Cast(i))
+                        hasReturn = true;
+                    if (NonLocalReturn::Cast(i))
+                        hasNonLocalReturn = true;
+
+                    if (auto sp = FrameState::Cast(i)) {
+                        if (!callerFrameState) {
+                            failedToInline = true;
+                            return;
                         }
 
-                        if (Return::Cast(i))
-                            hasReturn = true;
-                        if (NonLocalReturn::Cast(i))
-                            hasNonLocalReturn = true;
+                        // When inlining a frameState we need to chain it
+                        // with the frameStates after the call to the
+                        // inlinee
+                        if (!sp->next()) {
+                            auto copyFromFs = callerFrameState;
+                            auto cloneSp =
+                                FrameState::Cast(copyFromFs->clone());
 
-                        if (auto sp = FrameState::Cast(i)) {
-                            if (!callerFrameState) {
-                                failedToInline = true;
-                                return;
-                            }
+                            ip = bb->insert(ip, cloneSp);
+                            sp->next(cloneSp);
 
-                            // When inlining a frameState we need to chain it
-                            // with the frameStates after the call to the
-                            // inlinee
-                            if (!sp->next()) {
-                                auto copyFromFs = callerFrameState;
-                                auto cloneSp =
-                                    FrameState::Cast(copyFromFs->clone());
+                            size_t created = 1;
+                            while (copyFromFs->next()) {
+                                assert(copyFromFs->next() == cloneSp->next());
+                                copyFromFs = copyFromFs->next();
+                                auto prevClone = cloneSp;
+                                cloneSp = FrameState::Cast(copyFromFs->clone());
 
                                 ip = bb->insert(ip, cloneSp);
-                                sp->next(cloneSp);
+                                created++;
 
-                                size_t created = 1;
-                                while (copyFromFs->next()) {
-                                    assert(copyFromFs->next() ==
-                                           cloneSp->next());
-                                    copyFromFs = copyFromFs->next();
-                                    auto prevClone = cloneSp;
-                                    cloneSp =
-                                        FrameState::Cast(copyFromFs->clone());
-
-                                    ip = bb->insert(ip, cloneSp);
-                                    created++;
-
-                                    prevClone->updateNext(cloneSp);
-                                }
-
-                                next = ip + created + 1;
+                                prevClone->updateNext(cloneSp);
                             }
-                        }
-                        // If the inlining resolved some env, we need to
-                        // update. For example this happens if we inline an
-                        // inner version. Then the lexical env is the current
-                        // versions env.
-                        if (needsEnvPatching && i->hasEnv() &&
-                            i->env() == inlineeCls->closureEnv()) {
-                            i->env(staticEnv);
-                        }
 
-                        // If we inline without context, then we need to update
-                        // the mkEnv instructions in the inlinee, such that
-                        // they do not update the (non-existing) context.
-                        if (allowInline != SafeToInline::NeedsContext) {
-                            if (auto mk = MkEnv::Cast(i)) {
-                                mk->context--;
-                            }
+                            next = ip + created + 1;
                         }
+                    }
+                    // If the inlining resolved some env, we need to
+                    // update. For example this happens if we inline an
+                    // inner version. Then the lexical env is the current
+                    // versions env.
+                    if (needsEnvPatching && i->hasEnv() &&
+                        i->env() == inlineeCls->closureEnv()) {
+                        i->env(staticEnv);
+                    }
 
-                        if (ld) {
-                            Value* a = (ld->pos < arguments.size())
-                                           ? arguments[ld->pos]
-                                           : MissingArg::instance();
-                            if (auto mk = MkArg::Cast(a)) {
-                                if (!ld->type.maybePromiseWrapped()) {
-                                    // This load already expects to load an
-                                    // eager value. We can just discard the
-                                    // promise altogether.
-                                    assert(mk->isEager());
-                                    a = mk->eagerArg();
-                                } else {
-                                    // We need to cast from a promise to a lazy
-                                    // value
-                                    auto type = ld->type.notMissing();
-                                    if (mk->isEager()) {
-                                        auto inType = mk->eagerArg()->type;
-                                        type =
-                                            inType.forced().orPromiseWrapped();
-                                        if (!inType.maybeMissing())
-                                            type = type.notMissing();
-                                    }
-                                    auto cast = new CastType(
-                                        a, CastType::Upcast, RType::prom, type);
-                                    ip = bb->insert(ip + 1, cast);
-                                    ip--;
-                                    a = cast;
-                                }
-                            }
-                            if (a == MissingArg::instance()) {
-                                ld->replaceUsesWith(
-                                    a, [&](Instruction* usage, size_t arg) {
-                                        if (auto mk = MkEnv::Cast(usage))
-                                            mk->missing[arg] = true;
-                                    });
+                    // If we inline without context, then we need to update
+                    // the mkEnv instructions in the inlinee, such that
+                    // they do not update the (non-existing) context.
+                    if (allowInline != SafeToInline::NeedsContext) {
+                        if (auto mk = MkEnv::Cast(i)) {
+                            mk->context--;
+                        }
+                    }
+
+                    if (ld) {
+                        Value* a = (ld->pos < arguments.size())
+                                       ? arguments[ld->pos]
+                                       : MissingArg::instance();
+                        if (auto mk = MkArg::Cast(a)) {
+                            if (!ld->type.maybePromiseWrapped()) {
+                                // This load already expects to load an
+                                // eager value. We can just discard the
+                                // promise altogether.
+                                assert(mk->isEager());
+                                a = mk->eagerArg();
                             } else {
-                                ld->replaceUsesWith(a);
+                                // We need to cast from a promise to a lazy
+                                // value
+                                auto type = ld->type.notMissing();
+                                if (mk->isEager()) {
+                                    auto inType = mk->eagerArg()->type;
+                                    type = inType.forced().orPromiseWrapped();
+                                    if (!inType.maybeMissing())
+                                        type = type.notMissing();
+                                }
+                                auto cast = new CastType(a, CastType::Upcast,
+                                                         RType::prom, type);
+                                ip = bb->insert(ip + 1, cast);
+                                ip--;
+                                a = cast;
                             }
-                            next = bb->remove(ip);
                         }
-                        ip = next;
+                        if (a == MissingArg::instance()) {
+                            ld->replaceUsesWith(
+                                a, [&](Instruction* usage, size_t arg) {
+                                    if (auto mk = MkEnv::Cast(usage))
+                                        mk->missing[arg] = true;
+                                });
+                        } else {
+                            ld->replaceUsesWith(a);
+                        }
+                        next = bb->remove(ip);
+                    }
+                    ip = next;
+                }
+            });
+
+            if (!hasReturn && !hasNonLocalReturn)
+                failedToInline = true;
+
+            if (failedToInline) {
+                std::vector<BB*> toDel;
+                Visitor::run(copy, [&](BB* bb) { toDel.push_back(bb); });
+                for (auto bb : toDel)
+                    delete bb;
+                bb->overrideNext(split);
+                inlineeCls->rirFunction()->flags.set(
+                    rir::Function::NotInlineable);
+            } else {
+                anyChange = true;
+                Checkpoint* cpAtCall = nullptr;
+                {
+                    AvailableCheckpoints cp(cls, code, log);
+                    cpAtCall = cp.at(theCall);
+                }
+
+                bb->overrideNext(copy);
+
+                // Copy over promises used by the inner version
+                std::vector<bool> copiedPromise(false);
+                std::vector<size_t> newPromId;
+                copiedPromise.resize(inlinee->promises().size(), false);
+                newPromId.resize(inlinee->promises().size());
+                Visitor::run(copy, [&](BB* bb) {
+                    auto it = bb->begin();
+                    while (it != bb->end()) {
+                        MkArg* mk = MkArg::Cast(*it);
+                        it++;
+                        if (!mk)
+                            continue;
+
+                        size_t id = mk->prom()->id;
+                        if (mk->prom()->owner == inlinee) {
+                            assert(id < copiedPromise.size());
+                            if (copiedPromise[id]) {
+                                mk->updatePromise(
+                                    cls->promises().at(newPromId[id]));
+                            } else {
+                                Promise* clone =
+                                    cls->createProm(mk->prom()->rirSrc());
+                                BB* promCopy = BBTransform::clone(
+                                    mk->prom()->entry, clone, cls);
+                                clone->entry = promCopy;
+                                newPromId[id] = clone->id;
+                                copiedPromise[id] = true;
+                                mk->updatePromise(clone);
+                            }
+                        }
                     }
                 });
 
-                if (!hasReturn && !hasNonLocalReturn)
-                    failedToInline = true;
+                auto inlineeRes = BBTransform::forInline(
+                    copy, split, inlineeCls->closureEnv(), cpAtCall);
 
-                if (failedToInline) {
-                    std::vector<BB*> toDel;
-                    Visitor::run(copy, [&](BB* bb) { toDel.push_back(bb); });
-                    for (auto bb : toDel)
-                        delete bb;
-                    bb->overrideNext(split);
-                    inlineeCls->rirFunction()->flags.set(
-                        rir::Function::NotInlineable);
-                } else {
-                    anyChange = true;
-                    Checkpoint* cpAtCall = nullptr;
-                    {
-                        AvailableCheckpoints cp(cls, code, log);
-                        cpAtCall = cp.at(theCall);
+                assert(inlineeRes != Tombstone::unreachable());
+
+                if (allowInline == SafeToInline::NeedsContext) {
+                    Value* op = nullptr;
+                    auto prologue = copy;
+                    copy = BBTransform::split(cls->nextBBId++, copy,
+                                              copy->begin(), cls);
+                    assert(prologue->isEmpty());
+                    if (auto call = Call::Cast(theCall)) {
+                        op = call->cls();
+                    } else if (auto call = StaticCall::Cast(theCall)) {
+                        if (call->runtimeClosure() != Tombstone::closure()) {
+                            op = call->runtimeClosure();
+                        } else {
+                            op = cmp.module->c(call->cls()->rirClosure());
+                        }
                     }
+                    assert(op);
+                    auto ast = cmp.module->c(rir::Pool::get(theCall->srcIdx));
+                    auto ctx = new PushContext(ast, op, theCallInstruction,
+                                               theCall->env());
+                    prologue->append(ctx);
 
-                    bb->overrideNext(copy);
+                    auto popc = new PopContext(inlineeRes, ctx);
+                    split->insert(split->begin() + 1, popc);
+                    popc->type = popc->type & theCall->type;
+                    popc->updateTypeAndEffects();
 
-                    // Copy over promises used by the inner version
-                    std::vector<bool> copiedPromise(false);
-                    std::vector<size_t> newPromId;
-                    copiedPromise.resize(inlinee->promises().size(), false);
-                    newPromId.resize(inlinee->promises().size());
-                    Visitor::run(copy, [&](BB* bb) {
-                        auto it = bb->begin();
-                        while (it != bb->end()) {
-                            MkArg* mk = MkArg::Cast(*it);
-                            it++;
-                            if (!mk)
-                                continue;
-
-                            size_t id = mk->prom()->id;
-                            if (mk->prom()->owner == inlinee) {
-                                assert(id < copiedPromise.size());
-                                if (copiedPromise[id]) {
-                                    mk->updatePromise(
-                                        cls->promises().at(newPromId[id]));
-                                } else {
-                                    Promise* clone =
-                                        cls->createProm(mk->prom()->rirSrc());
-                                    BB* promCopy = BBTransform::clone(
-                                        mk->prom()->entry, clone, cls);
-                                    clone->entry = promCopy;
-                                    newPromId[id] = clone->id;
-                                    copiedPromise[id] = true;
-                                    mk->updatePromise(clone);
-                                }
-                            }
-                        }
-                    });
-
-                    auto inlineeRes = BBTransform::forInline(
-                        copy, split, inlineeCls->closureEnv(), cpAtCall);
-
-                    assert(inlineeRes != Tombstone::unreachable());
-
-                    if (allowInline == SafeToInline::NeedsContext) {
-                        Value* op = nullptr;
-                        auto prologue = copy;
-                        copy = BBTransform::split(cls->nextBBId++, copy,
-                                                  copy->begin(), cls);
-                        assert(prologue->isEmpty());
-                        if (auto call = Call::Cast(theCall)) {
-                            op = call->cls();
-                        } else if (auto call = StaticCall::Cast(theCall)) {
-                            if (call->runtimeClosure() !=
-                                Tombstone::closure()) {
-                                op = call->runtimeClosure();
-                            } else {
-                                op = cmp.module->c(call->cls()->rirClosure());
-                            }
-                        }
-                        assert(op);
-                        auto ast =
-                            cmp.module->c(rir::Pool::get(theCall->srcIdx));
-                        auto ctx = new PushContext(ast, op, theCallInstruction,
-                                                   theCall->env());
-                        prologue->append(ctx);
-
-                        auto popc = new PopContext(inlineeRes, ctx);
-                        split->insert(split->begin() + 1, popc);
-                        popc->type = popc->type & theCall->type;
-                        popc->updateTypeAndEffects();
-
-                        if (hasNonLocalReturn) {
-                            assert(split->predecessors().empty());
-                            assert(copy->hasSinglePred());
-                            // No normal return, this means that pop-context
-                            // looks unreachable, even though it is reachable
-                            // through non-local returns.
-                            auto fake1 = new BB(cls, cls->nextBBId++);
-                            // avoids critical edge
-                            auto fake2 = new BB(cls, cls->nextBBId++);
-                            assert(((const BB*)prologue)->next() == copy);
-                            prologue->overrideNext(fake1);
-                            fake1->append(new Branch(OpaqueTrue::instance()));
-                            fake1->setSuccessors({fake2, split});
-                            fake2->setSuccessors({copy});
-                        }
-                        inlineeRes = popc;
+                    if (hasNonLocalReturn) {
+                        assert(split->predecessors().empty());
+                        assert(copy->hasSinglePred());
+                        // No normal return, this means that pop-context
+                        // looks unreachable, even though it is reachable
+                        // through non-local returns.
+                        auto fake1 = new BB(cls, cls->nextBBId++);
+                        // avoids critical edge
+                        auto fake2 = new BB(cls, cls->nextBBId++);
+                        assert(((const BB*)prologue)->next() == copy);
+                        prologue->overrideNext(fake1);
+                        fake1->append(new Branch(OpaqueTrue::instance()));
+                        fake1->setSuccessors({fake2, split});
+                        fake2->setSuccessors({copy});
                     }
-
-                    theCall->replaceUsesWith(inlineeRes);
-
-                    // Remove the call instruction
-                    split->remove(split->begin());
+                    inlineeRes = popc;
                 }
 
-                bb = split;
-                it = split->begin();
+                theCall->replaceUsesWith(inlineeRes);
 
-                // Can happen if split only contained the call instruction
-                if (it == split->end())
-                    break;
+                // Remove the call instruction
+                split->remove(split->begin());
             }
-        });
+
+            bb = split;
+            it = split->begin();
+
+            // Can happen if split only contained the call instruction
+            if (it == split->end())
+                break;
+        }
+    });
 
     return anyChange;
 }
 
-// TODO: maybe implement something more resonable to pass in those constants.
+// TODO: maybe implement something more reasonable to pass in those constants.
 // For now it seems a simple env variable is just fine.
-    size_t Parameter::INLINER_MAX_SIZE =
-        getenv("PIR_INLINER_MAX_SIZE") ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
-                                       : 2500;
-    size_t Parameter::INLINER_MAX_INLINEE_SIZE =
-        getenv("PIR_INLINER_MAX_INLINEE_SIZE")
-            ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
-            : 90;
-    size_t Parameter::INLINER_INITIAL_FUEL =
-        getenv("PIR_INLINER_INITIAL_FUEL")
-            ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
-            : 15;
-    size_t Parameter::INLINER_INLINE_UNLIKELY =
-        getenv("PIR_INLINER_INLINE_UNLIKELY")
-            ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))
-            : 0;
+size_t Parameter::INLINER_MAX_SIZE = getenv("PIR_INLINER_MAX_SIZE")
+                                         ? atoi(getenv("PIR_INLINER_MAX_SIZE"))
+                                         : 2500;
+size_t Parameter::INLINER_MAX_INLINEE_SIZE =
+    getenv("PIR_INLINER_MAX_INLINEE_SIZE")
+        ? atoi(getenv("PIR_INLINER_MAX_INLINEE_SIZE"))
+        : 90;
+size_t Parameter::INLINER_INITIAL_FUEL =
+    getenv("PIR_INLINER_INITIAL_FUEL")
+        ? atoi(getenv("PIR_INLINER_INITIAL_FUEL"))
+        : 15;
+size_t Parameter::INLINER_INLINE_UNLIKELY =
+    getenv("PIR_INLINER_INLINE_UNLIKELY")
+        ? atoi(getenv("PIR_INLINER_INLINE_UNLIKELY"))
+        : 0;
 
 } // namespace pir
 } // namespace rir

--- a/rir/src/compiler/opt/pass_definitions.h
+++ b/rir/src/compiler/opt/pass_definitions.h
@@ -71,7 +71,6 @@ PASS(DelayEnv, false, false)
  * passes will do the smart parts.
  */
 PASS(Inline, false, false)
-// PASS(Inline, true, false)
 
 /*
  * Goes through every operation that for the general case needs an environment
@@ -145,7 +144,6 @@ PASS(LoadElision, false, false)
 PASS(TypeInference, true, false)
 
 PASS(TypeSpeculation, false, false)
-// PASS(TypeSpeculation, true, false)
 
 PASS(PromiseSplitter, false, false)
 

--- a/rir/src/compiler/opt/scope_resolution.cpp
+++ b/rir/src/compiler/opt/scope_resolution.cpp
@@ -478,10 +478,9 @@ bool ScopeResolution::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                                     if (mk->context) {
                                         auto diff =
                                             contexts.before(deoptEnv)
-                                                .context() -
-                                            contexts.before(mk).context();
-                                        deoptEnv->context =
-                                            mk->context + diff;
+                                                .numContexts() -
+                                            contexts.before(mk).numContexts();
+                                        deoptEnv->context = mk->context + diff;
                                     } else {
                                         deoptEnv->context = 0;
                                     }

--- a/rir/src/compiler/pir/builder.cpp
+++ b/rir/src/compiler/pir/builder.cpp
@@ -123,8 +123,7 @@ Builder::Builder(Continuation* cnt, Value* closureEnv)
             e++;
             i++;
         }
-        auto mkenv = new MkEnv(closureEnv, names, args.data());
-        mkenv->missing = miss;
+        auto mkenv = new MkEnv(closureEnv, names, args.data(), miss);
 
         auto rirCode = cnt->owner()->rirFunction()->body();
         mkenv->updateTypeFeedback().feedbackOrigin.srcCode(rirCode);

--- a/rir/src/compiler/pir/code.h
+++ b/rir/src/compiler/pir/code.h
@@ -34,6 +34,8 @@ class Code {
     virtual rir::Code* rirSrc() const = 0;
     virtual void printName(std::ostream&) const = 0;
 
+    virtual bool isPromise() const { return false; }
+
     friend std::ostream& operator<<(std::ostream& out, const Code& e) {
         e.printName(out);
         return out;

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2432,7 +2432,7 @@ class VLIE(MkEnv, Effect::LeaksArg) {
         MutableLocalVarIt;
 
     inline void eachLocalVar(MutableLocalVarIt it) {
-        for (size_t i = 0; i < envSlot(); ++i) {
+        for (size_t i = 0; i < nLocals(); ++i) {
             bool m = missing[i];
             it(varName[i], arg(i), m);
             missing[i] = m;
@@ -2440,13 +2440,16 @@ class VLIE(MkEnv, Effect::LeaksArg) {
     }
 
     inline void eachLocalVar(LocalVarIt it) const {
-        for (size_t i = 0; i < envSlot(); ++i)
+        for (size_t i = 0; i < nLocals(); ++i) {
             it(varName[i], arg(i).val(), missing[i]);
+        }
     }
 
     inline void eachLocalVarRev(LocalVarIt it) const {
-        for (long i = envSlot() - 1; i >= 0; --i)
-            it(varName[i], arg(i).val(), missing[i]);
+        for (size_t i = 0; i < nLocals(); ++i) {
+            size_t ri = nLocals() - i - 1;
+            it(varName[ri], arg(ri).val(), missing[ri]);
+        }
     }
 
     MkEnv(Value* lexicalEnv, const std::vector<SEXP>& names, Value** args,
@@ -2482,7 +2485,7 @@ class VLIE(MkEnv, Effect::LeaksArg) {
     void printEnv(std::ostream& out, bool tty) const override final {}
     std::string name() const override { return stub ? "(MkEnv)" : "MkEnv"; }
 
-    size_t nLocals() { return nargs() - 1; }
+    size_t nLocals() const { return nargs() - 1; }
 
     int minReferenceCount() const override { return MAX_REFCOUNT; }
 
@@ -2643,12 +2646,12 @@ class VLI(Phi, Effects::None()) {
     const std::vector<BB*>& inputs() { return input; }
     void removeInputs(const std::unordered_set<BB*>& del);
 
-    typedef std::function<void(BB* bb, Value*)> PhiArgumentIterator;
+    typedef std::function<void(BB*, Value*)> PhiArgumentIterator;
     void eachArg(const PhiArgumentIterator& it) const {
         for (size_t i = 0; i < nargs(); ++i)
             it(input[i], arg(i).val());
     }
-    typedef std::function<void(BB* bb, InstrArg&)> MutablePhiArgumentIterator;
+    typedef std::function<void(BB*, InstrArg&)> MutablePhiArgumentIterator;
     void eachArg(const MutablePhiArgumentIterator& it) {
         for (size_t i = 0; i < nargs(); ++i)
             it(input[i], arg(i));

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2363,9 +2363,6 @@ class VLIE(CallBuiltin, Effects::Any()), public CallInstruction {
     Value* callerEnv() { return env(); }
 
     VisibilityFlag visibilityFlag() const override;
-    Value* frameStateOrTs() const override final {
-        return Tombstone::framestate();
-    }
 
   private:
     CallBuiltin(Value * callerEnv, SEXP builtin,
@@ -2406,9 +2403,6 @@ class VLI(CallSafeBuiltin, Effects(Effect::Warn) | Effect::Error |
         const override final;
 
     VisibilityFlag visibilityFlag() const override;
-    Value* frameStateOrTs() const override final {
-        return Tombstone::framestate();
-    }
 
     size_t gvnBase() const override;
 };
@@ -2668,9 +2662,9 @@ class VLI(Phi, Effects::None()) {
 // Instructions targeted specially for speculative optimization
 
 /*
- *  Must be the last instruction of a BB with two childs. One should
+ *  Must be the last instruction of a BB with two children. One should
  *  contain a deopt. Checkpoint takes either branch at random
- *  to ensure the optimizer consider deopt and non-deopt cases.
+ *  to ensure the optimizer considers both deopt and non-deopt cases.
  */
 class Checkpoint : public FixedLenInstruction<Tag::Checkpoint, Checkpoint, 0,
                                               Effects::NoneI(), HasEnvSlot::No,
@@ -2686,7 +2680,7 @@ class Checkpoint : public FixedLenInstruction<Tag::Checkpoint, Checkpoint, 0,
 
 /*
  * Replaces the current execution context with the one described by the
- * referenced framestate and jump to the deoptimized version of the
+ * referenced framestate and jumps to the deoptimized version of the
  * code at the point the framestate stores
  */
 
@@ -2698,9 +2692,7 @@ class Deopt : public FixedLenInstruction<Tag::Deopt, Deopt, 3, Effects::AnyI(),
     explicit Deopt(FrameState* frameState);
 
     Value* frameStateOrTs() const override final { return arg<0>().val(); }
-    FrameState* frameState() const {
-        return FrameState::Cast(frameStateOrTs());
-    }
+    void updateFrameState(Value* fs) override final { arg<0>().val() = fs; }
 
     bool hasDeoptReason() const;
 

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2562,6 +2562,11 @@ class FLI(PopContext, 2, Effect::ChangesContexts) {
     Value* result() const { return arg<0>().val(); }
 };
 
+class FLI(DropContext, 0, Effect::ChangesContexts) {
+  public:
+    DropContext() : FixedLenInstruction(PirType::voyd()) {}
+};
+
 class FLIE(LdDots, 1, Effect::ReadsEnv) {
   public:
     std::vector<SEXP> names;

--- a/rir/src/compiler/pir/instruction_list.h
+++ b/rir/src/compiler/pir/instruction_list.h
@@ -103,6 +103,7 @@
     V(MaterializeEnv)                                                          \
     V(PushContext)                                                             \
     V(PopContext)                                                              \
+    V(DropContext)                                                             \
     V(LdFunctionEnv)                                                           \
     V(Inc)                                                                     \
     V(Is)                                                                      \

--- a/rir/src/compiler/pir/promise.h
+++ b/rir/src/compiler/pir/promise.h
@@ -22,6 +22,8 @@ class Promise : public Code {
 
     void printName(std::ostream& out) const override;
 
+    bool isPromise() const override final { return true; }
+
   private:
     rir::Code* rirSrc_;
     const unsigned srcPoolIdx_;

--- a/rir/src/compiler/pir/singleton_values.h
+++ b/rir/src/compiler/pir/singleton_values.h
@@ -156,6 +156,7 @@ class Tombstone : public Value {
   private:
     explicit Tombstone(PirType t) : Value(t, Tag::Tombstone) {}
 };
+
 } // namespace pir
 } // namespace rir
 

--- a/rir/src/compiler/pir/tag.h
+++ b/rir/src/compiler/pir/tag.h
@@ -20,12 +20,13 @@ enum class Tag : uint8_t {
     COMPILER_INSTRUCTIONS(V)
 #undef V
 #define V(I) I,
-        COMPILER_VALUES(V)
+    COMPILER_VALUES(V)
 #undef V
 };
 
 const char* tagToStr(Tag t);
-}
-}
+
+} // namespace pir
+} // namespace rir
 
 #endif

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -1691,7 +1691,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert, Opcode* start,
     } else {
         BB* merge = insert.createBB();
         insert.enterBB(merge);
-        Phi* phi = insert(new Phi());
+        auto phi = insert(new Phi);
         for (auto r : results) {
             r.first->setNext(merge);
             phi->addInput(r.first, r.second);

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -811,7 +811,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                 break;
             }
 
-            // Specialcase for calling usemethod, the first argument is eager.
+            // Specialcase for calling UseMethod, the first argument is eager.
             // This helps determine the object type of the caller.
             {
                 auto dt = DispatchTable::unpack(BODY(ti.monomorphic));

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -163,8 +163,7 @@ Checkpoint* Rir2Pir::addCheckpoint(rir::Code* srcCode, Opcode* pos,
     return insert.emitCheckpoint(srcCode, pos, stack, inPromise());
 }
 
-Value* Rir2Pir::tryCreateArg(rir::Code* promiseCode, Builder& insert,
-                             bool eager) {
+Value* Rir2Pir::tryCreateArg(rir::Code* promiseCode, Builder& insert) {
     Promise* prom = insert.function->createProm(promiseCode);
     {
         Builder promiseBuilder(insert.function, prom);
@@ -175,17 +174,12 @@ Value* Rir2Pir::tryCreateArg(rir::Code* promiseCode, Builder& insert,
     }
 
     Value* eagerVal = UnboundValue::instance();
-    if (eager || Query::pureExceptDeopt(prom)) {
+    if (Query::pureExceptDeopt(prom)) {
         eagerVal = tryInlinePromise(promiseCode, insert);
         if (!eagerVal) {
             log.warn("Failed to inline a promise");
             return nullptr;
         }
-    }
-
-    if (eager) {
-        assert(eagerVal != UnboundValue::instance());
-        return eagerVal;
     }
 
     return insert(new MkArg(prom, eagerVal, insert.env));
@@ -437,7 +431,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
 
         // If this call was never executed we might as well compile an
         // unconditional deopt.
-        if (!inPromise() && !inlining() && feedback.taken == 0 &&
+        if (!inlining() && feedback.taken == 0 &&
             insert.function->optFunction->invocationCount() > 1 &&
             srcCode->function()->deadCallReached() < 3) {
             auto sp =
@@ -669,8 +663,8 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
         // Insert a guard if we want to speculate
         if (!staticMonomorphicBuiltin &&
             (monomorphicBuiltin || monomorphicClosure || monomorphicSpecial)) {
-            // Can't speculate in promises
-            if (inPromise()) {
+            // Can't speculate while inlining
+            if (inlining()) {
                 monomorphicBuiltin = monomorphicClosure = monomorphicSpecial =
                     false;
             } else {
@@ -683,12 +677,12 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                     auto bb = cp->nextBB();
                     auto dummyPos = bb->begin();
 
-                    Value* expection = nullptr;
+                    Value* expectation = nullptr;
                     if (ldfun && localFuns.count(ldfun->varName)) {
                         auto mk = localFuns.at(ldfun->varName);
                         if (mk && mk->originalBody->container() ==
                                       BODY(ti.monomorphic)) {
-                            expection = mk;
+                            expectation = mk;
                             // Even though we statically know the env, we must
                             // compile an Env::unclosed() closure here, since we
                             // cannot pass the pir env from the host function to
@@ -701,37 +695,46 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                     guardedCallee = BBTransform::insertCalleeGuard(
                         compiler, ti,
                         DeoptReason(ti.feedbackOrigin, DeoptReason::CallTarget),
-                        callee, stableEnv || expection, expection, cp, bb,
+                        callee, stableEnv || expectation, expectation, cp, bb,
                         dummyPos);
                 }
             }
         }
 
         auto eagerEval = [&](Value*& arg, size_t i, bool promiseWrapped) {
-            if (auto mk = MkArg::Cast(arg)) {
-                if (mk->isEager()) {
-                    arg = mk->eagerArg();
-                } else {
-                    auto original = arg;
-                    arg = tryCreateArg(mk->prom()->rirSrc(), insert, true);
-                    if (promiseWrapped)
-                        arg = insert(new MkArg(mk->prom(), arg, mk->env()));
-                    if (!arg) {
-                        log.warn("Failed to compile a promise");
-                        return false;
-                    }
-                    if (i != (size_t)-1 && at(nargs - 1 - i) == original) {
-                        // Inlined argument evaluation might have side effects.
-                        // Let's have a checkpoint here. This checkpoint needs
-                        // to capture the so far evaluated promises.
-                        stack.at(nargs - 1 - i) =
-                            promiseWrapped
-                                ? arg
-                                : insert(new MkArg(mk->prom(), arg, mk->env()));
-                        addCheckpoint(srcCode, pos, stack, insert);
-                    }
-                }
+            if (!MkArg::Cast(arg)) {
+                return true;
             }
+
+            auto mk = MkArg::Cast(arg);
+            if (mk->isEager()) {
+                arg = mk->eagerArg();
+                return true;
+            }
+
+            assert(!inlining());
+            auto original = arg;
+            arg = tryInlinePromise(mk->prom()->rirSrc(), insert);
+            if (!arg) {
+                log.warn("Failed to inline a promise");
+                return false;
+            }
+
+            if (promiseWrapped) {
+                arg = insert(new MkArg(mk->prom(), arg, mk->env()));
+            }
+
+            if (i != (size_t)-1 && at(nargs - 1 - i) == original) {
+                // Inlined argument evaluation might have side effects.
+                // Let's have a checkpoint here. This checkpoint needs
+                // to capture the so far evaluated promises.
+                stack.at(nargs - 1 - i) =
+                    promiseWrapped
+                        ? arg
+                        : insert(new MkArg(mk->prom(), arg, mk->env()));
+                addCheckpoint(srcCode, pos, stack, insert);
+            }
+
             return true;
         };
 
@@ -1453,7 +1456,7 @@ Value* Rir2Pir::tryTranslate(rir::Code* srcCode, Builder& insert, Opcode* start,
             auto asBool = insert(
                 new Identical(branchCondition, branchReason, PirType::val()));
 
-            if (!inPromise()) {
+            if (!inlining()) {
                 if (auto c = Instruction::Cast(branchCondition)) {
                     auto likely = c->typeFeedback().value;
                     if (likely == True::instance() ||

--- a/rir/src/compiler/rir2pir/rir2pir.h
+++ b/rir/src/compiler/rir2pir/rir2pir.h
@@ -92,6 +92,10 @@ class PromiseRir2Pir : public Rir2Pir {
         : Rir2Pir(cmp, cls, log, name, outerFeedback), inlining_(inlining) {}
 
   private:
+    // This is used for disabling speculation while inlining a promise in
+    // rir2pir (eg, eager eval for builtins). The problem is that the inlined
+    // promise doesn't have a location in rir bytecode, and so deopts would have
+    // nowhere to jump...
     bool inlining_;
     bool inlining() const override final { return inlining_; }
     bool inPromise() const override final { return true; }

--- a/rir/src/compiler/rir2pir/rir2pir.h
+++ b/rir/src/compiler/rir2pir/rir2pir.h
@@ -24,7 +24,7 @@ class Rir2Pir {
                                 const std::vector<PirType>& initialStack)
         __attribute__((warn_unused_result));
 
-    Value* tryCreateArg(rir::Code* prom, Builder& insert, bool eager)
+    Value* tryCreateArg(rir::Code* prom, Builder& insert)
         __attribute__((warn_unused_result));
 
     typedef std::unordered_map<Value*, Checkpoint*> CallTargetCheckpoints;

--- a/rir/src/compiler/util/bb_transform.cpp
+++ b/rir/src/compiler/util/bb_transform.cpp
@@ -172,7 +172,7 @@ Value* BBTransform::forInline(BB* inlinee, BB* splice, Value* context,
     return found;
 }
 
-BB* BBTransform::lowerExpect(Module* m, Code* code, BB* srcBlock,
+BB* BBTransform::lowerAssume(Module* m, Code* code, BB* srcBlock,
                              BB::Instrs::iterator position, Assume* assume,
                              bool condition, BB* deoptBlock_,
                              const std::string& debugMessage) {

--- a/rir/src/compiler/util/bb_transform.cpp
+++ b/rir/src/compiler/util/bb_transform.cpp
@@ -174,8 +174,8 @@ Value* BBTransform::forInline(BB* inlinee, BB* splice, Value* context,
 
 BB* BBTransform::lowerAssume(Module* m, Code* code, BB* srcBlock,
                              BB::Instrs::iterator position, Assume* assume,
-                             bool condition, BB* deoptBlock_,
-                             const std::string& debugMessage) {
+                             size_t nDropContexts, bool condition,
+                             BB* deoptBlock_, const std::string& debugMessage) {
 
     auto split =
         BBTransform::split(code->nextBBId++, srcBlock, position + 1, code);
@@ -195,6 +195,10 @@ BB* BBTransform::lowerAssume(Module* m, Code* code, BB* srcBlock,
         deoptBlock->append(ldmsg2);
         deoptBlock->append(new Call(Env::global(), ldprint, {ldmsg2},
                                     Tombstone::framestate(), 0));
+    }
+
+    while (nDropContexts--) {
+        deoptBlock->append(new DropContext());
     }
 
     auto deoptReason = m->deoptReasonValue(assume->reason);

--- a/rir/src/compiler/util/bb_transform.cpp
+++ b/rir/src/compiler/util/bb_transform.cpp
@@ -125,7 +125,7 @@ Value* BBTransform::forInline(BB* inlinee, BB* splice, Value* context,
                 continue;
             }
 
-            // This is the first cp of the inlinee, lets replace it with the
+            // This is the first CP of the inlinee, let's replace it with the
             // outer CP
             if (pos->isCheckpoint()) {
                 auto cp = Checkpoint::Cast(pos->last());
@@ -205,7 +205,7 @@ BB* BBTransform::lowerExpect(Module* m, Code* code, BB* srcBlock,
     auto d = Deopt::Cast(deoptBlock_->last());
     if (d->deoptReason() == DeoptReasonWrapper::unknown()) {
         auto newDr = new Phi(NativeType::deoptReason);
-        auto newDt = new Phi();
+        auto newDt = new Phi;
         deoptBlock_->insert(deoptBlock_->begin(), newDr);
         deoptBlock_->insert(deoptBlock_->begin(), newDt);
         d->setDeoptReason(newDr, newDt);

--- a/rir/src/compiler/util/bb_transform.h
+++ b/rir/src/compiler/util/bb_transform.h
@@ -28,7 +28,7 @@ class BBTransform {
                      Code* target);
     static Value* forInline(BB* inlinee, BB* cont, Value* context,
                             Checkpoint* entryCp);
-    static BB* lowerExpect(Module* m, Code* closure, BB* src,
+    static BB* lowerAssume(Module* m, Code* closure, BB* src,
                            BB::Instrs::iterator position, Assume* assume,
                            bool condition, BB* deoptBlock,
                            const std::string& debugMesage);

--- a/rir/src/compiler/util/bb_transform.h
+++ b/rir/src/compiler/util/bb_transform.h
@@ -1,11 +1,11 @@
 #ifndef BB_TRANSFORM_H
 #define BB_TRANSFORM_H
 
-#include "../pir/bb.h"
-#include "../pir/pir.h"
-#include "../pir/values.h"
 #include "compiler/analysis/cfg.h"
 #include "compiler/compiler.h"
+#include "compiler/pir/bb.h"
+#include "compiler/pir/pir.h"
+#include "compiler/pir/values.h"
 #include "compiler/rir2pir/rir2pir.h"
 #include "runtime/TypeFeedback.h"
 

--- a/rir/src/compiler/util/bb_transform.h
+++ b/rir/src/compiler/util/bb_transform.h
@@ -30,8 +30,8 @@ class BBTransform {
                             Checkpoint* entryCp);
     static BB* lowerAssume(Module* m, Code* closure, BB* src,
                            BB::Instrs::iterator position, Assume* assume,
-                           bool condition, BB* deoptBlock,
-                           const std::string& debugMesage);
+                           size_t nDropContexts, bool condition,
+                           BB* deoptBlock_, const std::string& debugMesage);
     static void insertAssume(Instruction* condition, bool assumePositive,
                              Checkpoint* cp, const FeedbackOrigin& origin,
                              DeoptReason::Reason reason, BB* bb,

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1670,8 +1670,6 @@ void deoptFramesWithContext(const CallContext* callCtxt,
             // case we leave the result on the top of the stack and the native
             // backend knows that if the deopt returns, it should pop the result
             // from the stack and return it as the promise's result.
-
-            // assert(false);
         }
     }
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -34,41 +34,40 @@ static SEXP evalRirCode(Code* c, SEXP env, const CallContext* callContext,
                         Opcode* initialPc = nullptr,
                         BindingCache* cache = nullptr);
 
+void printStack(int n) {
+    int sz = ostack_length();
+    std::cout << "ostack (length = " << sz << ")\n";
+    if (n > sz)
+        n = sz;
+    for (int i = n; i > 0; i--) {
+        auto cell = ostack_cell_at(i - 1);
+        auto sexp = cell->u.sxpval;
+        std::cout << "* ostack[" << (sz - i) << "] = ";
+        if (cell->tag == 0 && sexp) {
+            std::cout << Print::dumpSexp(sexp, 100);
+        } else {
+            std::cout << "{ tag = " << cell->tag << ", flags = " << cell->flags
+                      << ", u = { ival = " << cell->u.ival
+                      << ", dval = " << cell->u.dval << ", sxpval = " << sexp
+                      << " } }";
+        }
+        std::cout << "\n";
+    }
+    std::cout.flush();
+}
+
 // #define PRINT_INTERP
 // #define PRINT_STACK_SIZE 10
 #ifdef PRINT_INTERP
 static void printInterp(Opcode* pc, Code* c) {
 #ifdef PRINT_STACK_SIZE
-#define INTSEQSXP 9999
     // Prevent printing instructions (and recursing) while printing stack
     static bool printingStackSize = false;
     if (printingStackSize)
         return;
-
     // Print stack
     printingStackSize = true;
-    std::cout << "#; Stack:\n";
-    for (int i = 0;; i++) {
-        auto typ = ostack_cell_at(i)->tag;
-        SEXP sexp = ostack_at(i);
-        if (sexp == nullptr || ostack_length() - i == 0)
-            break;
-        else if (i == PRINT_STACK_SIZE) {
-            std::cout << "    ...\n";
-            break;
-        }
-        if (typ == 0) {
-            std::cout << "    >>> " << Print::dumpSexp(sexp) << " <<<\n";
-        } else if (typ == INTSXP || typ == LGLSXP) {
-            std::cout << "    int/lgl >>> " << ostack_cell_at(i)->u.ival
-                      << " <<<\n";
-        } else if (typ == REALSXP) {
-            std::cout << "    real >>> " << ostack_cell_at(i)->u.dval
-                      << " <<<\n";
-        } else if (typ == INTSEQSXP) {
-            std::cout << "    intseq >>> " << Print::dumpSexp(sexp) << " <<<\n";
-        }
-    }
+    printStack(PRINT_STACK_SIZE);
     printingStackSize = false;
 #endif
     // Print source
@@ -82,7 +81,6 @@ static void printInterp(Opcode* pc, Code* c) {
     std::cout << "#";
     bc.print(std::cout);
 }
-
 static void printLastop() { std::cout << "> lastop\n"; }
 #endif
 
@@ -276,27 +274,27 @@ static void __listAppend(SEXP* front, SEXP* last, SEXP value, SEXP name) {
 #pragma GCC diagnostic ignored "-Wcast-align"
 
 SEXP materialize(SEXP wrapper) {
-    SEXP res = nullptr;
-    RCNTXT* cur = (RCNTXT*)R_GlobalContext;
+
     if (auto lazyArgs = LazyArglist::check(wrapper)) {
-        res = lazyArgs->createArglist();
+        auto res = lazyArgs->createArglist();
         // Fixup the contexts chain
-        while (cur) {
+        for (auto cur = (RCNTXT*)R_GlobalContext; cur; cur = cur->nextcontext) {
             if (cur->promargs == wrapper)
                 cur->promargs = res;
-            cur = cur->nextcontext;
         }
-    } else if (auto lazyEnv = LazyEnvironment::check(wrapper)) {
-        assert(!lazyEnv->materialized());
+        return res;
+    }
 
+    if (auto lazyEnv = LazyEnvironment::check(wrapper)) {
+        assert(!lazyEnv->materialized());
         PROTECT(wrapper);
-        SEXP arglist = R_NilValue;
+        auto arglist = R_NilValue;
         auto names = lazyEnv->names;
         for (size_t i = 0; i < lazyEnv->nargs; ++i) {
-            SEXP val = lazyEnv->getArg(i);
+            auto val = lazyEnv->getArg(i);
             if (val == R_UnboundValue)
                 continue;
-            SEXP name = cp_pool_at(names[i]);
+            auto name = cp_pool_at(names[i]);
             if (TYPEOF(name) == LISTSXP)
                 name = CAR(name);
             // cons protects its args if needed
@@ -308,29 +306,29 @@ SEXP materialize(SEXP wrapper) {
                 SET_MISSING(arglist, 2);
         }
         auto parent = lazyEnv->getParent();
-        res = Rf_NewEnvironment(R_NilValue, arglist, parent);
+        auto res = Rf_NewEnvironment(R_NilValue, arglist, parent);
+        PROTECT(res);
         lazyEnv->materialized(res);
         // Make sure wrapper is not collected by the gc (we may still use it to
         // access the materialized env)
         Rf_setAttrib(res, symbol::delayedEnv, wrapper);
         lazyEnv->clear();
         // Fixup the contexts chain
-        while (cur) {
+        for (auto cur = (RCNTXT*)R_GlobalContext; cur; cur = cur->nextcontext) {
             if (cur->cloenv == wrapper)
                 cur->cloenv = res;
             if (cur->sysparent == wrapper)
                 cur->sysparent = res;
-            cur = cur->nextcontext;
         }
         if (LazyEnvironment::check(parent)) {
             parent = materialize(parent);
             SET_ENCLOS(res, parent);
         }
-
-        UNPROTECT(1);
+        UNPROTECT(2);
+        return res;
     }
-    assert(res);
-    return res;
+
+    assert(false);
 }
 
 SEXP materializeCallerEnv(CallContext& callCtx) {
@@ -1587,6 +1585,8 @@ void deoptFramesWithContext(const CallContext* callCtxt,
     if (auto le = LazyEnvironment::check(deoptEnv)) {
         assert(!le->materialized());
         deoptEnv = materialize(deoptEnv);
+        // Still need to set the cloenv because materialize only patches the
+        // context list starting with R_GlobalContext
         cntxt->cloenv = deoptEnv;
     }
     assert(TYPEOF(deoptEnv) == ENVSXP);


### PR DESCRIPTION
If there is a deoptimization in a promise (that is also the outermost frame, ie.,
forcing a promise that isn't inlined), we cannot longjump out of the optimized
execution, since the promise doesn't have its own context.

Thus we add a return instruction immediately after the deopt, which is only reached
if there was no longjump. In that case, we know that this is the evaluation of
a promise that deoptimized, and the result is left on the stack to be returned.

_TODO: actually use speculation in promises (most passes don't run on promises as of now)_