### PR TITLE
Fix SimpleInt and SimpleReal fromContext

### DIFF
--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -260,10 +260,10 @@ void PirType::fromContext(const Context& assumptions, unsigned arg,
         auto simpleType = [](PirType s) { return s.orPromiseWrapped(); };
 
         if (assumptions.isSimpleReal(i)) {
-            type = simpleType(PirType::simpleScalarReal());
+            type = type & simpleType(PirType::simpleScalarReal());
         }
         if (assumptions.isSimpleInt(i)) {
-            type = simpleType(PirType::simpleScalarInt());
+            type = type & simpleType(PirType::simpleScalarInt());
         }
     }
     // well, if the intersection of context info and current type is void, we

--- a/rir/src/compiler/pir/type.cpp
+++ b/rir/src/compiler/pir/type.cpp
@@ -256,14 +256,15 @@ void PirType::fromContext(const Context& assumptions, unsigned arg,
         type = type & type.notLazy();
         if (assumptions.isNotObj(i))
             type = type & type.notMissing().notObject();
-        if (assumptions.isSimpleReal(i))
-            type = type & PirType::simpleScalarReal()
-                              .orMaybeMissing()
-                              .orFullyPromiseWrapped();
-        if (assumptions.isSimpleInt(i))
-            type = type & PirType::simpleScalarInt()
-                              .orMaybeMissing()
-                              .orFullyPromiseWrapped();
+
+        auto simpleType = [](PirType s) { return s.orPromiseWrapped(); };
+
+        if (assumptions.isSimpleReal(i)) {
+            type = simpleType(PirType::simpleScalarReal());
+        }
+        if (assumptions.isSimpleInt(i)) {
+            type = simpleType(PirType::simpleScalarInt());
+        }
     }
     // well, if the intersection of context info and current type is void, we
     // probably made a wrong speculation. it's most probably a bug somewhere,


### PR DESCRIPTION
Fixes bug introduced in the 'is missing' refactoring of the pir types. 
SimpleInt would be annotated as (int | missing)$-~ , where it should actually be int$-~ 