### PR TITLE
cerr to logger->warning

### DIFF
--- a/rir/src/compiler/osr.cpp
+++ b/rir/src/compiler/osr.cpp
@@ -30,7 +30,7 @@ Function* OSR::compile(SEXP closure, rir::Code* c,
             auto dt = DispatchTable::unpack(BODY(closure));
             fun->dispatchTable(dt);
         },
-        [&]() { std::cerr << "Continuation compilation failed\n"; });
+        [&]() { logger.warn("Continuation compilation failed"); });
 
     delete module;
 


### PR DESCRIPTION
We should not directly write to cerr unless there is an assert(false) right after. Otherwise, we use the logger object for warnings , which does not actually print anything unless a debug flag is on