### PR TITLE
Automatically infer FORCE_COLORED_OUTPUT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ SET( CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
 # Due to the way ninja pipes compiler output, by default it has no color.
 # To get colors we must manually set some compilation flags. See also:
 #  * https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
-#  * ttps://github.com/ninja-build/ninja/issues/174
+#  * https://github.com/ninja-build/ninja/issues/174
 execute_process(
     COMMAND /usr/bin/test -t 1
     OUTPUT_FILE /dev/stdout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,15 +74,25 @@ SET( CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
     "Choose the type of build, options are: None Release DebugOpt Debug."
     FORCE )
 
-# Take from https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
-option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
-if (${FORCE_COLORED_OUTPUT})
+# Force the Ninja compilation output to be colored.
+#
+# Due to the way ninja pipes compiler output, by default it has no color.
+# To get colors we must manually set some compilation flags. See also:
+#  * https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
+#  * ttps://github.com/ninja-build/ninja/issues/174
+execute_process(
+    COMMAND /usr/bin/test -t 1
+    OUTPUT_FILE /dev/stdout
+    RESULT_VARIABLE STDOUT_IS_TERMINAL)
+if(STDOUT_IS_TERMINAL EQUAL 0)
+    # Looks like we are in an Unix system and that a human invoked cmake from a terminal.
+    # Let's make things pretty for them!
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
        add_compile_options (-fdiagnostics-color=always)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
        add_compile_options (-fcolor-diagnostics)
     endif ()
-endif ()
+endif()
 
 # Create proxy scripts for the scripts in /tools
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.bin_create")

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, we can proceed with the compilation:
 
     # Invoke cmake for the first time.
     # Possible build types: release, debugopt, debug
-    cmake -GNinja -DCMAKE_BUILD_TYPE=release -DFORCE_COLORED_OUTPUT=1 ..
+    cmake -GNinja -DCMAKE_BUILD_TYPE=release ..
 
     # Fetch and/or build LLVM and Gnu R.
     # On Ubuntu this downloads pre-compiled LLVM binaries, which takes around 10 minutes.
@@ -51,7 +51,7 @@ Congratulations! You can now run Ř with
 
 ### make vs ninja
 
-If you prefer to use `make` instead of `ninja`, remove the `-GNinja` and `-DFORCE_COLORED_OUTPUT=1` flags when you call `cmake`.
+If you prefer to use `make` instead of `ninja`, remove the `-GNinja` flag when you call `cmake`.
 Then use `make` in all the places where we told you to use `ninja`.
 
 ## Running tests


### PR DESCRIPTION
Teach cmake how to deduce if a human is calling it from a terminal.
This allows us to get rid of the FORCE_COLORED_OUTPUT cmake option.
One less thing for the user to worry about.