### PR TITLE
graal_version 22.0.0.2 should be the same as 22.1.0, though the forme…

### DIFF
--- a/container/benchmark-baseline/Dockerfile
+++ b/container/benchmark-baseline/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
-ARG GRAAL_VERSION=22.0.0.2
+ARG GRAAL_VERSION=22.1.0
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq && \


### PR DESCRIPTION
…r throws an error when ./gu install