### PR TITLE
Don't dispatch to native code that's still being compiled

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -304,7 +304,6 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
     pir::Log logger(debug);
     logger.title("Compiling " + name);
     pir::Compiler cmp(m, logger);
-    pir::Backend backend(m, logger, name);
     auto compile = [&](pir::ClosureVersion* c) {
         logger.flushAll();
         cmp.optimizeModule();
@@ -313,34 +312,41 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
             return;
 
         rir::Function* done = nullptr;
-        auto apply = [&](SEXP body, pir::ClosureVersion* c) {
-            auto fun = backend.getOrCompile(c);
-            Protect p(fun->container());
-            DispatchTable::unpack(body)->insert(fun);
-            if (body == BODY(what))
-                done = fun;
-        };
-        m->eachPirClosureVersion([&](pir::ClosureVersion* c) {
-            if (c->owner()->hasOriginClosure()) {
-                auto cls = c->owner()->rirClosure();
-                auto body = BODY(cls);
-                auto dt = DispatchTable::unpack(body);
-                if (dt->contains(c->context())) {
-                    auto other = dt->dispatch(c->context());
-                    assert(other != dt->baseline());
-                    assert(other->context() == c->context());
-                    if (other->body()->isCompiled())
+        {
+            // Single Backend instance, gets destroyed at the end of this block
+            // to finalize the LLVM module so that we can eagerly compile the
+            // body
+            pir::Backend backend(m, logger, name);
+            auto apply = [&](SEXP body, pir::ClosureVersion* c) {
+                auto fun = backend.getOrCompile(c);
+                Protect p(fun->container());
+                DispatchTable::unpack(body)->insert(fun);
+                if (body == BODY(what))
+                    done = fun;
+            };
+            m->eachPirClosureVersion([&](pir::ClosureVersion* c) {
+                if (c->owner()->hasOriginClosure()) {
+                    auto cls = c->owner()->rirClosure();
+                    auto body = BODY(cls);
+                    auto dt = DispatchTable::unpack(body);
+                    if (dt->contains(c->context())) {
+                        auto other = dt->dispatch(c->context());
+                        assert(other != dt->baseline());
+                        assert(other->context() == c->context());
+                        if (other->body()->isCompiled())
+                            return;
+                    }
+                    // Don't lower functions that have not been called often, as
+                    // they have incomplete type-feedback.
+                    if (dt->size() == 1 &&
+                        dt->baseline()->invocationCount() < 2)
                         return;
+                    apply(body, c);
                 }
-                // Don't lower functions that have not been called often, as
-                // they have incomplete type-feedback.
-                if (dt->size() == 1 && dt->baseline()->invocationCount() < 2)
-                    return;
-                apply(body, c);
-            }
-        });
-        if (!done)
-            apply(BODY(what), c);
+            });
+            if (!done)
+                apply(BODY(what), c);
+        }
         // Eagerly compile the main function
         done->body()->nativeCode();
     };

--- a/rir/src/bc/BC.cpp
+++ b/rir/src/bc/BC.cpp
@@ -365,7 +365,7 @@ void BC::print(std::ostream& out) const {
         auto args = immediate.callBuiltinFixedArgs;
         BC::NumArgs nargs = args.nargs;
         auto target = Pool::get(args.builtin);
-        out << nargs << " : " << Print::dumpSexp(target).c_str();
+        out << nargs << " : " << Print::dumpSexp(target);
         break;
     }
     case Opcode::push_:

--- a/rir/src/compiler/backend.cpp
+++ b/rir/src/compiler/backend.cpp
@@ -361,7 +361,7 @@ rir::Function* Backend::doCompile(ClosureVersion* cls, ClosureLog& log) {
         approximateRefcount(cls, c, refcount, log);
         std::unordered_set<Instruction*> needsLdVarForUpdate;
         approximateNeedsLdVarForUpdate(c, needsLdVarForUpdate);
-        auto res = done[c] = rir::Code::New(c->rirSrc()->src);
+        auto res = done[c] = rir::Code::NewNative(c->rirSrc()->src);
         // Can we do better?
         preserve(res->container());
         auto& pm = promMap.at(c);

--- a/rir/src/compiler/backend.h
+++ b/rir/src/compiler/backend.h
@@ -18,6 +18,7 @@ class Backend {
   public:
     Backend(Module* m, Log& logger, const std::string& name)
         : module(m), jit(name), logger(logger) {}
+    ~Backend() { jit.finalize(); }
     Backend(const Backend&) = delete;
     Backend& operator=(const Backend&) = delete;
 

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -816,7 +816,7 @@ static FunctionSignature
                      FunctionSignature::OptimizationLevel::Optimized);
 static Function* deoptSentinel;
 static SEXP deoptSentinelContainer = []() {
-    auto c = rir::Code::New(0);
+    auto c = rir::Code::NewNative(0);
     PROTECT(c->container());
     SEXP store = Rf_allocVector(EXTERNALSXP, sizeof(Function));
     R_PreserveObject(store);

--- a/rir/src/compiler/native/pir_jit_llvm.h
+++ b/rir/src/compiler/native/pir_jit_llvm.h
@@ -52,6 +52,7 @@ class PirJitLLVM {
                  const PromMap& m, const NeedsRefcountAdjustment& refcount,
                  const std::unordered_set<Instruction*>& needsLdVarForUpdate,
                  ClosureLog& log);
+    void finalize();
 
     using GetModule = std::function<llvm::Module&()>;
     using GetFunction = std::function<llvm::Function*(Code*)>;
@@ -82,7 +83,7 @@ class PirJitLLVM {
     }
 
     std::unordered_map<Code*, std::pair<rir::Code*, llvm::StringRef>> jitFixup;
-    void finalizeAndFixup();
+    bool finalized = false;
 
     static size_t nModules;
     static void initializeLLVM();

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1932,6 +1932,7 @@ SEXP evalRirCode(Code* c, SEXP env, const CallContext* callCtxt,
 #endif
 
     assert(c->info.magic == CODE_MAGIC);
+    assert(c->codeSize != 0);
 
     R_bcstack_t* basePtr = nullptr;
 

--- a/rir/src/runtime/Code.cpp
+++ b/rir/src/runtime/Code.cpp
@@ -48,7 +48,12 @@ Code* Code::New(Immediate ast, size_t codeSize, size_t sources, size_t locals,
                               locals, bindingCache);
 }
 
-Code* Code::New(Immediate ast) { return New(ast, 0, 0, 0, 0); }
+Code* Code::NewNative(Immediate ast) {
+    auto res = New(ast, 0, 0, 0, 0);
+    // This code mustn't be executed until the lazyCodeHandle_ is filled
+    res->pending_ = true;
+    return res;
+}
 
 Code::~Code() {
     // TODO: Not sure if this is actually called

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -50,15 +50,21 @@ typedef SEXP (*NativeCode)(Code*, void*, SEXP, SEXP);
 struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     friend class FunctionWriter;
     friend class CodeVerifier;
+
+    enum class Kind { Bytecode, Native } kind;
+
     // extra pool, pir type feedback, arg reordering info
     static constexpr size_t NumLocals = 4;
 
-    Code(FunctionSEXP fun, SEXP src, unsigned srcIdx, unsigned codeSize,
-         unsigned sourceSize, size_t localsCnt, size_t bindingsCacheSize);
+    Code(Kind kind, FunctionSEXP fun, SEXP src, unsigned srcIdx,
+         unsigned codeSize, unsigned sourceSize, size_t localsCnt,
+         size_t bindingsCacheSize);
     ~Code();
 
   private:
-    Code() : Code(NULL, 0, 0, 0, 0, 0, 0) {}
+    Code() : Code(Kind::Bytecode, nullptr, 0, 0, 0, 0, 0, 0) {}
+    static Code* New(Kind kind, Immediate ast, size_t codeSize, size_t sources,
+                     size_t locals, size_t bindingCache);
     /*
      * This array contains the GC reachable pointers. Currently there are three
      * of them.
@@ -70,23 +76,21 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
     SEXP locals_[NumLocals];
 
   public:
-    static Code* New(SEXP ast, size_t codeSize, size_t sources, size_t locals,
-                     size_t bindingCache);
-    static Code* New(Immediate ast, size_t codeSize, size_t sources,
-                     size_t locals, size_t bindingCache);
+    static Code* NewBytecode(Immediate ast, size_t codeSize, size_t sources,
+                             size_t locals, size_t bindingCache);
     static Code* NewNative(Immediate ast);
 
     constexpr static size_t MAX_CODE_HANDLE_LENGTH = 64;
 
   private:
     char lazyCodeHandle_[MAX_CODE_HANDLE_LENGTH] = "\0";
-    bool pending_ = false;
     NativeCode nativeCode_;
     NativeCode lazyCompile();
 
   public:
     void lazyCodeHandle(const std::string& h) {
         assert(h != "");
+        assert(kind == Kind::Native);
         auto l = h.length() + 1;
         if (l > MAX_CODE_HANDLE_LENGTH) {
             assert(false);
@@ -94,20 +98,27 @@ struct Code : public RirRuntimeObject<Code, CODE_MAGIC> {
         }
         memcpy(&lazyCodeHandle_, h.c_str(), l);
         lazyCodeHandle_[MAX_CODE_HANDLE_LENGTH - 1] = '\0';
-        pending_ = false;
     }
     NativeCode nativeCode() {
         if (nativeCode_)
             return nativeCode_;
-        if (pending_ || *lazyCodeHandle_ == '\0')
+        if (kind == Kind::Bytecode || *lazyCodeHandle_ == '\0')
             return nullptr;
         return lazyCompile();
     }
 
     bool isCompiled() const {
-        return *lazyCodeHandle_ != '\0' && nativeCode_ != nullptr;
+        return kind == Kind::Native && *lazyCodeHandle_ != '\0' &&
+               nativeCode_ != nullptr;
     }
-    bool pending() const { return pending_; }
+    // For Kind::Native there is an in-between state when the Code is already
+    // placed in a Function but its code handle isn't yet filled by the
+    // finalizer of PirJitLLVM. We need to prevent such instances from being
+    // evaluated (if we trigger some code in the backend, eg. during printing).
+    // The current workaround is to skip them during dispatch.
+    bool pendingCompilation() const {
+        return kind == Kind::Native && *lazyCodeHandle_ == '\0';
+    }
 
     static unsigned pad4(unsigned sizeInBytes) {
         unsigned x = sizeInBytes % 4;

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -55,7 +55,8 @@ struct DispatchTable
                       << "\n";
 #endif
             auto e = get(i);
-            if (a.smaller(e->context()) && !e->disabled() && !e->pending())
+            if (a.smaller(e->context()) && !e->disabled() &&
+                !e->pendingCompilation())
                 return e;
         }
         return baseline();

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -55,7 +55,7 @@ struct DispatchTable
                       << "\n";
 #endif
             auto e = get(i);
-            if (a.smaller(e->context()) && !e->disabled())
+            if (a.smaller(e->context()) && !e->disabled() && !e->pending())
                 return e;
         }
         return baseline();

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -162,7 +162,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     const Context& context() const { return context_; }
 
     bool disabled() const { return flags.contains(Flag::Deopt); }
-    bool pending() const { return body()->pending(); }
+    bool pendingCompilation() const { return body()->pendingCompilation(); }
 
     void registerDeopt() {
         // Deopt counts are kept on the optimized versions

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -135,7 +135,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
         RIR_FUNCTION_FLAGS(V)
 #undef V
 
-            FIRST = Deopt,
+        FIRST = Deopt,
         LAST = DisableNumArgumentsSpezialization
     };
     EnumSet<Flag> flags;
@@ -162,6 +162,7 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     const Context& context() const { return context_; }
 
     bool disabled() const { return flags.contains(Flag::Deopt); }
+    bool pending() const { return body()->pending(); }
 
     void registerDeopt() {
         // Deopt counts are kept on the optimized versions

--- a/rir/src/utils/FunctionWriter.h
+++ b/rir/src/utils/FunctionWriter.h
@@ -70,8 +70,8 @@ class FunctionWriter {
                "Trying to add more code after finalizing");
         unsigned codeSize = originalCodeSize - nops;
 
-        Code* code =
-            Code::New(ast, codeSize, sources.size(), localsCnt, bindingsCnt);
+        Code* code = Code::NewBytecode(src_pool_add(ast), codeSize,
+                                       sources.size(), localsCnt, bindingsCnt);
         preserve(code->container());
 
         size_t numberOfSources = 0;


### PR DESCRIPTION
In the native backend a Code object could be accessed from a DispatchTable while still being compiled
(we call deparse to print pir constants which can eval code). Such a Code would wrongly think it's bytecode
and start interpreting garbage.

This adds a pending flag that prevent dispatching to function versions that have pending Code objects. The flag
is set when we create a native Code object and reset when we finalize the LLVM module, at which point native
code can be emitted.