### PR TITLE
Pin the ReBench version to v1.1.0 which works

### DIFF
--- a/container/benchmark/Dockerfile
+++ b/container/benchmark/Dockerfile
@@ -3,5 +3,8 @@ FROM registry.gitlab.com/rirvm/rir_mirror:$CI_COMMIT_SHA
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip sudo time && \
     apt-get clean && rm -rf /var/cache/apt/lists && \
-    git clone --depth 1 https://github.com/smarr/ReBench.git /opt/ReBench && cd /opt/ReBench && pip3 install . && \
+    git clone https://github.com/smarr/ReBench.git /opt/ReBench && \
+    cd /opt/ReBench && \
+    git checkout 1aaba13 && \
+    pip3 install . && \
     git clone --depth 10 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking && cd /opt/rbenchmarking && git checkout a92447b37a03e96f8da1e18eb3cd8ab3b46fbf89


### PR DESCRIPTION
To prevent further problems, it will be easier to pin the rebench version that works for our benchmarks.
This one seems to work: https://gitlab.com/rirvm/rir_mirror/-/pipelines/960979822

The reason why this is necessary is that we only use commit SHA for the container names.
If someone reruns a pipeline, the benchmark image will be rebuilt using the latest rebench which might not work, thus making it irreproducible.