### PR TITLE
Limit recompilation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,6 +112,9 @@
     "cfenv": "cpp",
     "csignal": "cpp",
     "__functional_base_03": "cpp",
-    "__memory": "cpp"
+    "__memory": "cpp",
+    "__bits": "cpp",
+    "typeindex": "cpp",
+    "variant": "cpp"
   }
 }

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -1419,7 +1419,7 @@ static SEXP nativeCallTrampolineImpl(ArglistOrder::CallId callId, rir::Code* c,
     if (fail || (++recheck == 97 && RecompileHeuristic(fun))) {
         recheck = 0;
         inferCurrentContext(call, fun->nargs());
-        if (fail || RecompileCondition(dt, fun, fun, call.givenContext)) {
+        if (fail || RecompileCondition(dt, fun, call.givenContext)) {
             fun->unregisterInvocation();
             auto res = doCall(call, true);
             auto trg = dispatch(call, DispatchTable::unpack(BODY(call.callee)));

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -1419,7 +1419,7 @@ static SEXP nativeCallTrampolineImpl(ArglistOrder::CallId callId, rir::Code* c,
     if (fail || (++recheck == 97 && RecompileHeuristic(fun))) {
         recheck = 0;
         inferCurrentContext(call, fun->nargs());
-        if (fail || RecompileCondition(dt, fun, call.givenContext)) {
+        if (fail || RecompileCondition(dt, fun, fun, call.givenContext)) {
             fun->unregisterInvocation();
             auto res = doCall(call, true);
             auto trg = dispatch(call, DispatchTable::unpack(BODY(call.callee)));

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -980,11 +980,9 @@ SEXP doCall(CallContext& call, bool popArgs) {
         auto table = DispatchTable::unpack(body);
 
         inferCurrentContext(call, table->baseline()->signature().formalNargs());
-        auto dispatchResult =
-            table->dispatchConsideringDisabled(call.givenContext);
-        auto fun = dispatchResult.first;
-        auto disabledFun =
-            dispatchResult.second; // correct deopt count is stored here
+        Function* disabledFun;
+        auto fun =
+            table->dispatchConsideringDisabled(call.givenContext, &disabledFun);
 
         fun->registerInvocation();
 

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -986,7 +986,7 @@ SEXP doCall(CallContext& call, bool popArgs) {
 
         fun->registerInvocation();
 
-        if (!isDeoptimizing() && RecompileHeuristic(fun)) {
+        if (!isDeoptimizing() && RecompileHeuristic(fun, disabledFun)) {
             Context given = call.givenContext;
             // addDynamicAssumptionForOneTarget compares arguments with the
             // signature of the current dispatch target. There the number of
@@ -995,7 +995,7 @@ SEXP doCall(CallContext& call, bool popArgs) {
             // this as an explicit assumption.
 
             fun->clearDisabledAssumptions(given);
-            if (RecompileCondition(table, fun, disabledFun, given)) {
+            if (RecompileCondition(table, fun, given)) {
                 if (given.includes(pir::Compiler::minimalContext)) {
                     if (call.caller &&
                         call.caller->function()->invocationCount() > 0 &&

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -980,11 +980,11 @@ SEXP doCall(CallContext& call, bool popArgs) {
         auto table = DispatchTable::unpack(body);
 
         inferCurrentContext(call, table->baseline()->signature().formalNargs());
-        // Function* fun = dispatch(call, table);
         auto dispatchResult =
             table->dispatchConsideringDisabled(call.givenContext);
         auto fun = dispatchResult.first;
-        assert(fun);
+        auto disabledFun =
+            dispatchResult.second; // correct deopt count is stored here
 
         fun->registerInvocation();
 
@@ -997,7 +997,7 @@ SEXP doCall(CallContext& call, bool popArgs) {
             // this as an explicit assumption.
 
             fun->clearDisabledAssumptions(given);
-            if (RecompileCondition(table, fun, dispatchResult.second, given)) {
+            if (RecompileCondition(table, fun, disabledFun, given)) {
                 if (given.includes(pir::Compiler::minimalContext)) {
                     if (call.caller &&
                         call.caller->function()->invocationCount() > 0 &&

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -82,10 +82,23 @@ inline bool RecompileHeuristic(Function* fun) {
     return false;
 }
 
+inline bool ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
+                                                 const Context& context) {
+
+    auto targetDisabled = table->dispatchConsideringDisabled(context);
+    if (targetDisabled != table->baseline())
+        return targetDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
+
+    return false;
+}
+
 inline bool RecompileCondition(DispatchTable* table, Function* fun,
                                const Context& context) {
-    return (fun->flags.contains(Function::MarkOpt) || !fun->isOptimized() ||
-            (context.smaller(fun->context()) &&
+
+    return (fun->flags.contains(Function::MarkOpt) ||
+            (!fun->isOptimized() &&
+             !ShouldAbandonRecompilationOfBaseline(table, context)) ||
+            (fun->isOptimized() && context.smaller(fun->context()) &&
              context.isImproving(fun) > table->size()) ||
             fun->flags.contains(Function::Reoptimize));
 }

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -56,7 +56,7 @@ inline RCNTXT* findFunctionContextFor(SEXP e) {
 }
 
 inline bool RecompileHeuristic(Function* fun,
-                               Function* funConsideringDisabled = nullptr) {
+                               Function* funMaybeDisabled = nullptr) {
 
     auto flags = fun->flags;
     if (flags.contains(Function::MarkOpt))
@@ -64,11 +64,12 @@ inline bool RecompileHeuristic(Function* fun,
     if (flags.contains(Function::NotOptimizable))
         return false;
 
-    if (!funConsideringDisabled)
-        funConsideringDisabled = fun;
+    if (!funMaybeDisabled)
+        funMaybeDisabled = fun;
 
     auto abandon =
-        funConsideringDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
+        funMaybeDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
+
     auto wt = fun->isOptimized() ? pir::Parameter::PIR_REOPT_TIME
                                  : pir::Parameter::PIR_OPT_TIME;
     if (fun->invocationCount() >= 3 && fun->invocationTime() > wt) {
@@ -87,30 +88,6 @@ inline bool RecompileHeuristic(Function* fun,
 
     return false;
 }
-
-// inline bool
-// ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
-//                                      Function* funConsideringDisabled,
-//                                      const Context& context) {
-
-//     if (funConsideringDisabled != table->baseline())
-//         return funConsideringDisabled->deoptCount() >=
-//                pir::Parameter::DEOPT_ABANDON;
-
-//     return false;
-// }
-
-// inline bool RecompileCondition(DispatchTable* table, Function* fun,
-//                                Function* funDisabled, const Context& context)
-//                                {
-
-//     return (fun->flags.contains(Function::MarkOpt) ||
-//             (!fun->isOptimized() && !ShouldAbandonRecompilationOfBaseline(
-//                                         table, funDisabled, context)) ||
-//             (fun->isOptimized() && context.smaller(fun->context()) &&
-//              context.isImproving(fun) > table->size()) ||
-//             fun->flags.contains(Function::Reoptimize));
-// }
 
 inline bool RecompileCondition(DispatchTable* table, Function* fun,
                                const Context& context) {

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -87,7 +87,7 @@ inline bool ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
 
     auto targetDisabled = table->dispatchConsideringDisabled(context);
     if (targetDisabled != table->baseline())
-        return targetDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
+        return targetDisabled->deoptCount() >= 5;
 
     return false;
 }

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -83,21 +83,21 @@ inline bool RecompileHeuristic(Function* fun) {
 }
 
 inline bool ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
+                                                 Function* targetDisabled,
                                                  const Context& context) {
 
-    auto targetDisabled = table->dispatchConsideringDisabled(context);
     if (targetDisabled != table->baseline())
-        return targetDisabled->deoptCount() >= 5;
+        return targetDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
 
     return false;
 }
 
 inline bool RecompileCondition(DispatchTable* table, Function* fun,
-                               const Context& context) {
+                               Function* funDisabled, const Context& context) {
 
     return (fun->flags.contains(Function::MarkOpt) ||
-            (!fun->isOptimized() &&
-             !ShouldAbandonRecompilationOfBaseline(table, context)) ||
+            (!fun->isOptimized() && !ShouldAbandonRecompilationOfBaseline(
+                                        table, funDisabled, context)) ||
             (fun->isOptimized() && context.smaller(fun->context()) &&
              context.isImproving(fun) > table->size()) ||
             fun->flags.contains(Function::Reoptimize));

--- a/rir/src/interpreter/interp.h
+++ b/rir/src/interpreter/interp.h
@@ -82,12 +82,14 @@ inline bool RecompileHeuristic(Function* fun) {
     return false;
 }
 
-inline bool ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
-                                                 Function* targetDisabled,
-                                                 const Context& context) {
+inline bool
+ShouldAbandonRecompilationOfBaseline(DispatchTable* table,
+                                     Function* funConsideringDisabled,
+                                     const Context& context) {
 
-    if (targetDisabled != table->baseline())
-        return targetDisabled->deoptCount() >= pir::Parameter::DEOPT_ABANDON;
+    if (funConsideringDisabled != table->baseline())
+        return funConsideringDisabled->deoptCount() >=
+               pir::Parameter::DEOPT_ABANDON;
 
     return false;
 }

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -41,28 +41,10 @@ struct DispatchTable
     }
 
     Function* dispatch(Context a, bool ignorePending = true) const {
-        if (!a.smaller(userDefinedContext_)) {
-#ifdef DEBUG_DISPATCH
-            std::cout << "DISPATCH trying: " << a
-                      << " vs annotation: " << userDefinedContext_ << "\n";
-#endif
-            Rf_error("Provided context does not satisfy user defined context");
-        }
-
-        for (size_t i = 1; i < size(); ++i) {
-#ifdef DEBUG_DISPATCH
-            std::cout << "DISPATCH trying: " << a << " vs " << get(i)->context()
-                      << "\n";
-#endif
-            auto e = get(i);
-            if (a.smaller(e->context()) && !e->disabled() &&
-                (ignorePending || !e->pendingCompilation()))
-                return e;
-        }
-        return baseline();
+        return dispatchConsideringDisabled(a, ignorePending).first;
     }
 
-    std::pair<Function*, Function*>
+    inline std::pair<Function*, Function*>
     dispatchConsideringDisabled(Context a, bool ignorePending = true) const {
         if (!a.smaller(userDefinedContext_)) {
 #ifdef DEBUG_DISPATCH

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -62,6 +62,29 @@ struct DispatchTable
         return baseline();
     }
 
+    Function* dispatchConsideringDisabled(Context a,
+                                          bool ignorePending = true) const {
+        if (!a.smaller(userDefinedContext_)) {
+#ifdef DEBUG_DISPATCH
+            std::cout << "DISPATCH trying: " << a
+                      << " vs annotation: " << userDefinedContext_ << "\n";
+#endif
+            Rf_error("Provided context does not satisfy user defined context");
+        }
+
+        for (size_t i = 1; i < size(); ++i) {
+#ifdef DEBUG_DISPATCH
+            std::cout << "DISPATCH trying: " << a << " vs " << get(i)->context()
+                      << "\n";
+#endif
+            auto e = get(i);
+            if (a.smaller(e->context()) &&
+                (ignorePending || !e->pendingCompilation()))
+                return e;
+        }
+        return baseline();
+    }
+
     void baseline(Function* f) {
         assert(f->signature().optimization ==
                FunctionSignature::OptimizationLevel::Baseline);

--- a/rir/src/runtime/DispatchTable.h
+++ b/rir/src/runtime/DispatchTable.h
@@ -62,8 +62,8 @@ struct DispatchTable
         return baseline();
     }
 
-    Function* dispatchConsideringDisabled(Context a,
-                                          bool ignorePending = true) const {
+    std::pair<Function*, Function*>
+    dispatchConsideringDisabled(Context a, bool ignorePending = true) const {
         if (!a.smaller(userDefinedContext_)) {
 #ifdef DEBUG_DISPATCH
             std::cout << "DISPATCH trying: " << a
@@ -72,6 +72,8 @@ struct DispatchTable
             Rf_error("Provided context does not satisfy user defined context");
         }
 
+        Function* r2 = nullptr;
+
         for (size_t i = 1; i < size(); ++i) {
 #ifdef DEBUG_DISPATCH
             std::cout << "DISPATCH trying: " << a << " vs " << get(i)->context()
@@ -79,10 +81,17 @@ struct DispatchTable
 #endif
             auto e = get(i);
             if (a.smaller(e->context()) &&
-                (ignorePending || !e->pendingCompilation()))
-                return e;
+                (ignorePending || !e->pendingCompilation())) {
+
+                r2 = e;
+                if (!e->disabled())
+                    return std::pair<Function*, Function*>(e, r2);
+            }
         }
-        return baseline();
+
+        if (r2 == nullptr)
+            r2 = baseline();
+        return std::pair<Function*, Function*>(baseline(), r2);
     }
 
     void baseline(Function* f) {


### PR DESCRIPTION
Avoid recompilation of contexts that have deopted too many times