### PR TITLE
Context computed for StaticCall when compiling rir2pir was wrongly handling MissingArg

### DIFF
--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -913,14 +913,11 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             {
                 size_t i = 0;
                 for (const auto& arg : matchedArgs) {
-                    if (arg == MissingArg::instance()) {
-                        given.remove(Assumption::NoExplicitlyMissingArgs);
-                        i++;
-                    } else {
-                        if (auto j = Instruction::Cast(arg))
-                            j->updateTypeAndEffects();
-                        arg->callArgTypeToContext(given, i++);
-                    }
+
+                    if (auto j = Instruction::Cast(arg))
+                        j->updateTypeAndEffects();
+                    arg->callArgTypeToContext(given, i);
+                    i++;
                 }
             }
 


### PR DESCRIPTION
Context computed for static call handled MissingArg as a special case instead of  dispatching to arg->callArgTypeToContext() which already handles that case. The logic on rir2pir.cpp was different to the on the method callArgTypeToContext. This led to some  unnecessary compilation of versions since the context was not properly computed