### PR TITLE
Fix OSR on PIR_ENABLE=off

### DIFF
--- a/rir/src/compiler/parameter.h
+++ b/rir/src/compiler/parameter.h
@@ -38,7 +38,7 @@ struct Parameter {
 
     static bool ENABLE_PIR2RIR;
 
-    static bool ENABLE_OSR;
+    static const bool ENABLE_OSR;
 };
 
 } // namespace pir

--- a/rir/src/interpreter/instance.cpp
+++ b/rir/src/interpreter/instance.cpp
@@ -52,7 +52,6 @@ void context_init() {
     c->closureOptimizer = [](SEXP f, const Context&, SEXP n) { return f; };
 
     if (pir && std::string(pir).compare("off") == 0) {
-        pir::Parameter::ENABLE_OSR = false;
         // do nothing; use defaults
     } else if (pir && std::string(pir).compare("force") == 0) {
         c->closureCompiler = [](SEXP f, SEXP n) {

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1884,8 +1884,9 @@ SEXP colonCastRhs(SEXP newLhs, SEXP rhs) {
     return result;
 }
 
-bool pir::Parameter::ENABLE_OSR =
-    !getenv("PIR_OSR") || *getenv("PIR_OSR") != '0';
+const bool pir::Parameter::ENABLE_OSR =
+    (!getenv("PIR_OSR") || *getenv("PIR_OSR") != '0') &&
+    (!getenv("PIR_ENABLE") || (std::string(getenv("PIR_ENABLE")) == "off"));
 static size_t osrLimit =
     getenv("PIR_OSR_LIMIT") ? std::atoi(getenv("PIR_OSR_LIMIT")) : 5000;
 static SEXP osr(const CallContext* callCtxt, R_bcstack_t* basePtr, SEXP env,

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1886,7 +1886,7 @@ SEXP colonCastRhs(SEXP newLhs, SEXP rhs) {
 
 const bool pir::Parameter::ENABLE_OSR =
     (!getenv("PIR_OSR") || *getenv("PIR_OSR") != '0') &&
-    (!getenv("PIR_ENABLE") || (std::string(getenv("PIR_ENABLE")) == "off"));
+    (!getenv("PIR_ENABLE") || (std::string(getenv("PIR_ENABLE")) != "off"));
 static size_t osrLimit =
     getenv("PIR_OSR_LIMIT") ? std::atoi(getenv("PIR_OSR_LIMIT")) : 5000;
 static SEXP osr(const CallContext* callCtxt, R_bcstack_t* basePtr, SEXP env,


### PR DESCRIPTION
Currently when having PIR_ENABLE=off does not imply PIR_OSR=0.

This is due to static initialization ordering - the `context_init` function gets invoked before ENABLE_OSR is initialized, therefore the changes done to ENABLE_OSR inside the `context_init` are discarderd.