### PR TITLE
StaticCall constructor takes closure version  instead of closure

### DIFF
--- a/rir/src/compiler/opt/match_call_args.cpp
+++ b/rir/src/compiler/opt/match_call_args.cpp
@@ -243,22 +243,22 @@ bool MatchCallArgs::apply(Compiler& cmp, ClosureVersion* cls, Code* code,
                         assert(!usemethodTarget);
                         auto cls = c->cls()->followCastsAndForce();
                         auto nc = new StaticCall(
-                            c->env(), target->owner(), asmpt, matchedArgs,
-                            argOrderOrig, c->frameStateOrTs(), c->srcIdx, cls);
+                            c->env(), target, asmpt, matchedArgs, argOrderOrig,
+                            c->frameStateOrTs(), c->srcIdx, cls);
                         (*ip)->replaceUsesAndSwapWith(nc, ip);
                     } else if (auto c = namedCall) {
                         assert(!usemethodTarget);
                         auto cls = c->cls()->followCastsAndForce();
                         auto nc = new StaticCall(
-                            c->env(), target->owner(), asmpt, matchedArgs,
-                            argOrderOrig, c->frameStateOrTs(), c->srcIdx, cls);
+                            c->env(), target, asmpt, matchedArgs, argOrderOrig,
+                            c->frameStateOrTs(), c->srcIdx, cls);
                         (*ip)->replaceUsesAndSwapWith(nc, ip);
                     } else if (auto c = staticCall) {
                         assert(usemethodTarget);
                         auto cls = cmp.module->c(usemethodTarget);
                         auto nc = new StaticCall(
-                            c->env(), target->owner(), asmpt, matchedArgs,
-                            argOrderOrig, c->frameStateOrTs(), c->srcIdx, cls);
+                            c->env(), target, asmpt, matchedArgs, argOrderOrig,
+                            c->frameStateOrTs(), c->srcIdx, cls);
                         (*ip)->replaceUsesAndSwapWith(nc, ip);
                     } else {
                         assert(false);

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -1251,12 +1251,15 @@ NamedCall::NamedCall(Value* callerEnv, Value* fun,
     }
 }
 
-StaticCall::StaticCall(Value* callerEnv, Closure* cls, Context givenContext,
-                       const std::vector<Value*>& args,
+StaticCall::StaticCall(Value* callerEnv, ClosureVersion* clsVersion,
+                       Context givenContext, const std::vector<Value*>& args,
                        const ArglistOrder::CallArglistOrder& argOrderOrig,
                        Value* fs, unsigned srcIdx, Value* runtimeClosure)
     : VarLenInstructionWithEnvSlot(PirType::val(), callerEnv, srcIdx),
-      cls_(cls), argOrderOrig(argOrderOrig), givenContext(givenContext) {
+      cls_(clsVersion->owner()), argOrderOrig(argOrderOrig),
+      givenContext(givenContext) {
+
+    auto cls = clsVersion->owner();
     assert(cls->nargs() >= args.size());
     assert(fs);
     pushArg(fs, NativeType::frameState);
@@ -1272,7 +1275,8 @@ StaticCall::StaticCall(Value* callerEnv, Closure* cls, Context givenContext,
                     PirType() | RType::prom | RType::missing | PirType::val());
         }
     }
-    assert(tryDispatch());
+
+    assert(tryDispatch() == clsVersion);
 }
 
 PirType StaticCall::inferType(const GetType& getType) const {

--- a/rir/src/compiler/pir/instruction.h
+++ b/rir/src/compiler/pir/instruction.h
@@ -2263,8 +2263,8 @@ class VLIE(StaticCall, Effects::Any()), public CallInstruction {
     ArglistOrder::CallArglistOrder argOrderOrig;
 
   public:
-    StaticCall(Value * callerEnv, Closure * cls, Context givenContext,
-               const std::vector<Value*>& args,
+    StaticCall(Value * callerEnv, ClosureVersion * clsVersion,
+               Context givenContext, const std::vector<Value*>& args,
                const ArglistOrder::CallArglistOrder& argOrderOrig, Value* fs,
                unsigned srcIdx, Value* runtimeClosure = Tombstone::closure());
 

--- a/rir/src/compiler/rir2pir/rir2pir.cpp
+++ b/rir/src/compiler/rir2pir/rir2pir.cpp
@@ -913,14 +913,11 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
             {
                 size_t i = 0;
                 for (const auto& arg : matchedArgs) {
-                    if (arg == MissingArg::instance()) {
-                        given.remove(Assumption::NoExplicitlyMissingArgs);
-                        i++;
-                    } else {
-                        if (auto j = Instruction::Cast(arg))
-                            j->updateTypeAndEffects();
-                        arg->callArgTypeToContext(given, i++);
-                    }
+
+                    if (auto j = Instruction::Cast(arg))
+                        j->updateTypeAndEffects();
+                    arg->callArgTypeToContext(given, i);
+                    i++;
                 }
             }
 
@@ -932,7 +929,7 @@ bool Rir2Pir::compileBC(const BC& bc, Opcode* pos, Opcode* nextPos,
                 auto fs = insert.registerFrameState(srcCode, nextPos, stack,
                                                     inPromise());
                 auto cl = insert(
-                    new StaticCall(insert.env, f->owner(), given, matchedArgs,
+                    new StaticCall(insert.env, f, given, matchedArgs,
                                    std::move(argOrderOrig), fs, ast,
                                    f->owner()->closureEnv() == Env::notClosed()
                                        ? guardedCallee


### PR DESCRIPTION
We can now make sure that tryDispatch() matches the intended version