### PR TITLE
Remove redundant CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,14 +146,8 @@ else()
     )
 endif()
 
-add_custom_target(default-gnur
-    DEPENDS dependencies
-    COMMAND ${CMAKE_SOURCE_DIR}/tools/build-gnur.sh custom-r
-)
-
 add_custom_target(setup
     DEPENDS dependencies
-    DEPENDS default-gnur
 )
 
 add_custom_target(tests


### PR DESCRIPTION
The CMakeLists.txt file has an extra target, that does nothing.
The `build-gnur.sh` script changes it's behaviour only with the `--macos_gcc9` argument, thus calling it again with `custom-r` is redundant and might even be incorrect on MacOS.