### PR TITLE
Pin the ReBench version to v1.1.0 for the baseline container

### DIFF
--- a/container/benchmark-baseline/Dockerfile
+++ b/container/benchmark-baseline/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     curl --fail --silent --location --retry 3 https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAAL_VERSION/graalvm-ce-java11-linux-amd64-$GRAAL_VERSION.tar.gz | gunzip | tar x -C /opt/ && \
     cd /opt && ln -s graalvm-ce-java11-$GRAAL_VERSION graal && cd /opt/graal/bin && \
     ./gu install R && \
-    git clone --depth 1 https://github.com/smarr/ReBench.git /opt/ReBench && cd /opt/ReBench && pip3 install . && \
+    git clone https://github.com/smarr/ReBench.git /opt/ReBench && cd /opt/ReBench && git checkout 1aaba13 && pip3 install . && \
     mv /usr/local/bin/rebench-denoise /usr/local/bin/rebench-denoise.bkp && cp /usr/bin/false /usr/local/bin/rebench-denoise && \
     git clone --depth 10 https://github.com/reactorlabs/rbenchmarking /opt/rbenchmarking && cd /opt/rbenchmarking && git checkout a92447b37a03e96f8da1e18eb3cd8ab3b46fbf89 && \
     apt-get clean && rm -rf /var/cache/apt/lists


### PR DESCRIPTION
In #1246 I forgot to update also the image for the baseline benchmarking container.
This is now causing failures in the pipeline again (cf. https://gitlab.com/rirvm/rir_mirror/-/pipelines/971070046 for example).