### PR TITLE
Some README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ř
 
-## Giving it as spin
+## Giving it a spin
 
 The easiest way to try Ř is using our pre-built docker container
 
@@ -48,11 +48,6 @@ Then, we can proceed with the compilation:
 Congratulations! You can now run Ř with
 
     bin/R
-
-### In-tree builds
-
-If you just want to build Ř once and are not interested in hacking on it, then it might be OK to do an in-tree build.
-You can skip the step of creating a separate directory for the build and then use `cmake .` instead of `cmake ..`.
 
 ### make vs ninja
 


### PR DESCRIPTION
Based on my adventures trying to compile RIR on Fedora (bad idea)

1. Strongly recommend Ubuntu, due to fetch-llvm
2. Tell how to install the compilation dependencies
3. Encourage off-tree builds and ninja by default
4. Gather the macOS instructions in a single place

[skip ci]