### PR TITLE
Fix patching the constant pool

### DIFF
--- a/rir/src/utils/Pool.cpp
+++ b/rir/src/utils/Pool.cpp
@@ -8,6 +8,7 @@ namespace rir {
 std::unordered_map<double, unsigned> Pool::numbers;
 std::unordered_map<int, unsigned> Pool::ints;
 std::unordered_map<SEXP, size_t> Pool::contents;
+std::unordered_set<size_t> Pool::patchable;
 
 BC::PoolIdx Pool::getNum(double n) {
     if (numbers.count(n))

--- a/rir/src/utils/Pool.h
+++ b/rir/src/utils/Pool.h
@@ -20,6 +20,7 @@ class Pool {
     static std::unordered_map<double, BC::PoolIdx> numbers;
     static std::unordered_map<int, BC::PoolIdx> ints;
     static std::unordered_map<SEXP, size_t> contents;
+    static std::unordered_set<size_t> patchable;
 
   public:
     static BC::PoolIdx insert(SEXP e) {
@@ -34,14 +35,22 @@ class Pool {
 
     static BC::PoolIdx makeSpace() {
         size_t i = cp_pool_add(R_NilValue);
+        patchable.insert(i);
         return i;
     }
 
     static void patch(BC::PoolIdx idx, SEXP e) {
+        // Patching must not write to contents, otherwise nasty bugs can occur!
+        // Eg.: we makeSpace 42, patch X into 42, then patch Y into 42, X gets
+        // garbage collected, Z gets allocated to where X used to be, and now
+        // insert of Z finds X in contents and returns 42, which, first, returns
+        // Y when looked up in the constant pool, and, second, doesn't store Z
+        // which may get collected..
         SET_NAMED(e, 2);
+        // Also make sure we are not randomly patching a location that doesn't
+        // come from makeSpace
+        assert(patchable.count(idx));
         cp_pool_set(idx, e);
-        if (!contents.count(e))
-            contents[e] = idx;
     }
 
     static BC::PoolIdx getNum(double n);


### PR DESCRIPTION
This should fix the bug where occasionally the close_ bytecode would find a Function in the constant pool instead of a DispatchTable.

Some cells in the constant pool are created by makeSpace with the intention that we can later patch these (used for invalidating targets after deopts).
However, the patching would also write to the C++ contents cache that maps SEXPs to pool indices, and patching multiple times would leave the old mapping outdated.

For example:
1. makeSpace 42
2. patch X into 42
3. patch Y into 42
4. X gets garbage collected
5. Z gets allocated to where X used to be
6. insert of Z finds X in contents and returns 42
Now:
- constant pool at 42 returns Y
- Z may get collected since it's not reachable from the constant pool

Also, this makes sure that we cannot patch a location that doesn't come from calling makeSpace.