### PR TITLE
Ensure compilation in rir tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ test_release_2:
     expire_in: 1 week
 
 # Run some tests in the debug mode
-tests_debug:
+tests_debug_1:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
     GIT_STRATEGY: none
@@ -143,8 +143,11 @@ tests_debug:
     - R_ENABLE_JIT=3 bin/tests
     - PIR_ENABLE=off bin/tests
     - PIR_ENABLE=force bin/tests
+    - PIR_WARMUP=2 bin/tests
+    - PIR_WARMUP=3 bin/tests
+    - PIR_WARMUP=5 bin/tests
 
-tests_debug2:
+tests_debug_2:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
     GIT_STRATEGY: none
@@ -257,7 +260,6 @@ test_features_3:
     - PIR_DEOPTLESS=1 RIR_CHECK_PIR_TYPES=1 bin/tests
     - PIR_OSR=0 RIR_CHECK_PIR_TYPES=1 bin/tests
     - PIR_DEOPTLESS=1 PIR_OSR=0 bin/tests
-
   artifacts:
     paths:
     - logs
@@ -266,7 +268,7 @@ test_features_3:
 
 
 # Run ubsan and gc torture
-test_gctorture1:
+test_gctorture_1:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
     GIT_STRATEGY: none
@@ -286,7 +288,7 @@ test_gctorture1:
     when: on_failure
     expire_in: 1 week
 
-test_gctorture2:
+test_gctorture_2:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
   variables:
     GIT_STRATEGY: none
@@ -444,6 +446,7 @@ benchmark_gnur:
     - benchmarks.data
     - memory.data
     expire_in: 6 month
+
 benchmark_fastr:
   image: registry.gitlab.com/rirvm/rir_mirror/benchmark-baseline
   stage: Benchmark

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,7 +143,6 @@ tests_debug_1:
     - R_ENABLE_JIT=3 bin/tests
     - PIR_ENABLE=off bin/tests
     - PIR_ENABLE=force bin/tests
-    - PIR_WARMUP=2 bin/tests
     - PIR_WARMUP=3 bin/tests
     - PIR_WARMUP=5 bin/tests
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,12 +137,12 @@ tests_debug:
     - /opt/rir/container/build-releaseassert.sh
     - cd /opt/rir/build/releaseassert
     - export UNSOUND_OPTS=off
-    - R_ENABLE_JIT=0 ./bin/tests
-    - R_ENABLE_JIT=1 ./bin/tests
-    - R_ENABLE_JIT=2 ./bin/tests
-    - R_ENABLE_JIT=3 ./bin/tests
-    - PIR_ENABLE=off ./bin/tests
-    - PIR_ENABLE=force ./bin/tests
+    - R_ENABLE_JIT=0 bin/tests
+    - R_ENABLE_JIT=1 bin/tests
+    - R_ENABLE_JIT=2 bin/tests
+    - R_ENABLE_JIT=3 bin/tests
+    - PIR_ENABLE=off bin/tests
+    - PIR_ENABLE=force bin/tests
 
 tests_debug2:
   image: registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
@@ -158,7 +158,7 @@ tests_debug2:
   script:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
-    - ./bin/gnur-make-tests check-devel || $SAVE_LOGS
+    - bin/gnur-make-tests check-devel || $SAVE_LOGS
     - ../../tools/check-gnur-make-tests-error
   artifacts:
     paths:
@@ -201,14 +201,14 @@ test_features_1:
   script:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
-    - PIR_DEOPT_CHAOS=100000 PIR_DEOPT_CHAOS_NO_RETRIGGER=1 ./bin/tests || $SAVE_LOGS
-    - PIR_WARMUP=2 PIR_DEOPT_CHAOS=50000 ./bin/gnur-make-tests check || $SAVE_LOGS
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=0 FAST_TESTS=1 ./bin/tests
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=1 FAST_TESTS=1 ./bin/tests
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=2 FAST_TESTS=1 ./bin/tests
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=3 FAST_TESTS=1 ./bin/tests
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=4 FAST_TESTS=1 ./bin/tests
-    - PIR_GLOBAL_SPECIALIZATION_LEVEL=5 FAST_TESTS=1 ./bin/tests
+    - PIR_DEOPT_CHAOS=100000 PIR_DEOPT_CHAOS_NO_RETRIGGER=1 bin/tests
+    - PIR_WARMUP=2 PIR_DEOPT_CHAOS=50000 bin/gnur-make-tests check || $SAVE_LOGS
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=0 FAST_TESTS=1 bin/tests
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=1 FAST_TESTS=1 bin/tests
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=2 FAST_TESTS=1 bin/tests
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=3 FAST_TESTS=1 bin/tests
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=4 FAST_TESTS=1 bin/tests
+    - PIR_GLOBAL_SPECIALIZATION_LEVEL=5 FAST_TESTS=1 bin/tests
   artifacts:
     paths:
     - logs
@@ -228,7 +228,7 @@ test_features_2:
   script:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
-    - ./bin/gnur-make-tests check || $SAVE_LOGS
+    - bin/gnur-make-tests check || $SAVE_LOGS
   artifacts:
     paths:
     - logs
@@ -248,7 +248,7 @@ test_features_3:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
     - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=1 PIR_DEOPT_CHAOS=10000 bin/gnur-make-tests check || $SAVE_LOGS
-    - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=1 RIR_SERIALIZE_CHAOS=1 FAST_TESTS=1 ./bin/tests
+    - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=1 RIR_SERIALIZE_CHAOS=1 FAST_TESTS=1 bin/tests
     - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=1 PIR_DEOPTLESS=1 bin/tests
     - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=1 PIR_OSR=0 bin/tests
     - PIR_LLVM_OPT_LEVEL=0 PIR_OPT_LEVEL=0 bin/tests
@@ -279,7 +279,7 @@ test_gctorture1:
   script:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
-    - R_GCTORTURE=5000 ./bin/gnur-make-tests check || $SAVE_LOGS
+    - R_GCTORTURE=5000 bin/gnur-make-tests check || $SAVE_LOGS
   artifacts:
     paths:
     - logs
@@ -298,8 +298,8 @@ test_gctorture2:
     - schedules
   script:
     - cd /opt/rir/build/release
-    - PIR_INLINER_MAX_INLINEE_SIZE=2000 ./bin/tests
-    - PIR_INLINER_MAX_INLINEE_SIZE=1500 PIR_DEOPT_CHAOS=100000 ./bin/tests
+    - PIR_INLINER_MAX_INLINEE_SIZE=2000 bin/tests
+    - PIR_INLINER_MAX_INLINEE_SIZE=1500 PIR_DEOPT_CHAOS=100000 bin/tests
     - /opt/rir/container/build-releaseassert.sh
     - cd /opt/rir/build/releaseassert
     - PIR_TEST_CLEAR_TEMPS=1 R_GCTORTURE=80 bin/tests
@@ -322,7 +322,7 @@ test_big_inline:
   script:
     - /opt/rir/container/install-test-deps.sh
     - cd /opt/rir/build/release
-    - ./bin/gnur-make-tests check || $SAVE_LOGS
+    - bin/gnur-make-tests check || $SAVE_LOGS
   artifacts:
     paths:
     - logs

--- a/tools/tests
+++ b/tools/tests
@@ -47,26 +47,26 @@ function run_test {
   if [[ "$ENABLE_VALGRIND" == "1" ]]; then
       VALGRIND="-d valgrind --debugger-args=--error-exitcode=13 --debugger-args=--suppressions=$ROOT_DIR/.valgrind_suppressions"
   fi
-  
+
   if test "$(uname)" = "Darwin"; then
       LIB="dyn.load('${RIR_BUILD}/librir.dylib')"
   else
       LIB="dyn.load('${RIR_BUILD}/librir.so')"
   fi
-  
+
   name=`basename $test`
-  
+
   function status {
     done=`wc -l < $STATUS`
     echo -ne "\e[0K\r[${done}/${NUM_TESTS}] ${name} "
   }
   status
-  
+
   TEST=$(mktemp /tmp/r-test.XXXXXX)
   echo ${LIB} > $TEST
   echo "source('${ROOT_DIR}/rir/R/rir.R')" >> $TEST
   grep -v 'require("rir")' ${test} | grep -v 'require(rir)'  >> $TEST
-  
+
   LOG=$(mktemp /tmp/r-test.XXXXXX)
   if [[ "$R_LD_PRELOAD" != "" ]]; then
     export LD_PRELOAD=$R_LD_PRELOAD
@@ -108,6 +108,11 @@ TESTS_PATH="${ROOT_DIR}/rir/tests"
 
 NUM_TESTS=`find ${TESTS_PATH} -name '*.[Rr]' | wc -l`
 export NUM_TESTS
+
+# The tests assumed prior to the introduction of the time-based compilation
+# heuristics that the warmup is 3, this makes sure that we actually compile
+# code...
+export PIR_WARMUP=3
 
 find ${TESTS_PATH} -name '*.[Rr]' | xargs -n 1 -P `ncores` bash -c 'run_test $@'
 

--- a/tools/tests
+++ b/tools/tests
@@ -109,11 +109,6 @@ TESTS_PATH="${ROOT_DIR}/rir/tests"
 NUM_TESTS=`find ${TESTS_PATH} -name '*.[Rr]' | wc -l`
 export NUM_TESTS
 
-# The tests assumed prior to the introduction of the time-based compilation
-# heuristics that the warmup is 3, this makes sure that we actually compile
-# code...
-export PIR_WARMUP=3
-
 find ${TESTS_PATH} -name '*.[Rr]' | xargs -n 1 -P `ncores` bash -c 'run_test $@'
 
 rm -rf $STATUS


### PR DESCRIPTION
For now, it seems easiest to just set the warmup flag to 3 as it was before the introduction of the time-based heuristics