### PR TITLE
Fix pipeline - Docker in Docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 stages:
-  #- Build base container
+  - Build base container
   - Build container
   - Build benchmark container
   - Run tests
@@ -469,32 +469,32 @@ benchmark_fastr:
     - memory.data
     expire_in: 6 month
 
-# update_containers:
-#   image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-#   stage: Build base container
-#   variables:
-#     DOCKER_HOST: tcp://docker:2375/
-#     DOCKER_TLS_CERTDIR: ""
-#   services:
-#     - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-#       alias: docker
-#   before_script:
-#     - docker info
-#   only:
-#     refs:
-#       - schedules
-#   script:
-#     - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
-#     - docker pull docker.io/library/docker:19.03.0-dind
-#     - docker pull docker.io/library/docker:stable
-#     - docker pull docker.io/library/ubuntu:20.04
-#     - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-#     - docker tag docker.io/library/docker:stable registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-#     - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
-#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
-#     - cd container/benchmark-baseline && sh update.sh
-#   tags:
-#     - dockerInDocker
-#   retry: 1
+update_containers:
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+  stage: Build base container
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_TLS_CERTDIR: ""
+  services:
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+      alias: docker
+  before_script:
+    - docker info
+  only:
+    refs:
+      - schedules
+  script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
+    - docker pull docker.io/library/docker:19.03.0-dind
+    - docker pull docker.io/library/docker:stable
+    - docker pull docker.io/library/ubuntu:20.04
+    - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - docker tag docker.io/library/docker:stable registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+    - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
+    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
+    - cd container/benchmark-baseline && sh update.sh
+  tags:
+    - dockerInDocker
+  retry: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,12 +23,12 @@ variables:
 
 rir_container:
   stage: Build container
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
       alias: docker
   before_script:
     - docker info
@@ -44,12 +44,12 @@ benchmark_container:
   stage: Build benchmark container
   needs:
     - rir_container
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
       alias: docker
   before_script:
     - docker info
@@ -373,12 +373,12 @@ deploy:
   stage: Deploy
   except:
     - schedules
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
       alias: docker
   before_script:
     - docker info
@@ -485,14 +485,11 @@ update_containers:
       - schedules
   script:
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
-    - docker pull docker.io/library/docker:19.03.0-dind
-    - docker pull docker.io/library/docker:dind
+    - docker pull docker.io/library/docker:29.2.1-dind
     - docker pull docker.io/library/ubuntu:20.04
-    - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker tag docker.io/library/docker:dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+    - docker tag docker.io/library/docker:29.2.1-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
     - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:29.2.1-dind
     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
     - cd container/benchmark-baseline && sh update.sh
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -476,7 +476,7 @@ update_containers:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - name: docker:dind
       alias: docker
   before_script:
     - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -476,7 +476,7 @@ update_containers:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: docker:dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
       alias: docker
   before_script:
     - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ rir_container:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
       alias: docker
   before_script:
     - docker info
@@ -49,7 +49,7 @@ benchmark_container:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
       alias: docker
   before_script:
     - docker info
@@ -378,7 +378,7 @@ deploy:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
   services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
       alias: docker
   before_script:
     - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -470,7 +470,7 @@ benchmark_fastr:
     expire_in: 6 month
 
 update_containers:
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+  image: docker.io/library/docker:dind
   stage: Build base container
   variables:
     DOCKER_HOST: tcp://docker:2375/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,8 +469,9 @@ benchmark_fastr:
     - memory.data
     expire_in: 6 month
 
+# Do not use the dind from Gitlab - no need to bootstrap
 update_containers:
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
+  image: docker:dind
   stage: Build base container
   variables:
     DOCKER_HOST: tcp://docker:2375/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 stages:
-  - Build base container
+  #- Build base container
   - Build container
   - Build benchmark container
   - Run tests
@@ -469,32 +469,32 @@ benchmark_fastr:
     - memory.data
     expire_in: 6 month
 
-update_containers:
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-  stage: Build base container
-  variables:
-    DOCKER_HOST: tcp://docker:2375/
-    DOCKER_TLS_CERTDIR: ""
-  services:
-    - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-      alias: docker
-  before_script:
-    - docker info
-  only:
-    refs:
-      - schedules
-  script:
-    - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
-    - docker pull docker.io/library/docker:19.03.0-dind
-    - docker pull docker.io/library/docker:stable
-    - docker pull docker.io/library/ubuntu:20.04
-    - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker tag docker.io/library/docker:stable registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-    - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
-    - cd container/benchmark-baseline && sh update.sh
-  tags:
-    - dockerInDocker
-  retry: 1
+# update_containers:
+#   image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+#   stage: Build base container
+#   variables:
+#     DOCKER_HOST: tcp://docker:2375/
+#     DOCKER_TLS_CERTDIR: ""
+#   services:
+#     - name: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+#       alias: docker
+#   before_script:
+#     - docker info
+#   only:
+#     refs:
+#       - schedules
+#   script:
+#     - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
+#     - docker pull docker.io/library/docker:19.03.0-dind
+#     - docker pull docker.io/library/docker:stable
+#     - docker pull docker.io/library/ubuntu:20.04
+#     - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+#     - docker tag docker.io/library/docker:stable registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+#     - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
+#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
+#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+#     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
+#     - cd container/benchmark-baseline && sh update.sh
+#   tags:
+#     - dockerInDocker
+#   retry: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -470,7 +470,7 @@ benchmark_fastr:
     expire_in: 6 month
 
 update_containers:
-  image: docker.io/library/docker:dind
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
   stage: Build base container
   variables:
     DOCKER_HOST: tcp://docker:2375/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ variables:
 
 rir_container:
   stage: Build container
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
@@ -44,7 +44,7 @@ benchmark_container:
   stage: Build benchmark container
   needs:
     - rir_container
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
@@ -373,7 +373,7 @@ deploy:
   stage: Deploy
   except:
     - schedules
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
   variables:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
@@ -470,7 +470,7 @@ benchmark_fastr:
     expire_in: 6 month
 
 update_containers:
-  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+  image: registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
   stage: Build base container
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -486,13 +486,13 @@ update_containers:
   script:
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin registry.gitlab.com
     - docker pull docker.io/library/docker:19.03.0-dind
-    - docker pull docker.io/library/docker:stable
+    - docker pull docker.io/library/docker:dind
     - docker pull docker.io/library/ubuntu:20.04
     - docker tag docker.io/library/docker:19.03.0-dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker tag docker.io/library/docker:stable registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+    - docker tag docker.io/library/docker:dind registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
     - docker tag docker.io/library/ubuntu:20.04 registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:19.03.0-dind
-    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:stable
+    - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/docker:dind
     - docker push registry.gitlab.com/rirvm/rir_mirror/dockerhub_mirror/ubuntu:20.04
     - cd container/benchmark-baseline && sh update.sh
   tags:


### PR DESCRIPTION
The Docker in Docker (that build other Docker images) jobs in Gitlab CI/CD broke.  
The `docker:stable` image has been [deprecated since June 2020](https://hub.docker.com/_/docker#image-variants).  
After replacing it with the `docker:dind`, the version for the service (19.03.0) was too old to be used with `docker:dind`, so that one is also updated to use the latest.