### PR TITLE
fix tests: install missing xvfb

### DIFF
--- a/container/install-test-deps.sh
+++ b/container/install-test-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get -o dir::cache::archives=apt-cache install -y -qq texlive-latex-base xvfb texlive-fonts-extra tcl tk
+DEBIAN_FRONTEND=noninteractive apt-get -o dir::cache::archives=apt-cache install -y -qq texlive-latex-base xvfb texlive-fonts-extra tcl tk xvfb


### PR DESCRIPTION
This should finally fix these issues: https://gitlab.com/rirvm/rir_mirror/-/jobs/2244682601  https://gitlab.com/rirvm/rir_mirror/-/jobs/2244682601/artifacts/file/logs/-opt-rir-external-custom-r-tests-grDevices.log