### PR TITLE
Add support for worktrees in build-gnur.sh

### DIFF
--- a/tools/build-gnur.sh
+++ b/tools/build-gnur.sh
@@ -20,10 +20,12 @@ if [[ "$1" == "--macos_gcc9" ]]; then
     MACOS_GCC9=1
 fi
 
-if test -d ${SRC_DIR}/.git; then
+if test -e ${SRC_DIR}/.git; then
     echo "-> update submodules"
     git submodule update --init
+fi
 
+if test -d ${SRC_DIR}/.git; then
     echo "-> install git hooks"
     ${SRC_DIR}/tools/install_hooks.sh
 fi


### PR DESCRIPTION
When using a git worktree, the git commands still work, but the `.git` is not a directory, but a text file.
This change enables the `.build-gnur.sh` script to work even in git worktrees.