### PR TITLE
Fix a crash involving switch() and NA_character_

### DIFF
--- a/rir/tests/rir_switch.R
+++ b/rir/tests/rir_switch.R
@@ -65,3 +65,13 @@ stopifnot(f5(2) == "42")
 stopifnot(f5(3) == c(1, 2))
 stopifnot(f5(3.002) == c(1, 2))
 stopifnot(f5(42) == NULL)
+
+
+f6 <- rir.compile(function(x) {
+    switch(x, a=17, 42)
+})
+f7 <- rir.compile(function(x) {
+    switch(x, "NA"=17, 42)
+})
+stopifnot(f6(NA_character_) == 42)
+stopifnot(f7(NA_character_) == 17)


### PR DESCRIPTION
Don't crash our implementation of switch() when receiving NA.
This also solves another issue where the test suite would crash in locales other than en_US.UTF-8.

Fixes #1187.