### PR TITLE
macOS support + update code to fetch and build llvm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,5 +180,9 @@ if(APPLE)
     target_link_libraries(${PROJECT_NAME} R)
     # to resolve build error from
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
-    target_link_libraries(${PROJECT_NAME} -lintl)
+    # target_link_libraries(${PROJECT_NAME} -lintl)
+    include_directories(${LLVM_DIR}/include)
+    # Note: May need to update the version here
+    include_directories(/opt/homebrew/Cellar/gettext/0.21.1/include)
+    target_link_libraries(${PROJECT_NAME} /opt/homebrew/Cellar/gettext/0.21.1/lib/libintl.dylib)
 endif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ if(APPLE)
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
     # target_link_libraries(${PROJECT_NAME} -lintl)
     include_directories(${LLVM_DIR}/include)
+    target_link_directories(${PROJECT_NAME} INTERFACE ${LLVM_DIR}/lib)
     # Note: May need to update the version here
     include_directories(/opt/homebrew/Cellar/gettext/0.21.1/include)
     target_link_libraries(${PROJECT_NAME} /opt/homebrew/Cellar/gettext/0.21.1/lib/libintl.dylib)

--- a/rir/src/compiler/analysis/reference_count.h
+++ b/rir/src/compiler/analysis/reference_count.h
@@ -5,6 +5,7 @@
 #include "dead.h"
 #include "generic_static_analysis.h"
 #include "utils/Map.h"
+#include <map>
 
 namespace rir {
 namespace pir {

--- a/rir/src/compiler/native/allocator.cpp
+++ b/rir/src/compiler/native/allocator.cpp
@@ -102,10 +102,7 @@ void NativeAllocator::compute() {
             }
         };
 
-        size_t pos = 0;
         for (auto i : *bb) {
-            ++pos;
-
             if (!needsASlot(i))
                 continue;
 

--- a/rir/src/compiler/native/builtins.cpp
+++ b/rir/src/compiler/native/builtins.cpp
@@ -991,7 +991,11 @@ void recordTypefeedbackImpl(Opcode* pos, rir::Code* code, SEXP value) {
 
 void assertFailImpl(const char* msg) {
     std::cout << "Assertion in jitted code failed: '" << msg << "'\n";
+#ifdef __ARM_ARCH
+    __builtin_debugtrap();
+#else
     asm("int3");
+#endif
 }
 
 void printValueImpl(SEXP v) { Rf_PrintValue(v); }

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3888,7 +3888,11 @@ SEXP evalRirCode(Code* c, SEXP env, const CallContext* callCtxt,
         INSTRUCTION(ret_) { goto eval_done; }
 
         INSTRUCTION(int3_) {
+#ifdef __ARM_ARCH
+            __builtin_debugtrap();
+#else
             asm("int3");
+#endif
             NEXT();
         }
 

--- a/rir/src/interpreter/profiler.cpp
+++ b/rir/src/interpreter/profiler.cpp
@@ -169,6 +169,7 @@ void RuntimeProfiler::initProfiler() {
 
 #else
 void RuntimeProfiler::initProfiler() {}
+bool RuntimeProfiler::enabled() { return false; }
 #endif
 
 } // namespace rir

--- a/rir/src/runtime/Code.h
+++ b/rir/src/runtime/Code.h
@@ -11,7 +11,9 @@
 #include <ostream>
 #include <time.h>
 
+#ifndef __ARM_ARCH
 #include <asm/msr.h>
+#endif
 
 namespace rir {
 

--- a/rir/src/runtime/Function.h
+++ b/rir/src/runtime/Function.h
@@ -80,9 +80,15 @@ struct Function : public RirRuntimeObject<Function, FUNCTION_MAGIC> {
     void addDeoptCount(size_t n) { deoptCount_ += n; }
 
     static inline unsigned long rdtsc() {
+#ifdef __ARM_ARCH
+        uint64_t val;
+        asm volatile("mrs %0, cntvct_el0" : "=r" (val));
+        return val;
+#else
         unsigned low, high;
         asm volatile("rdtsc" : "=a"(low), "=d"(high));
         return ((low) | ((uint64_t)(high) << 32));
+#endif
     }
     static constexpr unsigned long MAX_TIME_MEASURE = 1e9;
 

--- a/tools/build-gnur.sh
+++ b/tools/build-gnur.sh
@@ -65,7 +65,7 @@ function build_r {
         echo "-> configure $NAME"
         cd $R_DIR
         if [ $USING_OSX -eq 1 ]; then
-            CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND" ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no || cat config.log
+            CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND" LDFLAGS="-L/opt/homebrew/lib" ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no --with-x=no || cat config.log
         else
             CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND" ./configure
         fi
@@ -100,7 +100,11 @@ function build_r {
     fi
 
     echo "-> building $NAME"
-    make -j8
+    if [ $USING_OSX -eq 1 ]; then
+      MACOSX_DEPLOYMENT_TARGET=12.0 C_INCLUDE_PATH=/opt/homebrew/include make -j8
+    else
+      make -j8
+    fi
 }
 
 build_r custom-r

--- a/tools/build-gnur.sh
+++ b/tools/build-gnur.sh
@@ -65,7 +65,7 @@ function build_r {
         echo "-> configure $NAME"
         cd $R_DIR
         if [ $USING_OSX -eq 1 ]; then
-            CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND" LDFLAGS="-L/opt/homebrew/lib" ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no --with-x=no || cat config.log
+            CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND -I/opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" ./configure --enable-R-shlib --with-internal-tzcode --with-ICU=no --with-x=no --with-aqua=no || cat config.log
         else
             CFLAGS="-O2 -g -DSWITCH_TO_NAMED=$SND" ./configure
         fi
@@ -101,7 +101,8 @@ function build_r {
 
     echo "-> building $NAME"
     if [ $USING_OSX -eq 1 ]; then
-      MACOSX_DEPLOYMENT_TARGET=12.0 C_INCLUDE_PATH=/opt/homebrew/include make -j8
+      # We need `C_INCLUDE_PATH` here AND we need to include `/opt/homebrew/bin` in `./configure`
+      C_INCLUDE_PATH=/opt/homebrew/include make -j8
     else
       make -j8
     fi

--- a/tools/build-llvm.sh
+++ b/tools/build-llvm.sh
@@ -19,7 +19,7 @@ fi
 cd "${SRC_DIR}/external"
 
 if [ ! -f llvm-12.0.0.src.tar.xz ]; then
-    wget http://releases.llvm.org/12.0.0/llvm-12.0.0.src.tar.xz
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/llvm-12.0.0.src.tar.xz
 fi
 if [ ! -d "llvm-12.0.0.src" ]; then
     tar xf llvm-12.0.0.src.tar.xz

--- a/tools/build-llvm.sh
+++ b/tools/build-llvm.sh
@@ -11,25 +11,25 @@ fi
 SRC_DIR=`cd ${SCRIPTPATH}/.. && pwd`
 . "${SCRIPTPATH}/script_include.sh"
 
-if [ -d "${SRC_DIR}/external/llvm-8.0.0" ]; then
-    echo "${SRC_DIR}/external/llvm-8.0.0 already exists. Remove it to install a debug version of llvm."
+if [ -d "${SRC_DIR}/external/llvm-12" ]; then
+    echo "${SRC_DIR}/external/llvm-12 already exists. Remove it to install a debug version of llvm."
     exit 1
 fi
 
 cd "${SRC_DIR}/external"
 
-if [ ! -f llvm-8.0.0.src.tar.xz ]; then
-    wget http://releases.llvm.org/8.0.0/llvm-8.0.0.src.tar.xz
+if [ ! -f llvm-12.0.1.src.tar.xz ]; then
+    wget http://releases.llvm.org/12.0.1/llvm-12.0.1.src.tar.xz
 fi
-if [ ! -d "llvm-8.0.0.src" ]; then
-    tar xf llvm-8.0.0.src.tar.xz
-    mkdir llvm-8.0.0
-    cd llvm-8.0.0.src
+if [ ! -d "llvm-12.0.1.src" ]; then
+    tar xf llvm-12.0.1.src.tar.xz
+    mkdir llvm-12
+    cd llvm-12.0.1.src
     mkdir build
     cd build
     cmake -DCMAKE_BUILD_TYPE=Debug -GNinja ..
     ninja
 else
-    cd llvm-8.0.0.src/build
+    cd llvm-12.0.1.src/build
 fi
-cmake -DCMAKE_INSTALL_PREFIX=../../llvm-8.0.0 -P cmake_install.cmake
+cmake -DCMAKE_INSTALL_PREFIX=../../llvm-12 -P cmake_install.cmake

--- a/tools/build-llvm.sh
+++ b/tools/build-llvm.sh
@@ -18,18 +18,18 @@ fi
 
 cd "${SRC_DIR}/external"
 
-if [ ! -f llvm-12.0.1.src.tar.xz ]; then
-    wget http://releases.llvm.org/12.0.1/llvm-12.0.1.src.tar.xz
+if [ ! -f llvm-12.0.0.src.tar.xz ]; then
+    wget http://releases.llvm.org/12.0.0/llvm-12.0.0.src.tar.xz
 fi
-if [ ! -d "llvm-12.0.1.src" ]; then
-    tar xf llvm-12.0.1.src.tar.xz
+if [ ! -d "llvm-12.0.0.src" ]; then
+    tar xf llvm-12.0.0.src.tar.xz
     mkdir llvm-12
-    cd llvm-12.0.1.src
+    cd llvm-12.0.0.src
     mkdir build
     cd build
     cmake -DCMAKE_BUILD_TYPE=Debug -GNinja ..
     ninja
 else
-    cd llvm-12.0.1.src/build
+    cd llvm-12.0.0.src/build
 fi
 cmake -DCMAKE_INSTALL_PREFIX=../../llvm-12 -P cmake_install.cmake

--- a/tools/fetch-llvm.sh
+++ b/tools/fetch-llvm.sh
@@ -11,6 +11,10 @@ fi
 SRC_DIR=`cd ${SCRIPTPATH}/.. && pwd`
 . "${SCRIPTPATH}/script_include.sh"
 
+if [[ $(uname -m) == "arm64" ]]; then
+    echo "there is no LLVM 12 distribution for ARM64, so we will try to build instead"
+    exec "${SCRIPTPATH}/build-llvm.sh"
+fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     USING_OSX=1


### PR DESCRIPTION
* specifically looking at macOS ARM, with homebrew (where library code is in `/opt/homebrew`)

R_ENABLE_JIT=0 works

PIR_DEBUG=PrintEarlyPir,PrintFinalPir,... seem to create more issues
PIR_DEBUG=DryRun hasn't produced issues so far though some of the tests take a really long time, so they might be hanging

Here are log snippets of some of the test failures:

```
> for (i in 1:10) {
+     f12()
+ }

 *** caught segfault ***
address 0x100000020, cause 'invalid permissions'

Traceback:
 1: make.names(vnames, unique = TRUE)
 2: data.frame(x = ts(c(41, 42, 43)), y = c(61, 62, 63))
 3: f12()
An irrecoverable exception occurred. R is aborting now ...
*************************************************************************************
***  end log pir_regression2.R
*************************************************************************************
*
```

```
> dyn.load('/Users/jakobeha/Documents/grad/research/rir/build/librir.dylib')
> source('/Users/jakobeha/Documents/grad/research/rir/tools/../rir/R/rir.R')
> library(Matrix)
Error: package or namespace load failed for ‘Matrix’ in loadNamespace(package, lib.loc):
 bad target context--should NEVER happen if R was called correctly
Execution halted
*************************************************************************************
***  end log regression_spModel.matrix.R
*************************************************************************************
*************************************************************************************
xargs: bash: exited with status 255; aborting
```

```
> utils::str(allinfoNS("stats"))
List of 9
 $ DLLs          :List of 1
  ..$ stats:List of 5
  .. ..$ name         : chr "stats"
  .. ..$ path         : chr "/Users/jakobeha/Documents/grad/research/rir/external/custom-r/library/stats/libs/stats.so"
  .. ..$ dynamicLookup: logi FALSE
  .. ..$ handle       :
 *** caught segfault ***
address 0x10, cause 'invalid permissions'

Traceback:
 1: do.call(function(...) str(obj, ...), c(aList, list(...)), quote = TRUE)
 2: strSub(object[[i]], give.length = give.length, nest.lev = nest.lev +     1, indent.str = paste(indent.str, ".."))
 3: str.default(obj, ...)
 4: str(obj, ...)
 5: (function (...) str(obj, ...))(max.level = base::quote(NA), vec.len = base::quote(4L),     digits.d = base::quote(3L), nchar.max = base::quote(128),     give.attr = base::quote(TRUE), drop.deparse.attr = base::quote(TRUE),     give.head = base::quote(TRUE), width = base::quote(80L),     envir = base::quote(NULL), strict.width = base::quote("no"),     formatNum = base::quote(function (x, ...)     format(x, trim = TRUE, drop0trailing = TRUE, ...)), list.len = base::quote(99L),     deparse.lines = base::quote(NULL), give.length = base::quote(TRUE),     nest.lev = base::quote(2), indent.str = base::quote("  .. .."))
 6: do.call(function(...) str(obj, ...), c(aList, list(...)), quote = TRUE)
 7: strSub(object[[i]], give.length = give.length, nest.lev = nest.lev +     1, indent.str = paste(indent.str, ".."))
 8: str.default(obj, ...)
 9: str(obj, ...)
10: (function (...) str(obj, ...))(max.level = base::quote(NA), vec.len = base::quote(4L),     digits.d = base::quote(3L), nchar.max = base::quote(128),     give.attr = base::quote(TRUE), drop.deparse.attr = base::quote(TRUE),     give.head = base::quote(TRUE), width = base::quote(80L),     envir = base::quote(NULL), strict.width = base::quote("no"),     formatNum = base::quote(function (x, ...)     format(x, trim = TRUE, drop0trailing = TRUE, ...)), list.len = base::quote(99L),     deparse.lines = base::quote(NULL), give.length = base::quote(TRUE),     nest.lev = base::quote(1), indent.str = base::quote("  .."))
11: do.call(function(...) str(obj, ...), c(aList, list(...)), quote = TRUE)
12: strSub(object[[i]], give.length = give.length, nest.lev = nest.lev +     1, indent.str = paste(indent.str, ".."))
13: str.default(allinfoNS("stats"))
14: utils::str(allinfoNS("stats"))
An irrecoverable exception occurred. R is aborting now ...
*************************************************************************************
***  end log pir_regression6.R
*************************************************************************************
*************************************************************************************
xargs: bash: exited with status 255; aborting
```

```
> dyn.load('/Users/jakobeha/Documents/grad/research/rir/build/librir.dylib')
> source('/Users/jakobeha/Documents/grad/research/rir/tools/../rir/R/rir.R')
>   a <- b <- 0
>   plot(a, b    
+        )
> example(glm )
Error in loadNamespace(x) : 
  bad target context--should NEVER happen if R was called correctly
Calls: example -> loadNamespace
Execution halted
*************************************************************************************
***  end log regression_stats.R
*************************************************************************************
*************************************************************************************
xargs: bash: exited with status 255; aborting
```

```
> mkDend <- function(n, lab, method = "complete",
+                    ## gives *ties* often:
+                  rGen = function(n) 1+round(16*abs(rnorm(n)))) {
+     stopifnot(is.numeric(n), length(n) == 1, n >= 1, is.character(lab))
+     a <- matrix(rGen(n*n), n, n)
+     colnames(a) <- rownames(a) <- paste0(lab, 1:n)
+     .HC. <<- hclust(as.dist(a + t(a)), method=method)
+     as.dendrogram(.HC.)
+ }
> 
> ## recursive dendrogram methods and deeply nested dendrograms
> op <- options(expressions = 999)# , verbose = 2) # -> max. depth= 961
> set.seed(11); d <- mkDend(1500, "A", method="single")
> rd <- reorder(d, nobs(d):1)

 *** caught segfault ***
address 0x1, cause 'invalid permissions'

Traceback:
 1: match.arg(method)
 2: order(x, na.last = na.last, decreasing = decreasing, method = "radix")
 3: sort.list(vals)
 4: oV(x, wts)
 5: stopifnot(inherits(x, "dendrogram"))
 6: midcache.dendrogram(oV(x, wts))
 7: reorder.dendrogram(d, nobs(d):1)
 8: reorder(d, nobs(d):1)
An irrecoverable exception occurred. R is aborting now ...
*************************************************************************************
***  end log reg-tests-1c.R
*************************************************************************************
*************************************************************************************
xargs: bash: exited with status 255; aborting
```

https://github.com/reactorlabs/rir/issues/1193