### PR TITLE
fix CI x11 connection errors

### DIFF
--- a/tools/gnur-make-tests
+++ b/tools/gnur-make-tests
@@ -25,7 +25,7 @@ XVFB=`which Xvfb 2> /dev/null`
 if [[ "$DISPLAY" == "" && "$XVFB" != "" ]]; then
   # Some tests fail without display
   echo "Starting virtual FB display"
-  Xvfb :1 -ac -screen 0 800x166x16&
+  Xvfb :1 -ac -noreset -screen 0 800x166x16&
   export DISPLAY=:1
   USING_XVFB=true
 fi

--- a/tools/gnur-make-tests
+++ b/tools/gnur-make-tests
@@ -25,6 +25,7 @@ XVFB=`which Xvfb 2> /dev/null`
 if [[ "$DISPLAY" == "" && "$XVFB" != "" ]]; then
   # Some tests fail without display
   echo "Starting virtual FB display"
+  # for some reason noreset prevents XOpenDisplay to fail under high load
   Xvfb :1 -ac -noreset -screen 0 800x166x16&
   export DISPLAY=:1
   USING_XVFB=true


### PR DESCRIPTION
The problem is that sometimes XOpenDisplay in devX11.c:1440 fails. It is
something racy, it only happens if the program is quick to re-open a new
X11 connection after closing one and the machine has a high load.

Seen at https://gitlab.freedesktop.org/mesa/waffle/-/merge_requests/93
the `-noreset` option seems to fix it...