### PR TITLE
Builtins call factory. Improve precision when sending arguments

### DIFF
--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -899,11 +899,13 @@ Instruction* BuiltinCallFactory::New(Value* callerEnv, SEXP builtin,
     bool unsafe = false;
     for (auto a : args) {
         if (auto mk = MkArg::Cast(a)) {
-            if (mk->isEager())
+            if (mk->isEager()) {
                 if (!mk->eagerArg()->type.maybeObj())
                     continue;
-            noObj = false;
-            continue;
+                noObj = false;
+            }
+            // noObj = false;
+            // continue;
         }
         if (a->type.maybeObj()) {
             noObj = false;

--- a/rir/src/compiler/pir/instruction.cpp
+++ b/rir/src/compiler/pir/instruction.cpp
@@ -904,8 +904,6 @@ Instruction* BuiltinCallFactory::New(Value* callerEnv, SEXP builtin,
                     continue;
                 noObj = false;
             }
-            // noObj = false;
-            // continue;
         }
         if (a->type.maybeObj()) {
             noObj = false;


### PR DESCRIPTION
An argument to builtins was inferred to be an object if the argument itself is a MkPromise and it is not eager.