### PR TITLE
Fix the RIR_RECORD_SERIALIZE environment variable

### DIFF
--- a/rir/src/recording.h
+++ b/rir/src/recording.h
@@ -30,7 +30,6 @@ bool stringStartsWith(const std::string& s, const std::string& prefix);
 std::string getEnvironmentName(SEXP env);
 std::string getClosureName(SEXP cls);
 
-class Record;
 struct FunRecording;
 
 constexpr size_t NO_INDEX = (size_t)-1;
@@ -38,9 +37,7 @@ constexpr size_t PROMISE_INDEX = (size_t)-2;
 constexpr const char* GLOBAL_ENV_NAME = ".GlobalEnv";
 
 // Controls if SEXP closures should be serialized
-const bool SERIALIZE_SEXP = getenv("RIR_RECORD_SERIALIZE")
-                                     ? atoi(getenv("RIR_RECORD_SERIALIZE"))
-                                     : false;
+extern bool SERIALIZE_SEXP;
 
 enum class SpeculativeContextType { Callees, Test, Values };
 
@@ -482,7 +479,8 @@ struct FunRecording {
                           SEXP closure, uintptr_t address)
         : name(name), env(env), closure(closure), address(address) {}
 
-    explicit FunRecording(const std::string& name, uintptr_t address) : name(name), address(address) {}
+    explicit FunRecording(const std::string& name, uintptr_t address)
+        : name(name), address(address) {}
 };
 
 class Record {

--- a/rir/src/recording_hooks.cpp
+++ b/rir/src/recording_hooks.cpp
@@ -246,7 +246,7 @@ void recordDeopt(rir::Code* c, const DispatchTable* dt, DeoptReason& reason,
     } else if (Rf_isFunction(trigger)) {
         trigger_index = recorder_.initOrGetRecording(trigger);
         trigger = R_NilValue;
-    } else if (!SERIALIZE_SEXP){
+    } else if (!SERIALIZE_SEXP) {
         trigger = R_NilValue;
     }
 
@@ -254,7 +254,7 @@ void recordDeopt(rir::Code* c, const DispatchTable* dt, DeoptReason& reason,
                                  reason.origin.index(), trigger, trigger_index);
 }
 
-void recordSCDeoptFinish (){
+void recordSCDeoptFinish() {
     assert(in_deopt_);
     in_deopt_ = false;
 }
@@ -413,7 +413,13 @@ void recordFinalizer(SEXP) {
     UNPROTECT(1);
 }
 
+bool SERIALIZE_SEXP;
+
 void recordExecution(const char* filePath, const char* filterArg) {
+    SERIALIZE_SEXP = getenv("RIR_RECORD_SERIALIZE")
+                         ? atoi(getenv("RIR_RECORD_SERIALIZE"))
+                         : false;
+
     if (filterArg != nullptr) {
         filter_ = {.compile = false,
                    .deopt = false,


### PR DESCRIPTION
RIR_RECORD_SERIALIZE was not being intialized correctly, probably due to global values initialization logic shenanigans.

This fix pushes the global assignment to the `recordExecution` function, which is always called from `context_init` in interpreter/instance.cpp.